### PR TITLE
DOC_UPDATE Update configuration page and create tag queries page

### DIFF
--- a/docs/src/content/docs/getting-started/configuration.mdx
+++ b/docs/src/content/docs/getting-started/configuration.mdx
@@ -77,7 +77,7 @@ apply_requirements:
       approved:
         enabled: true        # Enable approval checking
         any_of: []           # No specific approvers required
-        any_of_count: 2      # Requires at least 2 approvals
+        any_of_count: 2      # Requires at least two approvals
         all_of: []           # No mandatory approvers
       
       # Prevents apply if merge conflicts exist

--- a/docs/src/content/docs/getting-started/configuration.mdx
+++ b/docs/src/content/docs/getting-started/configuration.mdx
@@ -187,7 +187,6 @@ See [Hooks](/configuration-reference/hooks) for details.
 
 Workflows allow you to define custom steps for Terrateam's Plan and Apply operations. You can use Workflows to replace or augment the default behavior.
 
-### Simple Workflow Example
 
 Here's a basic workflow that slightly modifies the default behavior:
 

--- a/docs/src/content/docs/getting-started/configuration.mdx
+++ b/docs/src/content/docs/getting-started/configuration.mdx
@@ -204,7 +204,6 @@ workflows:
 
 This simple workflow explicitly defines the standard Terraform workflow steps.
 
-### Advanced Workflow Example
 
 For more complex scenarios, you can create specialized workflows:
 

--- a/docs/src/content/docs/getting-started/configuration.mdx
+++ b/docs/src/content/docs/getting-started/configuration.mdx
@@ -205,7 +205,7 @@ workflows:
 This simple workflow explicitly defines the standard Terraform workflow steps.
 
 
-For more complex scenarios, you can create specialized workflows:
+For more complex scenarios, you can create specialized workflows, such as the next one:
 
 ```yaml
 workflows:

--- a/docs/src/content/docs/getting-started/configuration.mdx
+++ b/docs/src/content/docs/getting-started/configuration.mdx
@@ -83,7 +83,7 @@ access_control:
 
 This configuration allows anyone to trigger a Plan operation but restricts Apply operations to members of the `sre` team.
 
-See [Access Control](/configuration-reference/access-control) for details.
+Access the [Access Control](/configuration-reference/access-control) page to see the complete list of configurations available. 
 
 ## Apply Requirements
 

--- a/docs/src/content/docs/getting-started/configuration.mdx
+++ b/docs/src/content/docs/getting-started/configuration.mdx
@@ -45,25 +45,25 @@ Each section serves a specific purpose in customizing Terrateam's behavior:
 
 Tag queries are a core concept in Terrateam, allowing you to target specific operations for particular directories, environments, or infrastructure components. They connect various configuration sections and provide granular control over workflow execution, apply requirements, and access control.
 
-### How Do Tag Queries Work?
+Tag queries work by matching directories based on the tags assigned to them:
 
 1. **Assigning Tags**: In the configuration file (`.terrateam/config.yml`), you define **tags** for directories in the `dirs` section. These tags can represent environments, applications, or other organizational criteria.
 2. **Using Tag Queries**: In other configuration sections (such as `access_control`, `apply_requirements`, and `workflows`), you use **tag queries** to select and apply rules to specific directories or resources.
 
-### Usage Examples
+The most common usages for terrateam tags are:
 
 - Assign the `production` and `critical` tags to the `production` directory.
 - Create a workflow that applies only to this directory using `tag_query: "production"`.
 - Restrict permissions for critical directories using `tag_query: "critical"`.
 
-### Common Tag Query Patterns
+Some common tag queries include:
 
 - `tag_query: ""` → Matches all directories.
 - `tag_query: "production"` → Matches directories tagged with `production`.
 - `tag_query: "aws and production"` → Matches directories with both `aws` **and** `production` tags.
 - `tag_query: "staging or development"` → Matches directories with either the `staging` **or** `development` tag.
 
-### Benefits of Tag Queries
+The benefits of using tag queries to manage your infrastructure are:
 
 - **Structured Organization**: Define meaningful tags to better manage your infrastructure.
 - **Targeted Precision**: Combine dynamic tags (based on branch) and static tags (directories) for greater flexibility.

--- a/docs/src/content/docs/getting-started/configuration.mdx
+++ b/docs/src/content/docs/getting-started/configuration.mdx
@@ -26,7 +26,6 @@ hooks:
   # Executes custom commands before or after operations
 workflows:
   # Configures specialized plan and apply processes
-
 ```
 
 Each section serves a specific purpose in customizing Terrateam's behavior:
@@ -37,6 +36,37 @@ Each section serves a specific purpose in customizing Terrateam's behavior:
 - **hooks**: Allows custom actions before or after operations
 - **workflows**: Creates specialized processing for different directories or environments
 
+## Understanding Tag Queries
+
+Tag queries are a core concept in Terrateam, allowing you to target specific operations for particular directories, environments, or infrastructure components. They connect various configuration sections and provide granular control over workflow execution, apply requirements, and access control.
+
+### How Do Tag Queries Work?
+
+1. **Assigning Tags**: In the configuration file (`.terrateam/config.yml`), you define **tags** for directories in the `dirs` section. These tags can represent environments, applications, or other organizational criteria.
+2. **Using Tag Queries**: In other configuration sections (such as `access_control`, `apply_requirements`, and `workflows`), you use **tag queries** to select and apply rules to specific directories or resources.
+
+### Usage Examples
+
+- Assign the `production` and `critical` tags to the `production` directory.
+- Create a workflow that applies only to this directory using `tag_query: "production"`.
+- Restrict permissions for critical directories using `tag_query: "critical"`.
+
+### Common Tag Query Patterns
+
+- `tag_query: ""` → Matches all directories.
+- `tag_query: "production"` → Matches directories tagged with `production`.
+- `tag_query: "aws and production"` → Matches directories with both `aws` **and** `production` tags.
+- `tag_query: "staging or development"` → Matches directories with either the `staging` **or** `development` tag.
+
+### Benefits of Tag Queries
+
+- **Structured Organization**: Define meaningful tags to better manage your infrastructure.
+- **Targeted Precision**: Combine dynamic tags (based on branch) and static tags (directories) for greater flexibility.
+- **Refined Control**: Use operators (`and`, `or`, `not`, `in`) to build advanced rules.
+
+Tag queries provide an efficient mechanism to automate and manage your Terraform infrastructure with Terrateam, ensuring well-defined workflows aligned with your operational needs.
+
+See [Tag Queries](/advanced-workflows/tags) for more details.
 ## Access Control
 
 Access Control allows you to define policies for who can perform various Terrateam operations, such as planning and applying changes. You can configure access based on individual users, GitHub teams, or repository collaborator roles.
@@ -53,11 +83,7 @@ access_control:
 
 This configuration allows anyone to trigger a Plan operation but restricts Apply operations to members of the `sre` team.
 
-:::note
-The `tag_query` field is used to match specific directories or environments. An empty string (`''`) matches all directories. You can use it to create different access policies for different parts of your infrastructure, like `tag_query: 'production'` to set stricter permissions for production environments.
-:::
-
-For more information, see the [Access Control](/configuration-reference/access-control) section of the Configuration Reference.
+See [Access Control](/configuration-reference/access-control) for details.
 
 ## Apply Requirements
 
@@ -95,7 +121,7 @@ This configuration requires that the pull request has at least two approvals, no
 
 When `create_pending_apply_check` is enabled, Terrateam will create a `Terrateam Apply` GitHub status check. Combined with [GitHub Rulesets](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets), this prevents the pull request from being merged until all Apply operations have completed.
 
-For more information, see the [Apply Requirements](/configuration-reference/apply-requirements) section of the Configuration Reference.
+See [Apply Requirements](/configuration-reference/apply-requirements) for details.
 
 ## Dirs
 
@@ -131,7 +157,7 @@ This configuration:
 
 Terrateam also supports glob patterns in the `dirs` directive, allowing you to match multiple directories with similar configurations. The `${DIR}` variable can be used to specify the directory that Terrateam is working against, relative to the root of the repository.
 
-For more information, see the [Dirs](/configuration-reference/dirs) section of the Configuration Reference.
+See [Dirs](/configuration-reference/dirs) for details.
 
 ## Hooks
 
@@ -155,18 +181,37 @@ hooks:
         cmd: ['echo', 'Running post-hook for plan operations']
 ```
 
-For more details, see the [Hooks](/configuration-reference/hooks) section of the Configuration Reference.
+See [Hooks](/configuration-reference/hooks) for details.
 
 ## Workflows
 
 Workflows allow you to define custom steps for Terrateam's Plan and Apply operations. You can use Workflows to replace or augment the default behavior.
 
-Here's an example `workflows` configuration:
+### Simple Workflow Example
+
+Here's a basic workflow that slightly modifies the default behavior:
+
+```yaml
+workflows:
+  # Apply to all directories
+  - tag_query: ""
+    plan:
+      - type: init  # Run terraform init
+      - type: plan  # Run terraform plan
+    apply:
+      - type: init  # Run terraform init
+      - type: apply # Run terraform apply
+```
+
+This simple workflow explicitly defines the standard Terraform workflow steps.
+
+### Advanced Workflow Example
+
+For more complex scenarios, you can create specialized workflows:
 
 ```yaml
 workflows:
   # This workflow applies to any directory tagged with "production"
-  # (This could match directories set with tags: [production] in the dirs section)
   - tag_query: "production"
     plan:
       - type: init  # Run terraform init
@@ -180,13 +225,9 @@ workflows:
         run_on: failure  # Only if apply fails
 ```
 
-This workflow runs a custom plan and apply process for any directories tagged with `production`. The tag queries like `tag_query: "production"` match the tags defined in the `dirs` section, creating a connection between your directory structure and custom workflows.
+This advanced workflow runs a custom plan and apply process for any directories tagged with `production`. It adds production-specific variables during planning and executes error handling after failed applies.
 
-:::note
-All the examples in this page are complementary parts of a single configuration. The tag query in the workflow (`tag_query: "production"`) would match directories or workspaces tagged with `production` in the `dirs` section.
-:::
-
-For more information, see the [Workflows](/configuration-reference/workflows) section of the Configuration Reference.
+See [Workflows](/configuration-reference/workflows) for details.
 
 ## Other Configuration Options
 
@@ -197,4 +238,62 @@ The `config.yml` file supports many other configuration options, including:
 - `cost_estimation`: Enable and configure cost estimation for Terraform plans
 - `automerge`: Automatically merge pull requests after successful applies
 
-For a complete list of available options and their usage, refer to the [Configuration Reference](/configuration-reference) section of the documentation.
+See the [Configuration Reference](/configuration-reference) for a complete list of available options.
+
+## Basic Example
+
+Here's a complete basic example of a `config.yml` file that combines the various sections:
+
+```yaml
+# Basic Terrateam configuration example
+access_control:
+  policies:
+    - tag_query: ''  # All directories
+      plan: ['*']    # Anyone can plan
+      apply: ['team:infra', 'team:platform']  # Only specific teams can apply
+
+apply_requirements:
+  create_pending_apply_check: true
+  checks:
+    - tag_query: ""  # All directories
+      approved:
+        enabled: true
+        any_of_count: 1  # Requires at least 1 approval
+      
+dirs:
+  staging:
+    tags: [aws, staging]
+  production:
+    tags: [aws, production, critical]
+    workspaces:
+      default:
+        tags: [default]
+
+hooks:
+  all:
+    pre:
+      - type: run
+        cmd: ['echo', 'Starting Terraform operation']
+
+workflows:
+  - tag_query: "staging"
+    plan:
+      - type: init
+      - type: plan
+        extra_args: ["-var-file=staging.tfvars"]
+  
+  - tag_query: "production"
+    plan:
+      - type: init
+      - type: plan
+        extra_args: ["-var-file=production.tfvars"]
+```
+
+This configuration:
+1. Allows anyone to plan, but only members of `infra` or `platform` teams to apply
+2. Requires at least one approval before applying
+3. Defines staging and production directories with appropriate tags
+4. Runs a simple pre-hook for all operations
+5. Uses custom workflows for staging and production environments, applying the appropriate variable files
+
+You can start with a basic configuration like this and gradually add more advanced features as your deployment needs grow.

--- a/docs/src/content/docs/getting-started/configuration.mdx
+++ b/docs/src/content/docs/getting-started/configuration.mdx
@@ -240,7 +240,7 @@ See the [Configuration Reference](/configuration-reference) for a complete list 
 
 ## Basic Example
 
-Here's a complete basic example of a `config.yml` file that combines the various sections:
+Here's a complete example of a `config.yml` file containing a basic workflow that combines the configurations from the previous sections:
 
 ```yaml
 # Basic Terrateam configuration example

--- a/docs/src/content/docs/getting-started/configuration.mdx
+++ b/docs/src/content/docs/getting-started/configuration.mdx
@@ -17,16 +17,16 @@ The `config.yml` file is written in YAML and has the following basic structure:
 
 ```yaml
 access_control:
-  # Access Controls - Defines who can perform which operations
+  # Specifies user permissions for operations
 apply_requirements:
-  # Apply Requirements - Sets conditions that must be met before applying changes
+  # Defines preconditions for applying changes
 dirs:
-  # Repository Layout Definitions - Maps directories to tags, workspaces, and behaviors
+  # Maps directories to tags, workspaces, and behaviors
 hooks:
-  # Pre/Post Hooks - Custom commands to run before or after operations
+  # Executes custom commands before or after operations
 workflows:
-  # Custom Workflow Steps - Defines specialized plan and apply processes
-# Other Configuration Options - Additional settings for Terrateam behavior
+  # Configures specialized plan and apply processes
+
 ```
 
 Each section serves a specific purpose in customizing Terrateam's behavior:

--- a/docs/src/content/docs/getting-started/configuration.mdx
+++ b/docs/src/content/docs/getting-started/configuration.mdx
@@ -106,7 +106,7 @@ dirs:
       production:  # Workspace name
         tags: [production]  # Workspace-specific tags
     when_modified:
-      file_patterns: ["ec2/*.tf", "ec2/*.tfvars", "iam/*.tf", "iam/*.tfvars"]
+      file_patterns: ["${DIR}/*.tf", "${DIR}/*.tfvars", "iam/*.tf", "iam/*.tfvars"]
   iam:
     tags: [aws, iam]
 ```
@@ -217,7 +217,7 @@ Here's a complete example of a `config.yml` file containing a basic workflow tha
 # Basic Terrateam configuration example
 access_control:
   policies:
-    - tag_query: ''  # All directories
+    - tag_query: ''  # All directories and workspaces
       plan: ['*']    # Anyone can plan
       apply: ['team:infra', 'team:platform']  # Only specific teams can apply
 

--- a/docs/src/content/docs/getting-started/configuration.mdx
+++ b/docs/src/content/docs/getting-started/configuration.mdx
@@ -6,7 +6,9 @@ description: Understanding the Terrateam configuration file and how to customize
 import { Steps } from '@astrojs/starlight/components';
 
 The Terrateam configuration file (`config.yml`) is the primary way to customize how Terrateam interacts with your GitHub repository and Terraform code. This file is stored in the `.terrateam` directory at the root of your repository.
-
+:::note[Should i create the config.yml file?]
+Terrateam automatically checks if a config.yml exists, but the file is not required. If you don't create a config.yml file, Terrateam will use default settings.
+:::
 :::note
 Default settings work for most teams. Customize only if you need specific lock timing or policies.
 :::
@@ -206,6 +208,9 @@ workflows:
 ```
 
 This simple workflow explicitly defines the standard Terraform workflow steps.
+1. Initialization(`init`): Runs `terraform init` to prepare the directory for planning or applying changes.
+2. Planning(`plan`): Runs `terraform plan` to generate an execution plan for the changes.
+3. Apply(`apply`): Applies the changes to the infrastructure.
 
 
 For more complex scenarios, you can create specialized workflows, such as the next one:
@@ -291,10 +296,10 @@ workflows:
 ```
 
 This configuration:
-1. Allows anyone to plan, but only members of `infra` or `platform` teams to apply
-2. Requires at least one approval before applying
-3. Defines staging and production directories with appropriate tags
-4. Runs a simple pre-hook for all operations
-5. Uses custom workflows for staging and production environments, applying the appropriate variable files
+1. Allows anyone to plan, but only members of `infra` or `platform` teams to apply.
+2. Requires at least one approval before applying.
+3. Defines staging and production directories with appropriate tags.
+4. Runs a simple pre-hook for all operations.
+5. Uses custom workflows for staging and production environments, applying the appropriate variable files.
 
 You can start with a basic configuration like this and gradually add more advanced features as your deployment needs grow.

--- a/docs/src/content/docs/getting-started/configuration.mdx
+++ b/docs/src/content/docs/getting-started/configuration.mdx
@@ -91,7 +91,7 @@ apply_requirements:
           - "ci/.*"                # Ignores all CI status checks
 ```
 
-This configuration requires that the pull request has at least 2 approvals, no merge conflicts, and all status checks (except those matching `ci/.*`) have passed before an apply can be performed.
+This configuration requires that the pull request has at least two approvals, no merge conflicts, and all status checks (except those matching `ci/.*`) have passed before an apply can be performed.
 
 When `create_pending_apply_check` is enabled, Terrateam will create a `Terrateam Apply` GitHub status check. Combined with [GitHub Rulesets](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets), this prevents the pull request from being merged until all Apply operations have completed.
 

--- a/docs/src/content/docs/getting-started/configuration.mdx
+++ b/docs/src/content/docs/getting-started/configuration.mdx
@@ -5,15 +5,10 @@ description: Understanding the Terrateam configuration file and how to customize
 
 import { Steps } from '@astrojs/starlight/components';
 
-The Terrateam configuration file (`config.yml`) is the primary way to customize how Terrateam interacts with your GitHub repository and Terraform code. This file is stored in the `.terrateam` directory at the root of your repository.
-:::note[Should i create the config.yml file?]
-Terrateam automatically checks if a config.yml exists, but the file is not required. If you don't create a config.yml file, Terrateam will use default settings.
-:::
-:::note
-Default settings work for most teams. Customize only if you need specific lock timing or policies.
-:::
-:::note
-The `.terrateam/config.yml` file is the source of truth for Terrateam's behavior in your repository.
+Terrateam uses a `.terrateam/config.yml` file to customize how it interacts with your GitHub repository and Terraform code.
+
+:::note[Do I need a config file?]
+Terrateam uses sensible defaults if `.terrateam/config.yml` doesn’t exist. Add a config file only if you need custom workflows, OIDC, policies, or other advanced settings.
 :::
 
 ## Basic Structure
@@ -30,7 +25,7 @@ dirs:
 hooks:
   # Executes custom commands before or after operations
 workflows:
-  # Configures specialized plan and apply processes
+  # Configures specialized plan and apply steps
 ```
 
 Each section serves a specific purpose in customizing Terrateam's behavior:
@@ -39,7 +34,7 @@ Each section serves a specific purpose in customizing Terrateam's behavior:
 - `apply_requirements`: Defines conditions that must be met before changes can be applied
 - `dirs`: Maps your repository's directory structure to Terrateam's concepts
 - `hooks`: Allows custom actions before or after operations
-- `workflows`: Creates specialized processing for different directories or environments
+- `workflows`: Creates specialized processing for different workspaces
 
 ## Access Control
 
@@ -50,7 +45,7 @@ Here's an example `access_control` configuration:
 ```yaml
 access_control:
   policies:
-    - tag_query: ''  # Empty string matches all directories
+    - tag_query: ''  # Empty string matches all workspaces
       plan: ['*']    # Anyone can plan
       apply: ['team:sre']  # Only SRE team members can apply
 ```
@@ -71,7 +66,7 @@ apply_requirements:
   create_pending_apply_check: true
   
   checks:
-    - tag_query: ""  # Apply to all directories
+    - tag_query: ""  # Apply to all workspaces
       
       # Requires PR approvals
       approved:
@@ -161,12 +156,11 @@ See [Hooks](/configuration-reference/hooks) for details.
 
 Workflows allow you to define custom steps for Terrateam's Plan and Apply operations. You can use Workflows to replace or augment the default behavior.
 
-
 Here's a basic workflow that slightly modifies the default behavior:
 
 ```yaml
 workflows:
-  # Apply to all directories
+  # Apply to all workspaces
   - tag_query: ""
     plan:
       - type: init  # Run terraform init

--- a/docs/src/content/docs/getting-started/configuration.mdx
+++ b/docs/src/content/docs/getting-started/configuration.mdx
@@ -1,6 +1,6 @@
 ---
 title: Configuration 
-description: Understanding the Terrateam configuration file
+description: Understanding the Terrateam configuration file and how to customize your workflow
 ---
 
 import { Steps } from '@astrojs/starlight/components';
@@ -17,17 +17,25 @@ The `config.yml` file is written in YAML and has the following basic structure:
 
 ```yaml
 access_control:
-  # Access Controls
+  # Access Controls - Defines who can perform which operations
 apply_requirements:
-  # Apply Requirements
+  # Apply Requirements - Sets conditions that must be met before applying changes
 dirs:
-  # Repository Layout Definitions
+  # Repository Layout Definitions - Maps directories to tags, workspaces, and behaviors
 hooks:
-  # Pre/Post Hooks 
+  # Pre/Post Hooks - Custom commands to run before or after operations
 workflows:
-  # Custom Workflow Steps 
-# Other Configuration Options
+  # Custom Workflow Steps - Defines specialized plan and apply processes
+# Other Configuration Options - Additional settings for Terrateam behavior
 ```
+
+Each section serves a specific purpose in customizing Terrateam's behavior:
+
+- **access_control**: Controls who can run plan and apply operations
+- **apply_requirements**: Defines conditions that must be met before changes can be applied
+- **dirs**: Maps your repository's directory structure to Terrateam's concepts
+- **hooks**: Allows custom actions before or after operations
+- **workflows**: Creates specialized processing for different directories or environments
 
 ## Access Control
 
@@ -38,12 +46,16 @@ Here's an example `access_control` configuration:
 ```yaml
 access_control:
   policies:
-    - tag_query: ''
-      plan: ['*']
-      apply: ['team:sre']
+    - tag_query: ''  # Empty string matches all directories
+      plan: ['*']    # Anyone can plan
+      apply: ['team:sre']  # Only SRE team members can apply
 ```
 
 This configuration allows anyone to trigger a Plan operation but restricts Apply operations to members of the `sre` team.
+
+:::note
+The `tag_query` field is used to match specific directories or environments. An empty string (`''`) matches all directories. You can use it to create different access policies for different parts of your infrastructure, like `tag_query: 'production'` to set stricter permissions for production environments.
+:::
 
 For more information, see the [Access Control](/configuration-reference/access-control) section of the Configuration Reference.
 
@@ -51,24 +63,32 @@ For more information, see the [Access Control](/configuration-reference/access-c
 
 Apply Requirements allows you to specify conditions that must be met before an Apply operation can be performed on an unmerged pull request. This helps ensure that changes are properly reviewed and validated before being applied.
 
-Here's an example `apply_requirements` configuration:
+Here's an example `apply_requirements` configuration with explanations:
 
 ```yaml
 apply_requirements:
+  # Creates a status check that prevents merging until apply is complete
   create_pending_apply_check: true
+  
   checks:
-    - tag_query: ""
+    - tag_query: ""  # Apply to all directories
+      
+      # Requires PR approvals
       approved:
-        enabled: true
-        any_of: []
-        any_of_count: 2
-        all_of: []
+        enabled: true        # Enable approval checking
+        any_of: []           # No specific approvers required
+        any_of_count: 2      # Requires at least 2 approvals
+        all_of: []           # No mandatory approvers
+      
+      # Prevents apply if merge conflicts exist
       merge_conflicts:
         enabled: true
+      
+      # Requires all status checks to pass
       status_checks:
-        enabled: true
-        ignore_matching:
-          - "ci/.*"
+        enabled: true              # Enable status check verification
+        ignore_matching:           # Regex patterns for checks to ignore
+          - "ci/.*"                # Ignores all CI status checks
 ```
 
 This configuration requires that the pull request has at least 2 approvals, no merge conflicts, and all status checks (except those matching `ci/.*`) have passed before an apply can be performed.
@@ -79,24 +99,35 @@ For more information, see the [Apply Requirements](/configuration-reference/appl
 
 ## Dirs
 
-Dirs allow you to define which [Tags](/advanced-workflows/tags), Workspaces, and [When Modified](/configuration-reference/when-modified) rules rules apply to specific directories in your repository.
+Dirs allow you to define which [Tags](/advanced-workflows/tags), Workspaces, and [When Modified](/configuration-reference/when-modified) rules apply to specific directories in your repository.
 
 Here's an example `dirs` configuration:
 
 ```yaml
 dirs:
-  ec2:
-    tags: [aws, ec2]
+  ec2:  # Directory name (relative to repository root)
+    tags: [aws, ec2]  # Directory-level tags
     workspaces:
-      production:
-        tags: [production]
+      production:  # Workspace name
+        tags: [production]  # Workspace-specific tags
     when_modified:
       file_patterns: ["ec2/*.tf", "ec2/*.tfvars", "iam/*.tf", "iam/*.tfvars"]
   iam:
     tags: [aws, iam]
 ```
 
-This configuration assigns the Tags `aws` and `ec2` to the `ec2` directory, and the Tags `aws` and `iam` to the `iam` directory. It also specifies that the `production` Workspace should be used when a [Tag Query](/advanced-workflows/tags) includes `aws`, `ec2`, and `production` for a [Workflow](/configuration-reference/workflows) or [Command](/command-reference). Additionally, it overrides the [`when_modified`](/configuration-reference/when-modified) file patterns for the `ec2` directory.
+This configuration:
+
+1. Assigns directory-level tags `aws` and `ec2` to the `ec2` directory
+2. Assigns directory-level tags `aws` and `iam` to the `iam` directory
+3. Creates a `production` workspace for the `ec2` directory with the tag `production`
+4. Specifies custom file patterns that, when modified, will trigger Terrateam operations for the `ec2` directory
+
+:::note[Directory vs. Workspace Tags]
+- **Directory tags** (`tags` at the directory level) apply to all operations in that directory across all workspaces
+- **Workspace tags** (`tags` under a specific workspace) only apply when operating on that specific workspace
+- Tags are used in tag queries (like `tag_query: "aws"`) to target specific operations
+:::
 
 Terrateam also supports glob patterns in the `dirs` directive, allowing you to match multiple directories with similar configurations. The `${DIR}` variable can be used to specify the directory that Terrateam is working against, relative to the root of the repository.
 
@@ -114,12 +145,12 @@ Here's an example `hooks` configuration:
 
 ```yaml
 hooks:
-  all:
-    pre:
+  all:  # Apply to all operations (plan & apply)
+    pre:  # Run before the operation
       - type: run
         cmd: ['echo', 'Running pre-hook for all operations']
-  plan:
-    post:
+  plan:  # Apply only to plan operations
+    post:  # Run after the operation
       - type: run
         cmd: ['echo', 'Running post-hook for plan operations']
 ```
@@ -134,20 +165,26 @@ Here's an example `workflows` configuration:
 
 ```yaml
 workflows:
-  - tag_query: "dir:production"
+  # This workflow applies to any directory tagged with "production"
+  # (This could match directories set with tags: [production] in the dirs section)
+  - tag_query: "production"
     plan:
-      - type: init
-      - type: plan
-        extra_args: ["-var-file=production.tfvars"]
+      - type: init  # Run terraform init
+      - type: plan  # Run terraform plan
+        extra_args: ["-var-file=production.tfvars"]  # With these extra arguments
     apply:
-      - type: init
-      - type: apply
-      - type: run
+      - type: init  # Run terraform init for apply
+      - type: apply  # Run terraform apply
+      - type: run   # Run a custom command
         cmd: ['echo', 'Error running apply']
-        run_on: failure
+        run_on: failure  # Only if apply fails
 ```
 
-This workflow runs a custom plan and apply process for any changes in the `production` directory.
+This workflow runs a custom plan and apply process for any directories tagged with `production`. The tag queries like `tag_query: "production"` match the tags defined in the `dirs` section, creating a connection between your directory structure and custom workflows.
+
+:::note
+All the examples in this page are complementary parts of a single configuration. The tag query in the workflow (`tag_query: "production"`) would match directories or workspaces tagged with `production` in the `dirs` section.
+:::
 
 For more information, see the [Workflows](/configuration-reference/workflows) section of the Configuration Reference.
 

--- a/docs/src/content/docs/getting-started/configuration.mdx
+++ b/docs/src/content/docs/getting-started/configuration.mdx
@@ -35,43 +35,12 @@ workflows:
 
 Each section serves a specific purpose in customizing Terrateam's behavior:
 
-- **access_control**: Controls who can run plan and apply operations
-- **apply_requirements**: Defines conditions that must be met before changes can be applied
-- **dirs**: Maps your repository's directory structure to Terrateam's concepts
-- **hooks**: Allows custom actions before or after operations
-- **workflows**: Creates specialized processing for different directories or environments
+- `access_control`: Controls who can run plan and apply operations
+- `apply_requirements`: Defines conditions that must be met before changes can be applied
+- `dirs`: Maps your repository's directory structure to Terrateam's concepts
+- `hooks`: Allows custom actions before or after operations
+- `workflows`: Creates specialized processing for different directories or environments
 
-## Understanding Tag Queries
-
-Tag queries are a core concept in Terrateam, allowing you to target specific operations for particular directories, environments, or infrastructure components. They connect various configuration sections and provide granular control over workflow execution, apply requirements, and access control.
-
-Tag queries work by matching directories based on the tags assigned to them:
-
-1. **Assigning Tags**: In the configuration file (`.terrateam/config.yml`), you define **tags** for directories in the `dirs` section. These tags can represent environments, applications, or other organizational criteria.
-2. **Using Tag Queries**: In other configuration sections (such as `access_control`, `apply_requirements`, and `workflows`), you use **tag queries** to select and apply rules to specific directories or resources.
-
-The most common usages for terrateam tags are:
-
-- Assign the `production` and `critical` tags to the `production` directory.
-- Create a workflow that applies only to this directory using `tag_query: "production"`.
-- Restrict permissions for critical directories using `tag_query: "critical"`.
-
-Some common tag queries include:
-
-- `tag_query: ""` → Matches all directories.
-- `tag_query: "production"` → Matches directories tagged with `production`.
-- `tag_query: "aws and production"` → Matches directories with both `aws` **and** `production` tags.
-- `tag_query: "staging or development"` → Matches directories with either the `staging` **or** `development` tag.
-
-The benefits of using tag queries to manage your infrastructure are:
-
-- **Structured Organization**: Define meaningful tags to better manage your infrastructure.
-- **Targeted Precision**: Combine dynamic tags (based on branch) and static tags (directories) for greater flexibility.
-- **Refined Control**: Use operators (`and`, `or`, `not`, `in`) to build advanced rules.
-
-Tag queries provide an efficient mechanism to automate and manage your Terraform infrastructure with Terrateam, ensuring well-defined workflows aligned with your operational needs.
-
-See [Tag Queries](/advanced-workflows/tags) for more details.
 ## Access Control
 
 Access Control allows you to define policies for who can perform various Terrateam operations, such as planning and applying changes. You can configure access based on individual users, GitHub teams, or repository collaborator roles.

--- a/docs/src/content/docs/getting-started/configuration.mdx
+++ b/docs/src/content/docs/getting-started/configuration.mdx
@@ -8,6 +8,9 @@ import { Steps } from '@astrojs/starlight/components';
 The Terrateam configuration file (`config.yml`) is the primary way to customize how Terrateam interacts with your GitHub repository and Terraform code. This file is stored in the `.terrateam` directory at the root of your repository.
 
 :::note
+Default settings work for most teams. Customize only if you need specific lock timing or policies.
+:::
+:::note
 The `.terrateam/config.yml` file is the source of truth for Terrateam's behavior in your repository.
 :::
 

--- a/docs/src/content/docs/getting-started/tag-queries.mdx
+++ b/docs/src/content/docs/getting-started/tag-queries.mdx
@@ -1,0 +1,122 @@
+---
+title: Tag Queries
+description: Learn how to use tag queries in Terrateam to manage Terraform resources.​
+---
+
+Tag queries are a fundamental feature in Terrateam, enabling you to organize, manage, and automate your Terraform resources. You can create logical groupings based on various criteria, such as environment, application, or region, and use tag queries to match and filter resources. They act as filters that determine:  
+
+- Which workflows apply to which directories. 
+- Who has access to specific resources.  
+- How apply requirements are enforced.
+
+By using tag queries, you gain granular control over infrastructure management and automation.
+
+## Defining Tags
+
+Terrateam provides two primary methods for defining tags:
+
+- **Top-Level Tags**: Dynamic tags based on criteria like the destination branch of a pull request.
+- **Directory-Level Tags**: Static tags assigned directly to specific directories in your repository.
+
+### Top-Level Tags
+
+In the `.terrateam/config.yml` file, you can define dynamic tags using the top-level `tags` key. This allows for workflows that adapt to the context of your pull requests and branches. For example:
+
+```yaml
+tags:
+  dest_branch:
+    main: '^main$'
+    staging: '^staging$'
+    dev: '^dev$'
+```
+
+In this configuration, the `dest_branch` tag has three possible values: `main,` `staging,` and `dev.` Each value is associated with a regular expression matching the corresponding branch name.
+
+### Directory-Level Tags
+
+Within the `dirs` section of your [configuration](/getting-started/configuration/), you can assign static tags to specific directories:
+
+```yaml
+dirs:
+  dev:
+    tags: [dev]
+  staging:
+    tags: [staging]
+  prod:
+    tags: [prod]
+```
+
+Here:
+
+- The `dev` directory is tagged with `dev`.
+- The `staging` directory is tagged with `staging`.
+- The `prod` directory is tagged with `prod`.
+
+## Tag Query Syntax
+
+Tag queries are boolean expressions that allow you to match and filter resources based on their assigned tags. Terrateam supports a rich set of operators and features to create complex and targeted tag queries.
+
+The following operators are supported when creating tag queries:
+
+- `and`: Matches resources that have all the specified tags. This is the default operator if none is specified.
+- `or`: Matches resources that have at least one of the specified tags.
+- `not`: Matches resources that do not have the specified tag.
+- `in`: Matches resources that have the specified tag as a fragment in their path or name.
+- Parentheses: Used to group and prioritize expressions. 
+
+The following table presents some examples of tag queries:
+
+
+| **Tag Query Expression**     | **Description**                                               |
+|------------------------------|---------------------------------------------------------------|
+| `prod and api`               | Matches resources with both `prod` and `api` tags.            |
+| `staging or dev`             | Matches resources with either `staging` or `dev` tag.         |
+| `not deprecated`             | Matches resources without the `deprecated` tag.               |
+| `app in dir`                 | Matches resources where `app` is a fragment in their directory path. |
+| `(web or api) and prod`      | Matches resources with either `web` or `api` tags, and also the `prod` tag. |
+
+## Using Tag Queries
+
+Tag queries can be used in different parts of your Terrateam configuration to target specific resources and define granular behavior.
+
+### Workflows
+
+In the `workflows` section of your [configuration](/getting-started/configuration/) file, you can use tag queries to specify which resources a particular workflow should apply. In the following example, the first workflow is triggered for the `main` branch and `prod` environment, while the second workflow is triggered for the `staging` branch and `staging` environment. 
+
+```yaml
+workflows:
+  - tag_query: 'dest_branch:main and prod'
+    plan:
+      - type: init
+      - type: plan
+    apply:
+      - type: init
+      - type: apply
+  - tag_query: 'dest_branch:staging and staging'
+    plan:
+      - type: init
+      - type: plan
+    apply:
+      - type: init
+      - type: apply
+```
+
+### Commands
+
+When running Terrateam commands, you can use tag queries to target specific resources. For example, to target a plan to a specific tag query:
+
+  ```bash
+  terrateam plan <tag-query>
+  ```
+
+You can also apply a specific tag query:
+
+  ```bash
+  terrateam apply <tag-query>
+  ```
+
+:::note
+Check the [Tags](/advanced-workflows/tags) page to learn more about advanced tag queries.
+:::
+
+


### PR DESCRIPTION
## Description

Updates the getting tarted configuration page, and also creates a new page to address tag queries. The new page was supposed to appear before the configuration page. However, the sidebar is automatically generated. 

If we can update the astro.config file, we can reorder the sidebar.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [X] Documentation update
- [ ] Other (explain):

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/terrateamio/terrateam/blob/main/CONTRIBUTING.md)
- [x] The pull request title follows this format:
      `ISSUE_NUMBER ACTION_TYPE Short description` (e.g., `123 ADD Feature description`)
- [x] I have added tests and documentation (if applicable)
- [x] My changes generate no new warnings/errors and do not break existing functionality
