### PR TITLE
#193 FIX Workspaces with no change plans not giving up lock

### DIFF
--- a/code/src/terrat_files/sql/select_github_dirspaces_owned_by_other_pull_requests.sql
+++ b/code/src/terrat_files/sql/select_github_dirspaces_owned_by_other_pull_requests.sql
@@ -109,7 +109,10 @@ applies_for_merged_pull_requests as (
     inner join github_work_manifest_results as results
         on results.work_manifest = gwm.id
            and results.path = gwmds.path and results.workspace = gwmds.workspace
-    where gwm.run_type in ('apply', 'autoapply', 'unsafe-apply') and results.success
+    left join github_terraform_plans as gtp
+        on gtp.work_manifest = gwm.id and gtp.path = gwmds.path and gtp.workspace = gwmds.workspace
+    where (gwm.run_type in ('apply', 'autoapply', 'unsafe-apply') and results.success)
+          or (gwm.run_type in ('autoplan', 'plan') and gtp.has_changes is not null and not gtp.has_changes)
 ),
 unapplied_dirspaces as (
     select


### PR DESCRIPTION
Inside the PR, the workspace is considered applied however it is holding on to the lock after being merged.  This modified the SQL query to take the plan into account when looking at which locks are held.

## Description

<!-- Briefly describe the changes and the issue it fixes. -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (explain):

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/terrateamio/terrateam/blob/main/CONTRIBUTING.md)
- [x] The pull request title follows this format:
      `ISSUE_NUMBER ACTION_TYPE Short description` (e.g., `123 ADD Feature description`)
- [x] I have added tests and documentation (if applicable)
- [x] My changes generate no new warnings/errors and do not break existing functionality

## Additional context (optional)

<!-- Add any additional context here, e.g., screenshots, dependencies, etc. -->
