### PR TITLE
PRO-613 FIX Merge in progress error

### DIFF
--- a/code/src/terrat/terrat_github_evaluator3.ml
+++ b/code/src/terrat/terrat_github_evaluator3.ml
@@ -4310,8 +4310,11 @@ struct
                 ~repo:repo.Repo.name
                 ~pull_number:pull_request.Pull_request.id))
       >>= fun resp ->
+      let module Mna = Githubc2_pulls.Merge.Responses.Method_not_allowed in
       match Openapi.Response.value resp with
       | `OK _ -> Abb.Future.return (Ok ())
+      | `Method_not_allowed { Mna.primary = { Mna.Primary.message = Some message; _ }; _ }
+        when CCString.equal "Merge already in progress" message -> Abb.Future.return (Ok ())
       | `Method_not_allowed _ -> (
           Logs.info (fun m ->
               m


### PR DESCRIPTION
Do not try to merge again or report as error if a merge is already in progress.  This can happen by concurrent operations going on in a pull request (via environments).

## Description

<!-- Briefly describe the changes and the issue it fixes. -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (explain):

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/terrateamio/terrateam/blob/main/CONTRIBUTING.md)
- [x] The pull request title follows this format:
      `ISSUE_NUMBER ACTION_TYPE Short description` (e.g., `123 ADD Feature description`)
- [x] I have added tests and documentation (if applicable)
- [x] My changes generate no new warnings/errors and do not break existing functionality

## Additional context (optional)

<!-- Add any additional context here, e.g., screenshots, dependencies, etc. -->
