### PR TITLE
#450 REFACTOR Impove database resource usage

### DIFF
--- a/code/src/pgsql_pool/pgsql_pool.ml
+++ b/code/src/pgsql_pool/pgsql_pool.ml
@@ -23,6 +23,7 @@ end
 module Msg = struct
   type t =
     | Get of (Pgsql_io.t, unit) result Abb.Future.Promise.t
+    | Conn_timeout_check
     | Return of Pgsql_io.t
 end
 
@@ -30,6 +31,7 @@ module Server = struct
   type t = {
     metrics : Metrics.t -> unit Abb.Future.t;
     idle_check : Duration.t;
+    conn_timeout_check : Duration.t;
     tls_config : [ `Require of Otls.Tls_config.t | `Prefer of Otls.Tls_config.t ] option;
     passwd : string option;
     port : int option;
@@ -42,6 +44,15 @@ module Server = struct
     conns : Conn.t list;
     waiting : (Pgsql_io.t, unit) result Abb.Future.Promise.t Queue.t;
   }
+
+  let rec conn_timeout_check' timeout w =
+    let open Abb.Future.Infix_monad in
+    Abb.Sys.sleep @@ Duration.to_f timeout
+    >>= fun () ->
+    Abbs_channel.send w Msg.Conn_timeout_check
+    >>= function
+    | `Ok () -> conn_timeout_check' timeout w
+    | `Closed -> Abb.Future.return ()
 
   (* Consume waiting promises until we find one that is undetermined.  Needed in
      case a waiting future was terminated while waiting. *)
@@ -122,7 +133,7 @@ module Server = struct
                 Abb.Future.Promise.set p (Ok conn)
                 >>= fun () -> loop { t with num_conns = t.num_conns + 1 } w r
             | `Ok (Error (#Pgsql_io.create_err as err)) ->
-                Logs.err (fun m -> m "PGSQL_POOL : ERROR : %s" (Pgsql_io.show_create_err err));
+                Logs.err (fun m -> m "ERROR : %s" (Pgsql_io.show_create_err err));
                 Abb.Future.Promise.set p (Error ()) >>= fun () -> loop t w r
             | `Timeout -> Abb.Future.Promise.set p (Error ()) >>= fun () -> loop t w r))
     | `Ok (Msg.Return conn) when Pgsql_io.connected conn -> (
@@ -143,17 +154,44 @@ module Server = struct
         match take_until_undet t.waiting with
         | Some p -> handle_msg t w r (`Ok (Msg.Get p))
         | None -> loop t w r)
+    | `Ok Msg.Conn_timeout_check ->
+        let conn_timeout_check = Duration.to_f t.conn_timeout_check in
+        Logs.debug (fun m ->
+            m
+              "CONN_TIMEOUT_CHECK : STARTED : num_conns=%d : timeout=%0.0f"
+              t.num_conns
+              conn_timeout_check);
+        Abb.Sys.monotonic ()
+        >>= fun now ->
+        Abbs_future_combinators.List.fold_left
+          ~f:(fun t ({ Conn.conn; last_used } as c) ->
+            let age = now -. last_used in
+            Logs.debug (fun m -> m "CONN_TIMEOUT_CHECK : TEST : age=%0.0f" age);
+            if age >= conn_timeout_check then
+              Pgsql_io.destroy conn
+              >>= fun _ -> Abb.Future.return { t with num_conns = t.num_conns - 1 }
+            else Abb.Future.return { t with conns = c :: t.conns })
+          ~init:{ t with conns = [] }
+          t.conns
+        >>= fun t ->
+        Logs.debug (fun m -> m "CONN_TIMEOUT_CHECK : COMPLETED : num_conns=%d" t.num_conns);
+        loop t w r
     | `Closed ->
         Abbs_future_combinators.List.iter
           ~f:(fun Conn.{ conn; _ } -> Abbs_future_combinators.ignore (Pgsql_io.destroy conn))
           t.conns
+
+  let run t w r =
+    let open Abb.Future.Infix_monad in
+    Abb.Future.fork (conn_timeout_check' t.conn_timeout_check w) >>= fun _ -> loop t w r
 end
 
 type t = Msg.t Abbs_service_local.w
 
 let create
     ?(metrics = fun _ -> Abbs_future_combinators.unit)
-    ?(idle_check = Duration.of_year 1)
+    ?(idle_check = Duration.of_min 5)
+    ?(conn_timeout_check = Duration.of_min 1)
     ?tls_config
     ?passwd
     ?port
@@ -167,6 +205,7 @@ let create
       {
         metrics;
         idle_check;
+        conn_timeout_check;
         tls_config;
         passwd;
         port;
@@ -180,7 +219,7 @@ let create
         waiting = Queue.create ();
       }
   in
-  Abbs_service_local.create (Server.loop t)
+  Abbs_service_local.create (Server.run t)
 
 let destroy t = Abbs_future_combinators.ignore (Abbs_channel.close t)
 
@@ -198,6 +237,9 @@ let with_conn t ~f =
       | Error () -> Abb.Future.return (Error `Pgsql_pool_error))
     ~finally:(function
       | Ok conn -> (
+          (* Cleanup any prepared statements. *)
+          Pgsql_io.Prepared_stmt.execute conn Pgsql_io.Typed_sql.(sql /^ "DEALLOCATE")
+          >>= fun _ ->
           Abbs_channel.send t (Msg.Return conn)
           >>= function
           | `Ok () -> Abb.Future.return ()

--- a/code/src/pgsql_pool/pgsql_pool.mli
+++ b/code/src/pgsql_pool/pgsql_pool.mli
@@ -10,17 +10,22 @@ end
 type err = [ `Pgsql_pool_error ]
 type t
 
-(** Create a pool which will create [Pgsql] connections with the given
-    configuration.  No connections are made on creation.  [idle_check] specifies
-    how long between uses of a connection to check if it is still connected.
-    This is tested on the next use of the connection.  The check translates to a
-    ping being sent to the database to verify the connection is still alive.  By
-    default this check is 1 year.  A value of [0] checks it on every use.  If
-    the connection has been disconnected, the next connection is verified, and
-    so on, until a connection is found. *)
+(** Create a pool which will create [Pgsql] connections with the given configuration. No connections
+    are made on creation.
+
+    - [idle_check] specifies how long between uses of a connection to check if it is still
+      connected. This is tested on the next use of the connection. The check translates to a ping
+      being sent to the database to verify the connection is still alive. By default this check is 1
+      year. A value of [0] checks it on every use. If the connection has been disconnected, the next
+      connection is verified, and so on, until a connection is found.
+
+    - [conn_timeout_check] specifies how long a connection can be idle for before timing out and
+      being closed, shrinking the pool when it is not in active use. By default, this is 1 minute.
+*)
 val create :
   ?metrics:(Metrics.t -> unit Abb.Future.t) ->
   ?idle_check:Duration.t ->
+  ?conn_timeout_check:Duration.t ->
   ?tls_config:[ `Require of Otls.Tls_config.t | `Prefer of Otls.Tls_config.t ] ->
   ?passwd:string ->
   ?port:int ->
@@ -31,21 +36,20 @@ val create :
   string ->
   t Abb.Future.t
 
-(** Destroy the pool.  All idle connections are closed and connections in use
-   are closed once they are no longer used. *)
+(** Destroy the pool. All idle connections are closed and connections in use are closed once they
+    are no longer used. *)
 val destroy : t -> unit Abb.Future.t
 
-(** Perform an operation with a connection.  If there is no available idle
-   connection and there are fewer than [max_conns] created, then create a new
-   one and use it, otherwise wait until a connection is idle.
+(** Perform an operation with a connection. If there is no available idle connection and there are
+    fewer than [max_conns] created, then create a new one and use it, otherwise wait until a
+    connection is idle.
 
-   This function expects that the pool will always be available and it throws an
-   exception if it is not.  This error means retrying the operion will
-   consistently fail.
+    This function expects that the pool will always be available and it throws an exception if it is
+    not. This error means retrying the operion will consistently fail.
 
-   However if the pool is available but there are issues with creating new
-   connections to the database, it will return a [`Pgsql_pool_error] error.
-   This error is temporarily and retrying the operation may succeed. *)
+    However if the pool is available but there are issues with creating new connections to the
+    database, it will return a [`Pgsql_pool_error] error. This error is temporarily and retrying the
+    operation may succeed. *)
 val with_conn :
   t -> f:(Pgsql_io.t -> ('a, ([> err ] as 'e)) result Abb.Future.t) -> ('a, 'e) result Abb.Future.t
 

--- a/code/src/terrat_cli/terrat_cli.ml
+++ b/code/src/terrat_cli/terrat_cli.ml
@@ -56,14 +56,15 @@ module Cmdline = struct
     Logs.set_level level;
     let default_remove_loggers =
       [
-        "happy-eyeballs";
-        "dns_client";
-        "dns_cache";
         "abb.dns";
-        "cohttp_abb";
-        "cohttp_abb.io";
         "abb_curl";
         "abb_curl_easy";
+        "cohttp_abb";
+        "cohttp_abb.io";
+        "dns_cache";
+        "dns_client";
+        "happy-eyeballs";
+        "pgsql.pool";
       ]
     in
     let loggers =


### PR DESCRIPTION
Issue a DEALLOCATE when a connection is done, to clean up any prepared statements, and disconnect idled connections.

## Description

<!-- Briefly describe the changes and the issue it fixes. -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Other (explain):

Refactor database resource usage

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/terrateamio/terrateam/blob/main/CONTRIBUTING.md)
- [x] The pull request title follows this format:
      `ISSUE_NUMBER ACTION_TYPE Short description` (e.g., `123 ADD Feature description`)
- [x] I have added tests and documentation (if applicable)
- [x] My changes generate no new warnings/errors and do not break existing functionality

## Additional context (optional)

<!-- Add any additional context here, e.g., screenshots, dependencies, etc. -->
