### PR TITLE
#561 ADD Comment module with new Append behaviour

### DIFF
--- a/code/pds.conf
+++ b/code/pds.conf
@@ -1303,6 +1303,17 @@ deps = [
   "terrat_pull_request",
 ]
 
+[src.terrat_vcs_comment]
+install = false
+deps = [
+  "abbs",
+  "containers",
+  "ppx_deriving.ord",
+  "ppx_deriving.show",
+  "terrat_data",
+  "terrat_dirspace"
+]
+
 [src.terrat_vcs_event_evaluator]
 install = false
 deps = [
@@ -1339,6 +1350,7 @@ deps = [
 install = false
 deps = [
   "terrat_vcs_api_github",
+  "terrat_vcs_comment",
   "terrat_vcs_provider2",
 ]
 
@@ -1346,6 +1358,7 @@ deps = [
 install = false
 deps = [
   "terrat_vcs_api_gitlab",
+  "terrat_vcs_comment",
   "terrat_vcs_provider2",
 ]
 
@@ -1393,6 +1406,7 @@ deps = [
   "terrat_telemetry",
   "terrat_user",
   "terrat_vcs_api_github",
+  "terrat_vcs_comment",
   "terrat_vcs_event_evaluator",
   "terrat_vcs_provider2",
   "terrat_vcs_provider2_github",
@@ -1625,6 +1639,9 @@ deps = [
   "terrat_sql_of_tag_query",
   "terrat_tag_query_ast",
 ]
+
+[tests.terrat_vcs_comment]
+deps = ["oth", "oth_abb", "terrat_vcs_comment"]
 
 [tests.uritmpl]
 deps = ["uritmpl", "oth"]

--- a/code/src/abb_future_combinators/abb_future_combinators.ml
+++ b/code/src/abb_future_combinators/abb_future_combinators.ml
@@ -192,7 +192,12 @@ module Make (Fut : Abb_intf.Future.S) = struct
                Fut.fork (finally v))
       >>= fun fut ->
       Fut.add_dep ~dep:fut (Fut.Promise.future p);
-      fut)
+      Fut.await_bind
+        (function
+          | `Det _ -> Fut.return ()
+          | `Exn exn -> Fut.Promise.set_exn p exn
+          | `Aborted -> Fut.abort (Fut.Promise.future p))
+        fut)
     >>= fun _ -> Fut.Promise.future p
 
   let to_result fut = fut >>= fun v -> Fut.return (Ok v)

--- a/code/src/terrat_vcs_comment/terrat_vcs_comment.ml
+++ b/code/src/terrat_vcs_comment/terrat_vcs_comment.ml
@@ -1,0 +1,122 @@
+module Strategy = struct
+  type t =
+    | Append
+    | Delete
+    | Minimize
+  [@@deriving ord, show]
+end
+
+module type S = sig
+  type t
+  type el [@@deriving ord, show]
+  type comment_id [@@deriving ord, show]
+
+  val query_comment_id : t -> el -> (comment_id option, [> `Error ]) result Abb.Future.t
+  val query_els_for_comment_id : t -> comment_id -> (el list, [> `Error ]) result Abb.Future.t
+  val upsert_comment_id : t -> el list -> comment_id -> (unit, [> `Error ]) result Abb.Future.t
+  val delete_comment : t -> comment_id -> (unit, [> `Error ]) result Abb.Future.t
+  val minimize_comment : t -> comment_id -> (unit, [> `Error ]) result Abb.Future.t
+  val post_comment : t -> el list -> (comment_id, [> `Error ]) result Abb.Future.t
+  val rendered_length : t -> el list -> int
+  val strategy : el -> Strategy.t
+  val compact : el -> el
+  val max_comment_length : int
+end
+
+module Make (M : S) = struct
+  module By_strategy = Terrat_data.Group_by (struct
+    type t = M.el
+    type key = Strategy.t
+
+    let key = M.strategy
+    let compare = Strategy.compare
+  end)
+
+  module Id_set = CCSet.Make (struct
+    type t = M.comment_id
+
+    let compare = M.compare_comment_id
+  end)
+
+  module El_set = CCSet.Make (struct
+    type t = M.el
+
+    let compare = M.compare_el
+  end)
+
+  let partition_by_strategy els = By_strategy.group els
+  let compact t e = if M.rendered_length t [ e ] < M.max_comment_length then e else M.compact e
+
+  let find_existing_comments_for_el t els =
+    let open Abbs_future_combinators.Infix_result_monad in
+    let module Alr = Abbs_future_combinators.List_result in
+    Alr.filter_map ~f:(fun el -> M.query_comment_id t el) els
+    >>= fun cids ->
+    let uniq = Id_set.of_list cids |> Id_set.to_list in
+    Abb.Future.return (Ok uniq)
+
+  let find_all_els_from t comment_ids =
+    let open Abbs_future_combinators.Infix_result_monad in
+    let module Alr = Abbs_future_combinators.List_result in
+    Alr.map ~f:(M.query_els_for_comment_id t) comment_ids
+    >>= fun elss ->
+    let flat = CCList.flatten elss in
+    let set = El_set.of_list flat in
+    let list = El_set.to_list set in
+    Abb.Future.return (Ok list)
+
+  let split_by_size t els =
+    let combine (groups, curr_acc) r =
+      if M.rendered_length t (r :: curr_acc) < M.max_comment_length then (groups, r :: curr_acc)
+      else (CCList.rev curr_acc :: groups, [ r ])
+    in
+    let groups, rest = CCList.fold_left combine ([], []) els in
+    CCList.rev (CCList.rev rest :: groups) |> CCList.filter CCFun.(CCList.is_empty %> not)
+
+  let append t elss =
+    let open Abbs_future_combinators.Infix_result_monad in
+    let module Alr = Abbs_future_combinators.List_result in
+    let append_single t els = M.post_comment t els >>= fun cid -> M.upsert_comment_id t els cid in
+    Abbs_future_combinators.List_result.iter ~f:(append_single t) elss
+
+  let delete t elss =
+    let open Abbs_future_combinators.Infix_result_monad in
+    let module Alr = Abbs_future_combinators.List_result in
+    let delete_if_comment_exists els =
+      find_existing_comments_for_el t els
+      >>= fun cids ->
+      Alr.iter ~f:(M.delete_comment t) cids
+      >>= fun () ->
+      find_all_els_from t cids
+      >>= fun els -> M.post_comment t els >>= fun new_cid -> M.upsert_comment_id t els new_cid
+    in
+    Alr.iter ~f:delete_if_comment_exists elss
+
+  let minimize t elss =
+    let open Abbs_future_combinators.Infix_result_monad in
+    let module Alr = Abbs_future_combinators.List_result in
+    let minimize_single els =
+      find_existing_comments_for_el t els
+      >>= fun cids ->
+      Alr.iter ~f:(M.minimize_comment t) cids
+      >>= fun () -> M.post_comment t els >>= fun new_cid -> M.upsert_comment_id t els new_cid
+    in
+    Alr.iter ~f:minimize_single elss
+
+  let run t els =
+    let open Abbs_future_combinators.Infix_result_monad in
+    let module Alr = Abbs_future_combinators.List_result in
+    let compressed = CCList.map (compact t) els in
+    let sorted = CCList.sort M.compare_el compressed in
+    let groups = partition_by_strategy sorted in
+    let split = CCList.map (fun (k, v) -> (k, split_by_size t v)) groups in
+    match split with
+    | [] -> M.post_comment t [] >>= fun _ -> Abb.Future.return (Ok ())
+    | _ ->
+        Abbs_future_combinators.List_result.iter
+          ~f:(function
+            | Strategy.Append, els -> append t els
+            | Strategy.Delete, els -> delete t els
+            | Strategy.Minimize, els -> minimize t els)
+          split
+end

--- a/code/src/terrat_vcs_comment/terrat_vcs_comment.mli
+++ b/code/src/terrat_vcs_comment/terrat_vcs_comment.mli
@@ -1,0 +1,51 @@
+module Strategy : sig
+  type t =
+    | Append
+    | Delete
+    | Minimize
+  [@@deriving ord, show]
+end
+
+(** Primitive operations *)
+module type S = sig
+  (** Contains DB connection, API-related data, whatever 
+      we need to communicate with external systems *)
+  type t
+
+  (** Corresponds to the actual content of an output like
+      workspaces, dirspaces, metadata, etc. *)
+  type el [@@deriving ord, show]
+
+  (** The Id that we are going to get from the VCS, on
+      GitHub this is an uint64. *)
+  type comment_id [@@deriving ord, show]
+
+  (** DB/Persistence operations *)
+  val query_comment_id : t -> el -> (comment_id option, [> `Error ]) result Abb.Future.t
+
+  val query_els_for_comment_id : t -> comment_id -> (el list, [> `Error ]) result Abb.Future.t
+
+  val upsert_comment_id : t -> el list -> comment_id -> (unit, [> `Error ]) result Abb.Future.t
+
+  (** Modify existing comments from a VCS provider *)
+  val delete_comment : t -> comment_id -> (unit, [> `Error ]) result Abb.Future.t
+
+  val minimize_comment : t -> comment_id -> (unit, [> `Error ]) result Abb.Future.t
+  val post_comment : t -> el list -> (comment_id, [> `Error ]) result Abb.Future.t
+
+  (** Element primitives *)
+  val rendered_length : t -> el list -> int
+  val strategy : el -> Strategy.t
+  (** When an el is too big to fit in a comment, compact formats it in a
+      way that redirects people to our UI. Instead of working within the 
+      limitations of certain version control systems. *)
+  val compact : el -> el
+
+  (** Constraints *)
+  val max_comment_length : int
+end
+
+module Make (M : S) : sig
+  (* raw input, raw string, intermediary type *)
+  val run : M.t -> M.el list -> (unit, [> `Error ]) result Abb.Future.t
+end

--- a/code/src/terrat_vcs_service_github/terrat_vcs_service_github_assets.ml
+++ b/code/src/terrat_vcs_service_github/terrat_vcs_service_github_assets.ml
@@ -1,0 +1,198 @@
+module Tmpl = struct
+  module Transformers = struct
+    let money =
+      ( "money",
+        Snabela.Kv.(
+          function
+          | F num -> S (Printf.sprintf "%01.02f" num)
+          | any -> any) )
+
+    let plan_diff =
+      ( "plan_diff",
+        Snabela.Kv.(
+          function
+          | S plan -> S (Terrat_plan_diff.transform plan)
+          | any -> any) )
+
+    let compact_plan =
+      ( "compact_plan",
+        Snabela.Kv.(
+          function
+          | S plan ->
+              S
+                (plan
+                |> CCString.split_on_char '\n'
+                |> CCList.filter (fun s -> CCString.find ~sub:"= (known after apply)" s = -1)
+                |> CCString.concat "\n")
+          | any -> any) )
+
+    let minus_one =
+      ( "minus_one",
+        Snabela.Kv.(
+          function
+          | I v -> I (v - 1)
+          | F v -> F (v -. 1.0)
+          | any -> any) )
+  end
+
+  let read fname =
+    fname
+    |> Terrat_files_github_tmpl.read
+    |> CCOption.get_exn_or fname
+    |> Snabela.Template.of_utf8_string
+    |> (function
+    | Ok tmpl -> tmpl
+    | Error (#Snabela.Template.err as err) -> failwith (Snabela.Template.show_err err))
+    |> fun tmpl ->
+    Snabela.of_template tmpl Transformers.[ money; compact_plan; plan_diff; minus_one ]
+
+  let terrateam_comment_help = read "terrateam_comment_help.tmpl"
+  let apply_requirements_config_err_tag_query = read "apply_requirements_config_err_tag_query.tmpl"
+
+  let apply_requirements_config_err_invalid_query =
+    read "apply_requirements_config_err_invalid_query.tmpl"
+
+  let apply_requirements_validation_err = read "apply_requirements_validation_err.tmpl"
+  let mismatched_refs = read "mismatched_refs.tmpl"
+  let missing_plans = read "missing_plans.tmpl"
+  let dirspaces_owned_by_other_pull_requests = read "dirspaces_owned_by_other_pull_requests.tmpl"
+  let conflicting_work_manifests = read "conflicting_work_manifests.tmpl"
+  let depends_on_cycle = read "depends_on_cycle.tmpl"
+  let maybe_stale_work_manifests = read "maybe_stale_work_manifests.tmpl"
+  let repo_config_parse_failure = read "repo_config_parse_failure.tmpl"
+  let repo_config_schema_err = read "repo_config_schema_err.tmpl"
+  let repo_config_generic_failure = read "repo_config_generic_failure.tmpl"
+  let pull_request_not_appliable = read "pull_request_not_appliable.tmpl"
+  let pull_request_not_mergeable = read "pull_request_not_mergeable.tmpl"
+  let apply_no_matching_dirspaces = read "apply_no_matching_dirspaces.tmpl"
+  let plan_no_matching_dirspaces = read "plan_no_matching_dirspaces.tmpl"
+  let base_branch_not_default_branch = read "dest_branch_no_match.tmpl"
+  let auto_apply_running = read "auto_apply_running.tmpl"
+  let bad_custom_branch_tag_pattern = read "bad_custom_branch_tag_pattern.tmpl"
+  let bad_glob = read "bad_glob.tmpl"
+  let unlock_success = read "unlock_success.tmpl"
+  let access_control_all_dirspaces_denied = read "access_control_all_dirspaces_denied.tmpl"
+  let access_control_dirspaces_denied = read "access_control_dirspaces_denied.tmpl"
+  let access_control_files_denied = read "access_control_files_denied.tmpl"
+  let access_control_unlock_denied = read "access_control_unlock_denied.tmpl"
+  let access_control_ci_config_update_denied = read "access_control_ci_config_update_denied.tmpl"
+
+  let access_control_terrateam_config_update_denied =
+    read "access_control_terrateam_config_update_denied.tmpl"
+
+  let access_control_lookup_err = read "access_control_lookup_err.tmpl"
+  let tag_query_error = read "tag_query_error.tmpl"
+  let account_expired_err = read "account_expired_err.tmpl"
+  let repo_config = read "repo_config.tmpl"
+  let unexpected_temporary_err = read "unexpected_temporary_err.tmpl"
+  let failed_to_start_workflow = read "failed_to_start_workflow.tmpl"
+  let failed_to_find_workflow = read "failed_to_find_workflow.tmpl"
+  let comment_too_large = read "comment_too_large.tmpl"
+  let index_complete = read "index_complete.tmpl"
+  let invalid_lock_id = read "unlock_failed_bad_id.tmpl"
+
+  (* Repo config errors *)
+  let repo_config_err_access_control_policy_apply_autoapprove_match_parse_err =
+    read "repo_config_err_access_control_policy_apply_autoapprove_match_parse_err.tmpl"
+
+  let repo_config_err_access_control_policy_apply_force_match_parse_err =
+    read "repo_config_err_access_control_policy_apply_force_match_parse_err.tmpl"
+
+  let repo_config_err_access_control_policy_apply_match_parse_err =
+    read "repo_config_err_access_control_policy_apply_match_parse_err.tmpl"
+
+  let repo_config_err_access_control_policy_apply_with_superapproval_match_parse_err =
+    read "repo_config_err_access_control_policy_apply_with_supperapproval_match_parse_err.tmpl"
+
+  let repo_config_err_access_control_policy_plan_match_parse_err =
+    read "repo_config_err_access_control_policy_plan_match_parse_err.tmpl"
+
+  let repo_config_err_access_control_policy_superapproval_match_parse_err =
+    read "repo_config_err_access_control_policy_superapproval_match_parse_err.tmpl"
+
+  let repo_config_err_access_control_policy_tag_query_err =
+    read "repo_config_err_access_control_policy_tag_query_err.tmpl"
+
+  let repo_config_err_access_control_terrateam_config_update_match_parse_err =
+    read "repo_config_err_access_control_terrateam_config_update_match_parse_err.tmpl"
+
+  let repo_config_err_access_control_ci_config_update_match_parse_err =
+    read "repo_config_err_access_control_ci_config_update_match_parse_err.tmpl"
+
+  let repo_config_err_access_control_file_match_parse_err =
+    read "repo_config_err_access_control_file_match_parse_err.tmpl"
+
+  let repo_config_err_access_control_unlock_match_parse_err =
+    read "repo_config_err_access_control_unlock_match_parse_err.tmpl"
+
+  let repo_config_err_apply_requirements_approved_all_of_match_parse_err =
+    read "repo_config_err_apply_requirements_approved_all_of_match_parse_err.tmpl"
+
+  let repo_config_err_apply_requirements_approved_any_of_match_parse_err =
+    read "repo_config_err_apply_requirements_approved_any_of_match_parse_err.tmpl"
+
+  let repo_config_err_apply_requirements_check_tag_query_err =
+    read "repo_config_err_apply_requirements_check_tag_query_err.tmpl"
+
+  let repo_config_err_depends_on_err = read "repo_config_err_depends_on_err.tmpl"
+  let repo_config_err_drift_schedule_err = read "repo_config_err_drift_schedule_err.tmpl"
+  let repo_config_err_drift_tag_query_err = read "repo_config_err_drift_tag_query_err.tmpl"
+  let repo_config_err_glob_parse_err = read "repo_config_err_glob_parse_err.tmpl"
+
+  let repo_config_err_hooks_unknown_run_on_err =
+    read "repo_config_err_hooks_unknown_run_on_err.tmpl"
+
+  let repo_config_err_hooks_unknown_visible_on_err =
+    read "repo_config_err_hooks_unknown_visible_on_err.tmpl"
+
+  let repo_config_err_pattern_parse_err = read "repo_config_err_pattern_parse_err.tmpl"
+  let repo_config_err_unknown_lock_policy_err = read "repo_config_err_unknown_lock_policy_err.tmpl"
+
+  let repo_config_err_window_parse_timezone_err =
+    read "repo_config_err_window_parse_timezone_err.tmpl"
+
+  let repo_config_err_workflows_apply_unknown_run_on_err =
+    read "repo_config_err_workflows_apply_unknown_run_on_err.tmpl"
+
+  let repo_config_err_workflows_apply_unknown_visible_on_err =
+    read "repo_config_err_workflows_apply_unknown_visible_on_err.tmpl"
+
+  let repo_config_err_workflows_plan_unknown_run_on_err =
+    read "repo_config_err_workflows_plan_unknown_run_on_err.tmpl"
+
+  let repo_config_err_workflows_plan_unknown_visible_on_err =
+    read "repo_config_err_workflows_plan_unknown_visible_on_err.tmpl"
+
+  let repo_config_err_workflows_tag_query_parse_err =
+    read "repo_config_err_workflows_tag_query_parse_err.tmpl"
+
+  let plan_complete = read "plan_complete.tmpl"
+  let apply_complete = read "apply_complete.tmpl"
+  let plan_complete2 = read "plan_complete2.tmpl"
+  let apply_complete2 = read "apply_complete2.tmpl"
+  let automerge_failure = read "automerge_error.tmpl"
+  let premium_feature_err_access_control = read "premium_feature_err_access_control.tmpl"
+
+  let premium_feature_err_multiple_drift_schedules =
+    read "premium_feature_err_multiple_drift_schedules.tmpl"
+
+  let premium_feature_err_gatekeeping = read "premium_feature_err_gatekeeping.tmpl"
+  let repo_config_merge_err = read "repo_config_merge_err.tmpl"
+  let gate_check_failure = read "gate_check_failure.tmpl"
+  let tier_check = read "tier_check.tmpl"
+  let build_tree_failure = read "build_tree_failure.tmpl"
+end
+
+module Ui = struct
+  module Api = Terrat_vcs_api_github
+
+  let work_manifest_url config account work_manifest =
+    let module Wm = Terrat_work_manifest3 in
+    Some
+      (Uri.of_string
+         (Printf.sprintf
+            "%s/i/%d/runs/%s"
+            (Uri.to_string (Terrat_config.terrateam_web_base_url @@ Api.Config.config config))
+            (Api.Account.id account)
+            (Uuidm.to_string work_manifest.Wm.id)))
+end

--- a/code/src/terrat_vcs_service_github/terrat_vcs_service_github_comment.ml
+++ b/code/src/terrat_vcs_service_github/terrat_vcs_service_github_comment.ml
@@ -1,0 +1,102 @@
+module Api = Terrat_vcs_api_github
+module By_scope = Terrat_vcs_service_github_scope.By_scope
+module Publisher_tools = Terrat_vcs_service_github_publishers.Publisher_tools
+module Output = Terrat_vcs_service_github_publishers.Output
+module Scope = Terrat_vcs_service_github_scope.Scope
+module Tmpl = Terrat_vcs_service_github_assets.Tmpl
+module Ui = Terrat_vcs_service_github_assets.Ui
+module Visible_on = Terrat_base_repo_config_v1.Workflow_step.Visible_on
+
+module S = struct
+  type t = {
+    account_status : Terrat_vcs_provider2.Account_status.t;
+    client : Api.Client.t;
+    config : Api.Config.t;
+    is_layered_run : bool;
+    hooks : (Scope.t * Terrat_api_components_workflow_step_output.t list) list;
+    pull_request : (unit, unit) Api.Pull_request.t;
+    request_id : string;
+    remaining_layers : Terrat_change_match3.Dirspace_config.t list list;
+    result : Terrat_api_components_work_manifest_tf_operation_result2.t;
+    work_manifest : (Api.Account.t, unit) Terrat_work_manifest3.Existing.t;
+  }
+
+  type el = {
+    dirspace : Terrat_dirspace.t;
+    steps : Terrat_api_components_workflow_step_output.t list;
+    strategy : Terrat_vcs_comment.Strategy.t;
+  }
+  [@@deriving show]
+
+  (*TODO: fix this later*)
+  type comment_id = unit [@@deriving ord, show]
+
+  module Cmp = struct
+    type t = bool * bool * Terrat_dirspace.t [@@deriving ord]
+  end
+
+  let query_comment_id t el = raise (Failure "nyi")
+  let query_els_for_comment_id t cid = raise (Failure "nyi")
+  let upsert_comment_id t els cid = Abb.Future.return (Ok ())
+  let delete_comment t comment_id = raise (Failure "nyi")
+  let minimize_comment t comment_id = raise (Failure "nyi")
+
+  let post_comment t els =
+    let open Abbs_future_combinators.Infix_result_monad in
+    let module R2 = Terrat_api_components.Work_manifest_tf_operation_result2 in
+    let gates = t.result.R2.gates in
+    let by_dirspace = CCList.map (fun el -> (Scope.Dirspace el.dirspace, el.steps)) els in
+    let by_scope = t.hooks @ by_dirspace in
+    let body =
+      Publisher_tools.create_run_output
+        ~view:`Full
+        t.request_id
+        t.account_status
+        t.config
+        t.is_layered_run
+        t.remaining_layers
+        by_scope
+        gates
+        t.work_manifest
+    in
+    let request_id = t.request_id in
+    let msg_type = "GITHUB COMMENT" in
+    Api.comment_on_pull_request ~request_id t.client t.pull_request body
+    >>= fun () ->
+    Logs.info (fun m -> m "%s : PUBLISHED_COMMENT : %s" request_id msg_type);
+    Abb.Future.return (Ok ())
+
+  let rendered_length t els =
+    let module R2 = Terrat_api_components.Work_manifest_tf_operation_result2 in
+    let gates = t.result.R2.gates in
+    let by_dirspace = CCList.map (fun el -> (Scope.Dirspace el.dirspace, el.steps)) els in
+    let by_scope = t.hooks @ by_dirspace in
+    let out =
+      Publisher_tools.create_run_output
+        ~view:`Full
+        t.request_id
+        t.account_status
+        t.config
+        t.is_layered_run
+        t.remaining_layers
+        by_scope
+        gates
+        t.work_manifest
+    in
+    CCString.length out
+
+  let strategy el = el.strategy
+
+  (* TODO: For testing purposes only, will change this later *)
+  (* TODO: Wirte with proper templates on Tmpl later *)
+  let compact el = el
+
+  let compare_el el1 el2 =
+    let module P = Terrat_vcs_service_github_publishers in
+    P.dirspace_compare (el1.dirspace, el1.steps) (el2.dirspace, el2.steps)
+
+  (* Github Limits it to 2^16 = 65536
+     https://github.com/mshick/add-pr-comment/issues/93#issuecomment-1531415467
+     I set it to a smaller value *)
+  let max_comment_length = 65536 / 2
+end

--- a/code/src/terrat_vcs_service_github/terrat_vcs_service_github_provider.ml
+++ b/code/src/terrat_vcs_service_github/terrat_vcs_service_github_provider.ml
@@ -1,6 +1,11 @@
 let src = Logs.Src.create "vcs_service_github_provider"
 
+module Api = Terrat_vcs_api_github
+module By_scope = Terrat_vcs_service_github_scope.By_scope
 module Logs = (val Logs.src_log src : Logs.LOG)
+module Scope = Terrat_vcs_service_github_scope.Scope
+module Tmpl = Terrat_vcs_service_github_assets.Tmpl
+module Ui = Terrat_vcs_service_github_assets.Ui
 
 let not_a_bad_chunk_size = 500
 let replace_nul_byte = CCString.replace ~which:`All ~sub:"\x00" ~by:"\\0"
@@ -40,38 +45,7 @@ module Metrics = struct
       "run_overall_result_count"
 end
 
-module Scope = struct
-  type t =
-    | Dirspace of Terrat_dirspace.t
-    | Run of {
-        flow : string;
-        subflow : string;
-      }
-  [@@deriving eq, ord]
-
-  let of_terrat_api_scope =
-    let module S = Terrat_api_components.Workflow_step_output_scope in
-    let module Ds = Terrat_api_components.Workflow_step_output_scope_dirspace in
-    let module R = Terrat_api_components.Workflow_step_output_scope_run in
-    function
-    | S.Workflow_step_output_scope_dirspace { Ds.dir; workspace; _ } ->
-        Dirspace { Terrat_dirspace.dir; workspace }
-    | S.Workflow_step_output_scope_run { R.flow; subflow; _ } -> Run { flow; subflow }
-end
-
-module By_scope = Terrat_data.Group_by (struct
-  module T = Terrat_api_components.Workflow_step_output
-
-  type t = T.t
-  type key = Scope.t
-
-  let compare = Scope.compare
-  let key { T.scope; _ } = Scope.of_terrat_api_scope scope
-end)
-
 let name = "github"
-
-module Api = Terrat_vcs_api_github
 
 module Unlock_id = struct
   type t =
@@ -2214,208 +2188,7 @@ module Gate = struct
   let eval ~request_id _ _ _ _ = Abb.Future.return (Ok [])
 end
 
-module Ui = struct
-  let work_manifest_url config account work_manifest =
-    let module Wm = Terrat_work_manifest3 in
-    Some
-      (Uri.of_string
-         (Printf.sprintf
-            "%s/i/%d/runs/%s"
-            (Uri.to_string (Terrat_config.terrateam_web_base_url @@ Api.Config.config config))
-            (Api.Account.id account)
-            (Uuidm.to_string work_manifest.Wm.id)))
-end
-
 module Comment = struct
-  module Tmpl = struct
-    module Transformers = struct
-      let money =
-        ( "money",
-          Snabela.Kv.(
-            function
-            | F num -> S (Printf.sprintf "%01.02f" num)
-            | any -> any) )
-
-      let plan_diff =
-        ( "plan_diff",
-          Snabela.Kv.(
-            function
-            | S plan -> S (Terrat_plan_diff.transform plan)
-            | any -> any) )
-
-      let compact_plan =
-        ( "compact_plan",
-          Snabela.Kv.(
-            function
-            | S plan ->
-                S
-                  (plan
-                  |> CCString.split_on_char '\n'
-                  |> CCList.filter (fun s -> CCString.find ~sub:"= (known after apply)" s = -1)
-                  |> CCString.concat "\n")
-            | any -> any) )
-
-      let minus_one =
-        ( "minus_one",
-          Snabela.Kv.(
-            function
-            | I v -> I (v - 1)
-            | F v -> F (v -. 1.0)
-            | any -> any) )
-    end
-
-    let read fname =
-      fname
-      |> Terrat_files_github_tmpl.read
-      |> CCOption.get_exn_or fname
-      |> Snabela.Template.of_utf8_string
-      |> (function
-      | Ok tmpl -> tmpl
-      | Error (#Snabela.Template.err as err) -> failwith (Snabela.Template.show_err err))
-      |> fun tmpl ->
-      Snabela.of_template tmpl Transformers.[ money; compact_plan; plan_diff; minus_one ]
-
-    let terrateam_comment_help = read "terrateam_comment_help.tmpl"
-
-    let apply_requirements_config_err_tag_query =
-      read "apply_requirements_config_err_tag_query.tmpl"
-
-    let apply_requirements_config_err_invalid_query =
-      read "apply_requirements_config_err_invalid_query.tmpl"
-
-    let apply_requirements_validation_err = read "apply_requirements_validation_err.tmpl"
-    let mismatched_refs = read "mismatched_refs.tmpl"
-    let missing_plans = read "missing_plans.tmpl"
-    let dirspaces_owned_by_other_pull_requests = read "dirspaces_owned_by_other_pull_requests.tmpl"
-    let conflicting_work_manifests = read "conflicting_work_manifests.tmpl"
-    let depends_on_cycle = read "depends_on_cycle.tmpl"
-    let maybe_stale_work_manifests = read "maybe_stale_work_manifests.tmpl"
-    let repo_config_parse_failure = read "repo_config_parse_failure.tmpl"
-    let repo_config_schema_err = read "repo_config_schema_err.tmpl"
-    let repo_config_generic_failure = read "repo_config_generic_failure.tmpl"
-    let pull_request_not_appliable = read "pull_request_not_appliable.tmpl"
-    let pull_request_not_mergeable = read "pull_request_not_mergeable.tmpl"
-    let apply_no_matching_dirspaces = read "apply_no_matching_dirspaces.tmpl"
-    let plan_no_matching_dirspaces = read "plan_no_matching_dirspaces.tmpl"
-    let base_branch_not_default_branch = read "dest_branch_no_match.tmpl"
-    let auto_apply_running = read "auto_apply_running.tmpl"
-    let bad_custom_branch_tag_pattern = read "bad_custom_branch_tag_pattern.tmpl"
-    let bad_glob = read "bad_glob.tmpl"
-    let unlock_success = read "unlock_success.tmpl"
-    let access_control_all_dirspaces_denied = read "access_control_all_dirspaces_denied.tmpl"
-    let access_control_dirspaces_denied = read "access_control_dirspaces_denied.tmpl"
-    let access_control_files_denied = read "access_control_files_denied.tmpl"
-    let access_control_unlock_denied = read "access_control_unlock_denied.tmpl"
-    let access_control_ci_config_update_denied = read "access_control_ci_config_update_denied.tmpl"
-
-    let access_control_terrateam_config_update_denied =
-      read "access_control_terrateam_config_update_denied.tmpl"
-
-    let access_control_lookup_err = read "access_control_lookup_err.tmpl"
-    let tag_query_error = read "tag_query_error.tmpl"
-    let account_expired_err = read "account_expired_err.tmpl"
-    let repo_config = read "repo_config.tmpl"
-    let unexpected_temporary_err = read "unexpected_temporary_err.tmpl"
-    let failed_to_start_workflow = read "failed_to_start_workflow.tmpl"
-    let failed_to_find_workflow = read "failed_to_find_workflow.tmpl"
-    let comment_too_large = read "comment_too_large.tmpl"
-    let index_complete = read "index_complete.tmpl"
-    let invalid_lock_id = read "unlock_failed_bad_id.tmpl"
-
-    (* Repo config errors *)
-    let repo_config_err_access_control_policy_apply_autoapprove_match_parse_err =
-      read "repo_config_err_access_control_policy_apply_autoapprove_match_parse_err.tmpl"
-
-    let repo_config_err_access_control_policy_apply_force_match_parse_err =
-      read "repo_config_err_access_control_policy_apply_force_match_parse_err.tmpl"
-
-    let repo_config_err_access_control_policy_apply_match_parse_err =
-      read "repo_config_err_access_control_policy_apply_match_parse_err.tmpl"
-
-    let repo_config_err_access_control_policy_apply_with_superapproval_match_parse_err =
-      read "repo_config_err_access_control_policy_apply_with_supperapproval_match_parse_err.tmpl"
-
-    let repo_config_err_access_control_policy_plan_match_parse_err =
-      read "repo_config_err_access_control_policy_plan_match_parse_err.tmpl"
-
-    let repo_config_err_access_control_policy_superapproval_match_parse_err =
-      read "repo_config_err_access_control_policy_superapproval_match_parse_err.tmpl"
-
-    let repo_config_err_access_control_policy_tag_query_err =
-      read "repo_config_err_access_control_policy_tag_query_err.tmpl"
-
-    let repo_config_err_access_control_terrateam_config_update_match_parse_err =
-      read "repo_config_err_access_control_terrateam_config_update_match_parse_err.tmpl"
-
-    let repo_config_err_access_control_ci_config_update_match_parse_err =
-      read "repo_config_err_access_control_ci_config_update_match_parse_err.tmpl"
-
-    let repo_config_err_access_control_file_match_parse_err =
-      read "repo_config_err_access_control_file_match_parse_err.tmpl"
-
-    let repo_config_err_access_control_unlock_match_parse_err =
-      read "repo_config_err_access_control_unlock_match_parse_err.tmpl"
-
-    let repo_config_err_apply_requirements_approved_all_of_match_parse_err =
-      read "repo_config_err_apply_requirements_approved_all_of_match_parse_err.tmpl"
-
-    let repo_config_err_apply_requirements_approved_any_of_match_parse_err =
-      read "repo_config_err_apply_requirements_approved_any_of_match_parse_err.tmpl"
-
-    let repo_config_err_apply_requirements_check_tag_query_err =
-      read "repo_config_err_apply_requirements_check_tag_query_err.tmpl"
-
-    let repo_config_err_depends_on_err = read "repo_config_err_depends_on_err.tmpl"
-    let repo_config_err_drift_schedule_err = read "repo_config_err_drift_schedule_err.tmpl"
-    let repo_config_err_drift_tag_query_err = read "repo_config_err_drift_tag_query_err.tmpl"
-    let repo_config_err_glob_parse_err = read "repo_config_err_glob_parse_err.tmpl"
-
-    let repo_config_err_hooks_unknown_run_on_err =
-      read "repo_config_err_hooks_unknown_run_on_err.tmpl"
-
-    let repo_config_err_hooks_unknown_visible_on_err =
-      read "repo_config_err_hooks_unknown_visible_on_err.tmpl"
-
-    let repo_config_err_pattern_parse_err = read "repo_config_err_pattern_parse_err.tmpl"
-
-    let repo_config_err_unknown_lock_policy_err =
-      read "repo_config_err_unknown_lock_policy_err.tmpl"
-
-    let repo_config_err_window_parse_timezone_err =
-      read "repo_config_err_window_parse_timezone_err.tmpl"
-
-    let repo_config_err_workflows_apply_unknown_run_on_err =
-      read "repo_config_err_workflows_apply_unknown_run_on_err.tmpl"
-
-    let repo_config_err_workflows_apply_unknown_visible_on_err =
-      read "repo_config_err_workflows_apply_unknown_visible_on_err.tmpl"
-
-    let repo_config_err_workflows_plan_unknown_run_on_err =
-      read "repo_config_err_workflows_plan_unknown_run_on_err.tmpl"
-
-    let repo_config_err_workflows_plan_unknown_visible_on_err =
-      read "repo_config_err_workflows_plan_unknown_visible_on_err.tmpl"
-
-    let repo_config_err_workflows_tag_query_parse_err =
-      read "repo_config_err_workflows_tag_query_parse_err.tmpl"
-
-    let plan_complete = read "plan_complete.tmpl"
-    let apply_complete = read "apply_complete.tmpl"
-    let plan_complete2 = read "plan_complete2.tmpl"
-    let apply_complete2 = read "apply_complete2.tmpl"
-    let automerge_failure = read "automerge_error.tmpl"
-    let premium_feature_err_access_control = read "premium_feature_err_access_control.tmpl"
-
-    let premium_feature_err_multiple_drift_schedules =
-      read "premium_feature_err_multiple_drift_schedules.tmpl"
-
-    let premium_feature_err_gatekeeping = read "premium_feature_err_gatekeeping.tmpl"
-    let repo_config_merge_err = read "repo_config_merge_err.tmpl"
-    let gate_check_failure = read "gate_check_failure.tmpl"
-    let tier_check = read "tier_check.tmpl"
-    let build_tree_failure = read "build_tree_failure.tmpl"
-  end
-
   let comment_on_pull_request ~request_id client pull_request msg_type body =
     let open Abbs_future_combinators.Infix_result_monad in
     Api.comment_on_pull_request ~request_id client pull_request body
@@ -2459,444 +2232,6 @@ module Comment = struct
       CCList.for_all (fun { O.success; ignore_errors; _ } -> success || ignore_errors) steps
 
     module Publisher2 = struct
-      module Visible_on = Terrat_base_repo_config_v1.Workflow_step.Visible_on
-
-      module Output = struct
-        type t = {
-          cmd : string option;
-          name : string;
-          success : bool;
-          text : string;
-          text_decorator : string option;
-          visible_on : Visible_on.t;
-        }
-
-        let make ?cmd ?text_decorator ~name ~success ~text ~visible_on () =
-          (* If name looks like <namespace>/<action> then remove the namespace *)
-          let name = CCOption.map_or ~default:name snd (CCString.Split.right ~by:"/" name) in
-          { cmd; name; success; text; text_decorator; visible_on }
-
-        let to_kv { cmd; name; success; text; text_decorator; visible_on } =
-          Snabela.Kv.(
-            Map.of_list
-              (CCList.flatten
-                 [
-                   [
-                     ("name", string name);
-                     ("text", string text);
-                     ("success", bool success);
-                     ("text_decorator", string (CCOption.get_or ~default:"" text_decorator));
-                   ];
-                   CCOption.map_or ~default:[] (fun cmd -> [ ("cmd", string cmd) ]) cmd;
-                 ]))
-
-        let filter ~overall_success =
-          CCList.filter (fun { visible_on; _ } ->
-              visible_on = Visible_on.Always
-              || (overall_success && visible_on = Visible_on.Success)
-              || ((not overall_success) && visible_on = Visible_on.Failure))
-      end
-
-      let kv_of_cost_estimation changed_dirspaces output =
-        let module P = struct
-          module S = struct
-            type t = {
-              prev_monthly_cost : float;
-              total_monthly_cost : float;
-              diff_monthly_cost : float;
-            }
-            [@@deriving of_yojson { strict = false }]
-          end
-
-          module Ds = struct
-            type t = {
-              dir : string;
-              workspace : string;
-              prev_monthly_cost : float;
-              total_monthly_cost : float;
-              diff_monthly_cost : float;
-            }
-            [@@deriving yojson { strict = false }]
-          end
-
-          type t = {
-            summary : S.t;
-            dirspaces : Ds.t list;
-            currency : string;
-          }
-          [@@deriving of_yojson { strict = false }]
-        end in
-        let module O = Terrat_api_components.Workflow_step_output in
-        if output.O.success then
-          let open CCResult.Infix in
-          P.of_yojson (O.Payload.to_yojson output.O.payload)
-          >>= fun payload ->
-          let summary = payload.P.summary in
-          let changed_dirspaces = Terrat_data.Dirspace_set.of_list changed_dirspaces in
-          Ok
-            Snabela.Kv.(
-              Map.of_list
-                [
-                  ("name", string "cost_estimation");
-                  ("success", bool output.O.success);
-                  ("prev_monthly_cost", float summary.P.S.prev_monthly_cost);
-                  ("total_monthly_cost", float summary.P.S.total_monthly_cost);
-                  ("diff_monthly_cost", float summary.P.S.diff_monthly_cost);
-                  ("currency", string payload.P.currency);
-                  ( "dirspaces",
-                    list
-                      (CCList.filter_map
-                         (fun {
-                                P.Ds.dir;
-                                workspace;
-                                total_monthly_cost;
-                                prev_monthly_cost;
-                                diff_monthly_cost;
-                              }
-                            ->
-                           if
-                             Terrat_data.Dirspace_set.mem
-                               { Terrat_dirspace.dir; workspace }
-                               changed_dirspaces
-                           then
-                             Some
-                               (Map.of_list
-                                  [
-                                    ("dir", string dir);
-                                    ("workspace", string workspace);
-                                    ("prev_monthly_cost", float prev_monthly_cost);
-                                    ("total_monthly_cost", float total_monthly_cost);
-                                    ("diff_monthly_cost", float diff_monthly_cost);
-                                  ])
-                           else None)
-                         payload.P.dirspaces) );
-                ])
-        else
-          let module P = struct
-            type t = { text : string } [@@deriving of_yojson { strict = false }]
-          end in
-          let open CCResult.Infix in
-          P.of_yojson (O.Payload.to_yojson output.O.payload)
-          >>= fun { P.text } ->
-          Ok Snabela.Kv.(Map.of_list [ ("success", bool output.O.success); ("text", string text) ])
-
-      let output_of_run ?(default_visible_on = Visible_on.Failure) output =
-        let module P = struct
-          type t = {
-            cmd : string list option; [@default None]
-            text : string option; [@default None]
-            visible_on : string option;
-          }
-          [@@deriving of_yojson { strict = false }]
-        end in
-        let module O = Terrat_api_components.Workflow_step_output in
-        let open CCResult.Infix in
-        P.of_yojson (O.Payload.to_yojson output.O.payload)
-        >>= fun { P.cmd; text; visible_on } ->
-        Ok
-          (Output.make
-             ?cmd:(CCOption.map (CCString.concat " ") cmd)
-             ~name:output.O.step
-             ~success:output.O.success
-             ~text:(CCOption.get_or ~default:"" text)
-             ~visible_on:
-               (CCOption.map_or
-                  ~default:default_visible_on
-                  (function
-                    | "always" -> Visible_on.Always
-                    | "failure" -> Visible_on.Failure
-                    | "success" -> Visible_on.Success
-                    | _ -> Visible_on.Failure)
-                  visible_on)
-             ())
-
-      let output_of_plan output =
-        let module P = struct
-          type t = {
-            cmd : string list option; [@default None]
-            text : string;
-            plan : string option; [@default None]
-            has_changes : bool option; [@default None]
-          }
-          [@@deriving of_yojson { strict = false }]
-        end in
-        let module O = Terrat_api_components.Workflow_step_output in
-        let open CCResult.Infix in
-        P.of_yojson (O.Payload.to_yojson output.O.payload)
-        >>= fun { P.cmd; text; has_changes; plan } ->
-        if output.O.success then
-          Ok
-            (Output.make
-               ?cmd:(CCOption.map (CCString.concat " ") cmd)
-               ~name:output.O.step
-               ~success:output.O.success
-               ~text:(CCOption.get_or ~default:text plan)
-               ~text_decorator:"diff"
-               ~visible_on:Visible_on.Always
-               ())
-        else
-          Ok
-            (Output.make
-               ?cmd:(CCOption.map (CCString.concat " ") cmd)
-               ~name:output.O.step
-               ~success:output.O.success
-               ~text
-               ~visible_on:Visible_on.Always
-               ())
-
-      let output_of_workflow_output output =
-        let module O = Terrat_api_components.Workflow_step_output in
-        match output.O.step with
-        | "run" | "env" -> output_of_run output
-        | "tf/init" | "pulumi/init" | "custom/init" | "fly/init" ->
-            output_of_run ~default_visible_on:Visible_on.Failure output
-        | "tf/apply" | "pulumi/apply" | "custom/apply" | "fly/apply" ->
-            output_of_run ~default_visible_on:Visible_on.Always output
-        | "tf/plan" | "pulumi/plan" | "custom/plan" | "fly/plan" -> output_of_plan output
-        | step -> output_of_run output
-
-      let output_of_raw output =
-        let module O = Terrat_api_components.Workflow_step_output in
-        let { O.step; success; payload; _ } = output in
-        Output.make
-          ~name:step
-          ~success
-          ~text:(Yojson.Safe.pretty_to_string (O.Payload.to_yojson payload))
-          ~visible_on:Visible_on.Failure
-          ()
-
-      let output_of_steps steps =
-        let module O = Terrat_api_components.Workflow_step_output in
-        CCList.filter_map
-          (fun output ->
-            match output.O.step with
-            | "tf/cost-estimation" -> None
-            | _ -> (
-                match output_of_workflow_output output with
-                | Ok output -> Some output
-                | Error _ -> Some (output_of_raw output)))
-          steps
-
-      let kv_of_outputs outputs = CCList.map Output.to_kv outputs
-
-      let dirspace_compare (dirspace1, steps1) (dirspace2, steps2) =
-        let module Cmp = struct
-          type t = bool * bool * Terrat_dirspace.t [@@deriving ord]
-        end in
-        let has_changes1 = steps_has_changes steps1 in
-        let success1 = steps_success steps1 in
-        let has_changes2 = steps_has_changes steps2 in
-        let success2 = steps_success steps2 in
-        (* Negate has_changes because the order of [bool] is [false]
-             before [true]. *)
-        Cmp.compare (not has_changes1, success1, dirspace1) (not has_changes2, success2, dirspace2)
-
-      let create_run_output
-          ~view
-          request_id
-          account_status
-          config
-          is_layered_run
-          remaining_dirspace_configs
-          by_scope
-          gates
-          work_manifest =
-        let module Wm = Terrat_work_manifest3 in
-        let module R2 = Terrat_api_components.Work_manifest_tf_operation_result2 in
-        let module O = Terrat_api_components.Workflow_step_output in
-        let module Sds = Terrat_api_components.Workflow_step_output_scope_dirspace in
-        let module Sr = Terrat_api_components.Workflow_step_output_scope_run in
-        let hooks_pre =
-          CCList.Assoc.get ~eq:Scope.equal (Scope.Run { flow = "hooks"; subflow = "pre" }) by_scope
-        in
-        let hooks_post =
-          CCList.Assoc.get ~eq:Scope.equal (Scope.Run { flow = "hooks"; subflow = "post" }) by_scope
-        in
-        let dirspaces =
-          by_scope
-          |> CCList.filter_map (function
-               | Scope.Dirspace dirspace, steps -> Some (dirspace, steps)
-               | _ -> None)
-          |> CCList.sort dirspace_compare
-        in
-        let overall_success =
-          CCList.for_all
-            (fun (_, steps) ->
-              CCList.for_all (fun { O.success; ignore_errors; _ } -> success || ignore_errors) steps)
-            by_scope
-        in
-        let num_remaining_layers = CCList.length remaining_dirspace_configs in
-        let denied_dirspaces =
-          match work_manifest.Wm.denied_dirspaces with
-          | [] -> []
-          | dirspaces ->
-              Snabela.Kv.
-                [
-                  ( "denied_dirspaces",
-                    list
-                      (CCList.map
-                         (fun { Wm.Deny.dirspace = { Terrat_dirspace.dir; workspace }; policy } ->
-                           Map.of_list
-                             (CCList.flatten
-                                [
-                                  [ ("dir", string dir); ("workspace", string workspace) ];
-                                  (match policy with
-                                  | Some policy ->
-                                      [
-                                        ( "policy",
-                                          list
-                                            (CCList.map
-                                               (fun p ->
-                                                 Map.of_list
-                                                   [
-                                                     ( "item",
-                                                       string
-                                                         (Terrat_base_repo_config_v1.Access_control
-                                                          .Match
-                                                          .to_string
-                                                            p) );
-                                                   ])
-                                               policy) );
-                                      ]
-                                  | None -> []);
-                                ]))
-                         dirspaces) );
-                ]
-        in
-        let cost_estimation =
-          hooks_pre
-          |> CCOption.get_or ~default:[]
-          |> CCList.filter (fun { O.step; _ } -> CCString.equal step "tf/cost-estimation")
-          |> function
-          | [] -> []
-          | o :: _ -> (
-              let changed_dirspaces =
-                CCList.map
-                  (fun { Terrat_change.Dirspaceflow.dirspace; _ } -> dirspace)
-                  work_manifest.Wm.changes
-              in
-              match kv_of_cost_estimation changed_dirspaces o with
-              | Ok kv -> [ ("cost_estimation", Snabela.Kv.list [ kv ]) ]
-              | Error _ ->
-                  [ ("cost_estimation", Snabela.Kv.list [ Output.to_kv (output_of_raw o) ]) ])
-        in
-        let kv =
-          Snabela.Kv.(
-            Map.of_list
-              (CCList.flatten
-                 [
-                   CCOption.map_or
-                     ~default:[]
-                     (fun work_manifest_url ->
-                       [ ("work_manifest_url", string (Uri.to_string work_manifest_url)) ])
-                     (Ui.work_manifest_url config work_manifest.Wm.account work_manifest);
-                   CCOption.map_or
-                     ~default:[]
-                     (fun env -> [ ("environment", string env) ])
-                     work_manifest.Wm.environment;
-                   [
-                     ( "account_status",
-                       string
-                         (match account_status with
-                         | `Trial_ending duration when Duration.to_day duration < 15 ->
-                             (* Only mark as trial ending if less than two weeks from now *)
-                             "trial_ending"
-                         | `Trial_ending _ | `Active -> "active"
-                         | `Expired -> "expired"
-                         | `Disabled -> "disabled") );
-                     ( "trial_end_days",
-                       match account_status with
-                       | `Trial_ending duration -> int (Duration.to_day duration)
-                       | _ -> int 0 );
-                     ("is_layered_run", bool is_layered_run);
-                     ("num_more_layers", int num_remaining_layers);
-                     ("overall_success", bool overall_success);
-                     ( "pre_hooks",
-                       hooks_pre
-                       |> CCOption.get_or ~default:[]
-                       |> output_of_steps
-                       |> Output.filter ~overall_success
-                       |> kv_of_outputs
-                       |> list );
-                     ( "post_hooks",
-                       hooks_post
-                       |> CCOption.get_or ~default:[]
-                       |> output_of_steps
-                       |> Output.filter ~overall_success
-                       |> kv_of_outputs
-                       |> list );
-                     ("compact_view", bool (view = `Compact));
-                     ("compact_dirspaces", bool (CCList.length dirspaces > 5));
-                     ( "dirspaces",
-                       list
-                         (CCList.map
-                            (fun ({ Terrat_dirspace.dir; workspace }, steps) ->
-                              let has_changes = steps_has_changes steps in
-                              let success = steps_success steps in
-                              Map.of_list
-                                (CCList.flatten
-                                   [
-                                     [
-                                       ("dir", string dir);
-                                       ("workspace", string workspace);
-                                       ("success", bool success);
-                                       ( "steps",
-                                         list
-                                           (kv_of_outputs
-                                              (Output.filter
-                                                 ~overall_success
-                                                 (output_of_steps steps))) );
-                                       ("has_changes", bool has_changes);
-                                     ];
-                                   ]))
-                            dirspaces) );
-                     ( "gates",
-                       let module G = Terrat_api_components.Gate in
-                       list
-                       @@ CCList.map
-                            (fun { G.all_of; any_of; any_of_count; dir; token; workspace } ->
-                              let all_of = CCOption.get_or ~default:[] all_of in
-                              let any_of = CCOption.get_or ~default:[] any_of in
-                              let any_of_count = CCOption.get_or ~default:0 any_of_count in
-                              let dir = CCOption.get_or ~default:"" dir in
-                              let workspace = CCOption.get_or ~default:"" workspace in
-                              Map.of_list
-                                [
-                                  ("token", string token);
-                                  ("dir", string dir);
-                                  ("workspace", string workspace);
-                                  ( "all_of",
-                                    list
-                                    @@ CCList.map (fun q -> Map.of_list [ ("q", string q) ]) all_of
-                                  );
-                                  ( "any_of",
-                                    list
-                                    @@ CCList.map
-                                         (fun q -> Map.of_list [ ("q", string q) ])
-                                         (if any_of_count = 0 then [] else any_of) );
-                                  ("any_of_count", int any_of_count);
-                                ])
-                       @@ CCList.sort (fun { G.token = t1; _ } { G.token = t2; _ } ->
-                              CCString.compare t1 t2)
-                       @@ CCOption.get_or ~default:[] gates );
-                   ];
-                   denied_dirspaces;
-                   cost_estimation;
-                 ]))
-        in
-        let tmpl =
-          match CCList.rev work_manifest.Wm.steps with
-          | [] | Wm.Step.Index :: _ | Wm.Step.Build_config :: _ | Wm.Step.Build_tree :: _ ->
-              assert false
-          | Wm.Step.Plan :: _ -> Tmpl.plan_complete2
-          | Wm.Step.(Apply | Unsafe_apply) :: _ -> Tmpl.apply_complete2
-        in
-        match Snabela.apply tmpl kv with
-        | Ok body -> body
-        | Error (#Snabela.err as err) ->
-            Logs.err (fun m -> m "%s : ERROR : %a" request_id Snabela.pp_err err);
-            assert false
-
       let rec iterate_comment_posts
           ?(view = `Full)
           request_id
@@ -2910,10 +2245,19 @@ module Comment = struct
           work_manifest =
         let module Wm = Terrat_work_manifest3 in
         let module R2 = Terrat_api_components.Work_manifest_tf_operation_result2 in
+        let module Publisher_tools = Terrat_vcs_service_github_publishers.Publisher_tools in
+        let module Comment_api = Terrat_vcs_service_github_publishers.Comment_api in
         let by_scope = By_scope.group results.R2.steps in
         let gates = results.R2.gates in
+        let dirspaces =
+          CCList.filter
+            (function
+              | Scope.Dirspace _, _ -> true
+              | _ -> false)
+            by_scope
+        in
         let output =
-          create_run_output
+          Publisher_tools.create_run_output
             ~view
             request_id
             account_status
@@ -2929,13 +2273,6 @@ module Comment = struct
         >>= function
         | Ok () -> Abb.Future.return (Ok ())
         | Error `Error -> (
-            let dirspaces =
-              CCList.filter
-                (function
-                  | Scope.Dirspace _, _ -> true
-                  | _ -> false)
-                by_scope
-            in
             match (view, dirspaces) with
             | _, [] -> assert false
             | `Full, _ ->
@@ -2960,13 +2297,69 @@ module Comment = struct
                            [ ("work_manifest_url", string (Uri.to_string work_manifest_url)) ])
                          (Ui.work_manifest_url config work_manifest.Wm.account work_manifest)))
                 in
-                apply_template_and_publish
+                Comment_api.apply_template_and_publish
                   ~request_id
                   client
                   pull_request
                   "ITERATE_COMMENT_POST2"
                   Tmpl.comment_too_large
                   kv)
+    end
+
+    module Publisher3 = struct
+      module Gcm = Terrat_vcs_comment.Make (Terrat_vcs_service_github_comment.S)
+
+      let create_els results =
+        let module R2 = Terrat_api_components.Work_manifest_tf_operation_result2 in
+        let module Tcm = Terrat_vcs_service_github_comment in
+        let by_scope = By_scope.group results.R2.steps in
+        let strategy = Terrat_vcs_comment.Strategy.Append in
+        by_scope
+        |> CCList.filter_map (function
+             | Scope.Dirspace dirspace, steps ->
+                 Some { Terrat_vcs_service_github_comment.S.dirspace; steps; strategy }
+             | Scope.Run _, _ -> None)
+
+      let post_comment
+          request_id
+          account_status
+          config
+          client
+          is_layered_run
+          remaining_layers
+          result
+          pull_request
+          work_manifest =
+        let module Tcm = Terrat_vcs_service_github_comment in
+        let module R2 = Terrat_api_components.Work_manifest_tf_operation_result2 in
+        let pull_request =
+          Api.Pull_request.set_diff () pull_request |> Api.Pull_request.set_checks ()
+        in
+        let work_manifest = { work_manifest with Terrat_work_manifest3.target = () } in
+        let by_scope = By_scope.group result.R2.steps in
+        let hooks =
+          CCList.filter_map
+            (function
+              | (Scope.Run _, _) as run -> Some run
+              | _ -> None)
+            by_scope
+        in
+        let t =
+          {
+            Tcm.S.request_id;
+            account_status;
+            config;
+            client;
+            hooks;
+            is_layered_run;
+            remaining_layers;
+            result;
+            pull_request;
+            work_manifest;
+          }
+        in
+        let els = create_els result in
+        Gcm.run t els
     end
   end
 
@@ -3791,6 +3184,8 @@ module Comment = struct
           "REPO_CONFIG_SCHEMA_ERR"
           Tmpl.repo_config_schema_err
           kv
+    | `Notification_policy_comment_strategy_err err -> raise (Failure "nyi")
+    | `Notification_policy_tag_query_err err -> raise (Failure "nyi")
 
   let publish_comment ~request_id client user pull_request =
     let module Msg = Terrat_vcs_provider2.Msg in
@@ -4638,7 +4033,7 @@ module Comment = struct
     | Msg.Tf_op_result2
         { account_status; config; is_layered_run; remaining_layers; result; work_manifest } -> (
         let open Abb.Future.Infix_monad in
-        Result.Publisher2.iterate_comment_posts
+        Result.Publisher3.post_comment
           request_id
           account_status
           config

--- a/code/src/terrat_vcs_service_github/terrat_vcs_service_github_publishers.ml
+++ b/code/src/terrat_vcs_service_github/terrat_vcs_service_github_publishers.ml
@@ -1,0 +1,479 @@
+module Api = Terrat_vcs_api_github
+module Scope = Terrat_vcs_service_github_scope.Scope
+module By_scope = Terrat_vcs_service_github_scope.By_scope
+module Tmpl = Terrat_vcs_service_github_assets.Tmpl
+module Visible_on = Terrat_base_repo_config_v1.Workflow_step.Visible_on
+module Ui = Terrat_vcs_service_github_assets.Ui
+
+module Output = struct
+  type t = {
+    cmd : string option;
+    name : string;
+    success : bool;
+    text : string;
+    text_decorator : string option;
+    visible_on : Visible_on.t;
+  }
+
+  let make ?cmd ?text_decorator ~name ~success ~text ~visible_on () =
+    (* If name looks like <namespace>/<action> then remove the namespace *)
+    let name = CCOption.map_or ~default:name snd (CCString.Split.right ~by:"/" name) in
+    { cmd; name; success; text; text_decorator; visible_on }
+
+  let to_kv { cmd; name; success; text; text_decorator; visible_on } =
+    Snabela.Kv.(
+      Map.of_list
+        (CCList.flatten
+           [
+             [
+               ("name", string name);
+               ("text", string text);
+               ("success", bool success);
+               ("text_decorator", string (CCOption.get_or ~default:"" text_decorator));
+             ];
+             CCOption.map_or ~default:[] (fun cmd -> [ ("cmd", string cmd) ]) cmd;
+           ]))
+
+  let filter ~overall_success =
+    CCList.filter (fun { visible_on; _ } ->
+        visible_on = Visible_on.Always
+        || (overall_success && visible_on = Visible_on.Success)
+        || ((not overall_success) && visible_on = Visible_on.Failure))
+end
+
+let steps_has_changes steps =
+  let module P = struct
+    type t = { has_changes : bool [@default false] } [@@deriving of_yojson { strict = false }]
+  end in
+  let module O = Terrat_api_components.Workflow_step_output in
+  match
+    CCList.find_map
+      (function
+        | { O.step = "tf/plan" | "pulumi/plan" | "custom/plan" | "fly/plan"; payload; success; _ }
+          -> (
+            match P.of_yojson (O.Payload.to_yojson payload) with
+            | Ok { P.has_changes } -> Some has_changes
+            | _ -> None)
+        | _ -> None)
+      steps
+  with
+  | Some has_changes -> has_changes
+  | None -> false
+
+let steps_success steps =
+  let module O = Terrat_api_components.Workflow_step_output in
+  CCList.for_all (fun { O.success; ignore_errors; _ } -> success || ignore_errors) steps
+
+let kv_of_cost_estimation changed_dirspaces output =
+  let module P = struct
+    module S = struct
+      type t = {
+        prev_monthly_cost : float;
+        total_monthly_cost : float;
+        diff_monthly_cost : float;
+      }
+      [@@deriving of_yojson { strict = false }]
+    end
+
+    module Ds = struct
+      type t = {
+        dir : string;
+        workspace : string;
+        prev_monthly_cost : float;
+        total_monthly_cost : float;
+        diff_monthly_cost : float;
+      }
+      [@@deriving yojson { strict = false }]
+    end
+
+    type t = {
+      summary : S.t;
+      dirspaces : Ds.t list;
+      currency : string;
+    }
+    [@@deriving of_yojson { strict = false }]
+  end in
+  let module O = Terrat_api_components.Workflow_step_output in
+  if output.O.success then
+    let open CCResult.Infix in
+    P.of_yojson (O.Payload.to_yojson output.O.payload)
+    >>= fun payload ->
+    let summary = payload.P.summary in
+    let changed_dirspaces = Terrat_data.Dirspace_set.of_list changed_dirspaces in
+    Ok
+      Snabela.Kv.(
+        Map.of_list
+          [
+            ("name", string "cost_estimation");
+            ("success", bool output.O.success);
+            ("prev_monthly_cost", float summary.P.S.prev_monthly_cost);
+            ("total_monthly_cost", float summary.P.S.total_monthly_cost);
+            ("diff_monthly_cost", float summary.P.S.diff_monthly_cost);
+            ("currency", string payload.P.currency);
+            ( "dirspaces",
+              list
+                (CCList.filter_map
+                   (fun {
+                          P.Ds.dir;
+                          workspace;
+                          total_monthly_cost;
+                          prev_monthly_cost;
+                          diff_monthly_cost;
+                        }
+                      ->
+                     if
+                       Terrat_data.Dirspace_set.mem
+                         { Terrat_dirspace.dir; workspace }
+                         changed_dirspaces
+                     then
+                       Some
+                         (Map.of_list
+                            [
+                              ("dir", string dir);
+                              ("workspace", string workspace);
+                              ("prev_monthly_cost", float prev_monthly_cost);
+                              ("total_monthly_cost", float total_monthly_cost);
+                              ("diff_monthly_cost", float diff_monthly_cost);
+                            ])
+                     else None)
+                   payload.P.dirspaces) );
+          ])
+  else
+    let module P = struct
+      type t = { text : string } [@@deriving of_yojson { strict = false }]
+    end in
+    let open CCResult.Infix in
+    P.of_yojson (O.Payload.to_yojson output.O.payload)
+    >>= fun { P.text } ->
+    Ok Snabela.Kv.(Map.of_list [ ("success", bool output.O.success); ("text", string text) ])
+
+let output_of_run ?(default_visible_on = Visible_on.Failure) output =
+  let module P = struct
+    type t = {
+      cmd : string list option; [@default None]
+      text : string option; [@default None]
+      visible_on : string option;
+    }
+    [@@deriving of_yojson { strict = false }]
+  end in
+  let module O = Terrat_api_components.Workflow_step_output in
+  let open CCResult.Infix in
+  P.of_yojson (O.Payload.to_yojson output.O.payload)
+  >>= fun { P.cmd; text; visible_on } ->
+  Ok
+    (Output.make
+       ?cmd:(CCOption.map (CCString.concat " ") cmd)
+       ~name:output.O.step
+       ~success:output.O.success
+       ~text:(CCOption.get_or ~default:"" text)
+       ~visible_on:
+         (CCOption.map_or
+            ~default:default_visible_on
+            (function
+              | "always" -> Visible_on.Always
+              | "failure" -> Visible_on.Failure
+              | "success" -> Visible_on.Success
+              | _ -> Visible_on.Failure)
+            visible_on)
+       ())
+
+let output_of_plan output =
+  let module P = struct
+    type t = {
+      cmd : string list option; [@default None]
+      text : string;
+      plan : string option; [@default None]
+      has_changes : bool option; [@default None]
+    }
+    [@@deriving of_yojson { strict = false }]
+  end in
+  let module O = Terrat_api_components.Workflow_step_output in
+  let open CCResult.Infix in
+  P.of_yojson (O.Payload.to_yojson output.O.payload)
+  >>= fun { P.cmd; text; has_changes; plan } ->
+  if output.O.success then
+    Ok
+      (Output.make
+         ?cmd:(CCOption.map (CCString.concat " ") cmd)
+         ~name:output.O.step
+         ~success:output.O.success
+         ~text:(CCOption.get_or ~default:text plan)
+         ~text_decorator:"diff"
+         ~visible_on:Visible_on.Always
+         ())
+  else
+    Ok
+      (Output.make
+         ?cmd:(CCOption.map (CCString.concat " ") cmd)
+         ~name:output.O.step
+         ~success:output.O.success
+         ~text
+         ~visible_on:Visible_on.Always
+         ())
+
+let output_of_workflow_output output =
+  let module O = Terrat_api_components.Workflow_step_output in
+  match output.O.step with
+  | "run" | "env" -> output_of_run output
+  | "tf/init" | "pulumi/init" | "custom/init" | "fly/init" ->
+      output_of_run ~default_visible_on:Visible_on.Failure output
+  | "tf/apply" | "pulumi/apply" | "custom/apply" | "fly/apply" ->
+      output_of_run ~default_visible_on:Visible_on.Always output
+  | "tf/plan" | "pulumi/plan" | "custom/plan" | "fly/plan" -> output_of_plan output
+  | step -> output_of_run output
+
+let output_of_raw output =
+  let module O = Terrat_api_components.Workflow_step_output in
+  let { O.step; success; payload; _ } = output in
+  Output.make
+    ~name:step
+    ~success
+    ~text:(Yojson.Safe.pretty_to_string (O.Payload.to_yojson payload))
+    ~visible_on:Visible_on.Failure
+    ()
+
+let output_of_steps steps =
+  let module O = Terrat_api_components.Workflow_step_output in
+  CCList.filter_map
+    (fun output ->
+      match output.O.step with
+      | "tf/cost-estimation" -> None
+      | _ -> (
+          match output_of_workflow_output output with
+          | Ok output -> Some output
+          | Error _ -> Some (output_of_raw output)))
+    steps
+
+let kv_of_outputs outputs = CCList.map Output.to_kv outputs
+
+let dirspace_compare (dirspace1, steps1) (dirspace2, steps2) =
+  let module Cmp = struct
+    type t = bool * bool * Terrat_dirspace.t [@@deriving ord]
+  end in
+  let has_changes1 = steps_has_changes steps1 in
+  let success1 = steps_success steps1 in
+  let has_changes2 = steps_has_changes steps2 in
+  let success2 = steps_success steps2 in
+  (* Negate has_changes because the order of [bool] is [false]
+             before [true]. *)
+  Cmp.compare (not has_changes1, success1, dirspace1) (not has_changes2, success2, dirspace2)
+
+module Comment_api = struct
+  let comment_on_pull_request ~request_id client pull_request msg_type body =
+    let open Abbs_future_combinators.Infix_result_monad in
+    Api.comment_on_pull_request ~request_id client pull_request body
+    >>= fun () ->
+    Logs.info (fun m -> m "%s : PUBLISHED_COMMENT : %s" request_id msg_type);
+    Abb.Future.return (Ok ())
+
+  let apply_template_and_publish ~request_id client pull_request msg_type template kv =
+    match Snabela.apply template kv with
+    | Ok body -> comment_on_pull_request ~request_id client pull_request msg_type body
+    | Error (#Snabela.err as err) ->
+        Logs.err (fun m -> m "%s : TEMPLATE_ERROR : %a" request_id Snabela.pp_err err);
+        Abb.Future.return (Error `Error)
+end
+
+module Publisher_tools = struct
+  let create_run_output
+      ~view
+      request_id
+      account_status
+      config
+      is_layered_run
+      remaining_dirspace_configs
+      by_scope
+      gates
+      work_manifest =
+    let module Wm = Terrat_work_manifest3 in
+    let module R2 = Terrat_api_components.Work_manifest_tf_operation_result2 in
+    let module O = Terrat_api_components.Workflow_step_output in
+    let module Sds = Terrat_api_components.Workflow_step_output_scope_dirspace in
+    let module Sr = Terrat_api_components.Workflow_step_output_scope_run in
+    let hooks_pre =
+      CCList.Assoc.get ~eq:Scope.equal (Scope.Run { flow = "hooks"; subflow = "pre" }) by_scope
+    in
+    let hooks_post =
+      CCList.Assoc.get ~eq:Scope.equal (Scope.Run { flow = "hooks"; subflow = "post" }) by_scope
+    in
+    let dirspaces =
+      by_scope
+      |> CCList.filter_map (function
+           | Scope.Dirspace dirspace, steps -> Some (dirspace, steps)
+           | _ -> None)
+      |> CCList.sort dirspace_compare
+    in
+    let overall_success =
+      CCList.for_all
+        (fun (_, steps) ->
+          CCList.for_all (fun { O.success; ignore_errors; _ } -> success || ignore_errors) steps)
+        by_scope
+    in
+    let num_remaining_layers = CCList.length remaining_dirspace_configs in
+    let denied_dirspaces =
+      match work_manifest.Wm.denied_dirspaces with
+      | [] -> []
+      | dirspaces ->
+          Snabela.Kv.
+            [
+              ( "denied_dirspaces",
+                list
+                  (CCList.map
+                     (fun { Wm.Deny.dirspace = { Terrat_dirspace.dir; workspace }; policy } ->
+                       Map.of_list
+                         (CCList.flatten
+                            [
+                              [ ("dir", string dir); ("workspace", string workspace) ];
+                              (match policy with
+                              | Some policy ->
+                                  [
+                                    ( "policy",
+                                      list
+                                        (CCList.map
+                                           (fun p ->
+                                             Map.of_list
+                                               [
+                                                 ( "item",
+                                                   string
+                                                     (Terrat_base_repo_config_v1.Access_control
+                                                      .Match
+                                                      .to_string
+                                                        p) );
+                                               ])
+                                           policy) );
+                                  ]
+                              | None -> []);
+                            ]))
+                     dirspaces) );
+            ]
+    in
+    let cost_estimation =
+      hooks_pre
+      |> CCOption.get_or ~default:[]
+      |> CCList.filter (fun { O.step; _ } -> CCString.equal step "tf/cost-estimation")
+      |> function
+      | [] -> []
+      | o :: _ -> (
+          let changed_dirspaces =
+            CCList.map
+              (fun { Terrat_change.Dirspaceflow.dirspace; _ } -> dirspace)
+              work_manifest.Wm.changes
+          in
+          match kv_of_cost_estimation changed_dirspaces o with
+          | Ok kv -> [ ("cost_estimation", Snabela.Kv.list [ kv ]) ]
+          | Error _ -> [ ("cost_estimation", Snabela.Kv.list [ Output.to_kv (output_of_raw o) ]) ])
+    in
+    let kv =
+      Snabela.Kv.(
+        Map.of_list
+          (CCList.flatten
+             [
+               CCOption.map_or
+                 ~default:[]
+                 (fun work_manifest_url ->
+                   [ ("work_manifest_url", string (Uri.to_string work_manifest_url)) ])
+                 (Ui.work_manifest_url config work_manifest.Wm.account work_manifest);
+               CCOption.map_or
+                 ~default:[]
+                 (fun env -> [ ("environment", string env) ])
+                 work_manifest.Wm.environment;
+               [
+                 ( "account_status",
+                   string
+                     (match account_status with
+                     | `Trial_ending duration when Duration.to_day duration < 15 ->
+                         (* Only mark as trial ending if less than two weeks from now *)
+                         "trial_ending"
+                     | `Trial_ending _ | `Active -> "active"
+                     | `Expired -> "expired"
+                     | `Disabled -> "disabled") );
+                 ( "trial_end_days",
+                   match account_status with
+                   | `Trial_ending duration -> int (Duration.to_day duration)
+                   | _ -> int 0 );
+                 ("is_layered_run", bool is_layered_run);
+                 ("num_more_layers", int num_remaining_layers);
+                 ("overall_success", bool overall_success);
+                 ( "pre_hooks",
+                   hooks_pre
+                   |> CCOption.get_or ~default:[]
+                   |> output_of_steps
+                   |> Output.filter ~overall_success
+                   |> kv_of_outputs
+                   |> list );
+                 ( "post_hooks",
+                   hooks_post
+                   |> CCOption.get_or ~default:[]
+                   |> output_of_steps
+                   |> Output.filter ~overall_success
+                   |> kv_of_outputs
+                   |> list );
+                 ("compact_view", bool (view = `Compact));
+                 ("compact_dirspaces", bool (CCList.length dirspaces > 5));
+                 ( "dirspaces",
+                   list
+                     (CCList.map
+                        (fun ({ Terrat_dirspace.dir; workspace }, steps) ->
+                          let has_changes = steps_has_changes steps in
+                          let success = steps_success steps in
+                          Map.of_list
+                            (CCList.flatten
+                               [
+                                 [
+                                   ("dir", string dir);
+                                   ("workspace", string workspace);
+                                   ("success", bool success);
+                                   ( "steps",
+                                     list
+                                       (kv_of_outputs
+                                          (Output.filter ~overall_success (output_of_steps steps)))
+                                   );
+                                   ("has_changes", bool has_changes);
+                                 ];
+                               ]))
+                        dirspaces) );
+                 ( "gates",
+                   let module G = Terrat_api_components.Gate in
+                   list
+                   @@ CCList.map (fun { G.all_of; any_of; any_of_count; dir; token; workspace } ->
+                          let all_of = CCOption.get_or ~default:[] all_of in
+                          let any_of = CCOption.get_or ~default:[] any_of in
+                          let any_of_count = CCOption.get_or ~default:0 any_of_count in
+                          let dir = CCOption.get_or ~default:"" dir in
+                          let workspace = CCOption.get_or ~default:"" workspace in
+                          Map.of_list
+                            [
+                              ("token", string token);
+                              ("dir", string dir);
+                              ("workspace", string workspace);
+                              ( "all_of",
+                                list @@ CCList.map (fun q -> Map.of_list [ ("q", string q) ]) all_of
+                              );
+                              ( "any_of",
+                                list
+                                @@ CCList.map
+                                     (fun q -> Map.of_list [ ("q", string q) ])
+                                     (if any_of_count = 0 then [] else any_of) );
+                              ("any_of_count", int any_of_count);
+                            ])
+                   @@ CCList.sort (fun { G.token = t1; _ } { G.token = t2; _ } ->
+                          CCString.compare t1 t2)
+                   @@ CCOption.get_or ~default:[] gates );
+               ];
+               denied_dirspaces;
+               cost_estimation;
+             ]))
+    in
+    let tmpl =
+      match CCList.rev work_manifest.Wm.steps with
+      | [] | Wm.Step.Index :: _ | Wm.Step.Build_config :: _ | Wm.Step.Build_tree :: _ ->
+          assert false
+      | Wm.Step.Plan :: _ -> Tmpl.plan_complete2
+      | Wm.Step.(Apply | Unsafe_apply) :: _ -> Tmpl.apply_complete2
+    in
+    match Snabela.apply tmpl kv with
+    | Ok body -> body
+    | Error (#Snabela.err as err) ->
+        Logs.err (fun m -> m "%s : ERROR : %a" request_id Snabela.pp_err err);
+        assert false
+end

--- a/code/src/terrat_vcs_service_github/terrat_vcs_service_github_scope.ml
+++ b/code/src/terrat_vcs_service_github/terrat_vcs_service_github_scope.ml
@@ -1,0 +1,28 @@
+module Scope = struct
+  type t =
+    | Dirspace of Terrat_dirspace.t
+    | Run of {
+        flow : string;
+        subflow : string;
+      }
+  [@@deriving eq, ord]
+
+  let of_terrat_api_scope =
+    let module S = Terrat_api_components.Workflow_step_output_scope in
+    let module Ds = Terrat_api_components.Workflow_step_output_scope_dirspace in
+    let module R = Terrat_api_components.Workflow_step_output_scope_run in
+    function
+    | S.Workflow_step_output_scope_dirspace { Ds.dir; workspace; _ } ->
+        Dirspace { Terrat_dirspace.dir; workspace }
+    | S.Workflow_step_output_scope_run { R.flow; subflow; _ } -> Run { flow; subflow }
+end
+
+module By_scope = Terrat_data.Group_by (struct
+  module T = Terrat_api_components.Workflow_step_output
+
+  type t = T.t
+  type key = Scope.t
+
+  let compare = Scope.compare
+  let key { T.scope; _ } = Scope.of_terrat_api_scope scope
+end)

--- a/code/src/terrat_vcs_service_gitlab/terrat_vcs_service_gitlab_assets.ml
+++ b/code/src/terrat_vcs_service_gitlab/terrat_vcs_service_gitlab_assets.ml
@@ -1,0 +1,188 @@
+module Tmpl = struct
+  module Transformers = struct
+    let money =
+      ( "money",
+        Snabela.Kv.(
+          function
+          | F num -> S (Printf.sprintf "%01.02f" num)
+          | any -> any) )
+
+    let plan_diff =
+      ( "plan_diff",
+        Snabela.Kv.(
+          function
+          | S plan -> S (Terrat_plan_diff.transform plan)
+          | any -> any) )
+
+    let compact_plan =
+      ( "compact_plan",
+        Snabela.Kv.(
+          function
+          | S plan ->
+              S
+                (plan
+                |> CCString.split_on_char '\n'
+                |> CCList.filter (fun s -> CCString.find ~sub:"= (known after apply)" s = -1)
+                |> CCString.concat "\n")
+          | any -> any) )
+
+    let minus_one =
+      ( "minus_one",
+        Snabela.Kv.(
+          function
+          | I v -> I (v - 1)
+          | F v -> F (v -. 1.0)
+          | any -> any) )
+  end
+
+  let read fname =
+    fname
+    |> Terrat_files_gitlab_tmpl.read
+    |> CCOption.get_exn_or fname
+    |> Snabela.Template.of_utf8_string
+    |> (function
+    | Ok tmpl -> tmpl
+    | Error (#Snabela.Template.err as err) -> failwith (Snabela.Template.show_err err))
+    |> fun tmpl ->
+    Snabela.of_template tmpl Transformers.[ money; compact_plan; plan_diff; minus_one ]
+
+  let terrateam_comment_help = read "terrateam_comment_help.tmpl"
+  let apply_requirements_config_err_tag_query = read "apply_requirements_config_err_tag_query.tmpl"
+
+  let apply_requirements_config_err_invalid_query =
+    read "apply_requirements_config_err_invalid_query.tmpl"
+
+  let apply_requirements_validation_err = read "apply_requirements_validation_err.tmpl"
+  let mismatched_refs = read "mismatched_refs.tmpl"
+  let missing_plans = read "missing_plans.tmpl"
+  let dirspaces_owned_by_other_pull_requests = read "dirspaces_owned_by_other_pull_requests.tmpl"
+  let conflicting_work_manifests = read "conflicting_work_manifests.tmpl"
+  let depends_on_cycle = read "depends_on_cycle.tmpl"
+  let maybe_stale_work_manifests = read "maybe_stale_work_manifests.tmpl"
+  let repo_config_parse_failure = read "repo_config_parse_failure.tmpl"
+  let repo_config_schema_err = read "repo_config_schema_err.tmpl"
+  let repo_config_generic_failure = read "repo_config_generic_failure.tmpl"
+  let pull_request_not_appliable = read "pull_request_not_appliable.tmpl"
+  let pull_request_not_mergeable = read "pull_request_not_mergeable.tmpl"
+  let apply_no_matching_dirspaces = read "apply_no_matching_dirspaces.tmpl"
+  let plan_no_matching_dirspaces = read "plan_no_matching_dirspaces.tmpl"
+  let base_branch_not_default_branch = read "dest_branch_no_match.tmpl"
+  let auto_apply_running = read "auto_apply_running.tmpl"
+  let bad_custom_branch_tag_pattern = read "bad_custom_branch_tag_pattern.tmpl"
+  let bad_glob = read "bad_glob.tmpl"
+  let unlock_success = read "unlock_success.tmpl"
+  let access_control_all_dirspaces_denied = read "access_control_all_dirspaces_denied.tmpl"
+  let access_control_dirspaces_denied = read "access_control_dirspaces_denied.tmpl"
+  let access_control_files_denied = read "access_control_files_denied.tmpl"
+  let access_control_unlock_denied = read "access_control_unlock_denied.tmpl"
+  let access_control_ci_config_update_denied = read "access_control_ci_config_update_denied.tmpl"
+
+  let access_control_terrateam_config_update_denied =
+    read "access_control_terrateam_config_update_denied.tmpl"
+
+  let access_control_lookup_err = read "access_control_lookup_err.tmpl"
+  let tag_query_error = read "tag_query_error.tmpl"
+  let account_expired_err = read "account_expired_err.tmpl"
+  let repo_config = read "repo_config.tmpl"
+  let unexpected_temporary_err = read "unexpected_temporary_err.tmpl"
+  let failed_to_start_workflow = read "failed_to_start_workflow.tmpl"
+  let failed_to_find_workflow = read "failed_to_find_workflow.tmpl"
+  let comment_too_large = read "comment_too_large.tmpl"
+  let index_complete = read "index_complete.tmpl"
+  let invalid_lock_id = read "unlock_failed_bad_id.tmpl"
+
+  (* Repo config errors *)
+  let repo_config_err_access_control_policy_apply_autoapprove_match_parse_err =
+    read "repo_config_err_access_control_policy_apply_autoapprove_match_parse_err.tmpl"
+
+  let repo_config_err_access_control_policy_apply_force_match_parse_err =
+    read "repo_config_err_access_control_policy_apply_force_match_parse_err.tmpl"
+
+  let repo_config_err_access_control_policy_apply_match_parse_err =
+    read "repo_config_err_access_control_policy_apply_match_parse_err.tmpl"
+
+  let repo_config_err_access_control_policy_apply_with_superapproval_match_parse_err =
+    read "repo_config_err_access_control_policy_apply_with_supperapproval_match_parse_err.tmpl"
+
+  let repo_config_err_access_control_policy_plan_match_parse_err =
+    read "repo_config_err_access_control_policy_plan_match_parse_err.tmpl"
+
+  let repo_config_err_access_control_policy_superapproval_match_parse_err =
+    read "repo_config_err_access_control_policy_superapproval_match_parse_err.tmpl"
+
+  let repo_config_err_access_control_policy_tag_query_err =
+    read "repo_config_err_access_control_policy_tag_query_err.tmpl"
+
+  let repo_config_err_access_control_terrateam_config_update_match_parse_err =
+    read "repo_config_err_access_control_terrateam_config_update_match_parse_err.tmpl"
+
+  let repo_config_err_access_control_ci_config_update_match_parse_err =
+    read "repo_config_err_access_control_ci_config_update_match_parse_err.tmpl"
+
+  let repo_config_err_access_control_file_match_parse_err =
+    read "repo_config_err_access_control_file_match_parse_err.tmpl"
+
+  let repo_config_err_access_control_unlock_match_parse_err =
+    read "repo_config_err_access_control_unlock_match_parse_err.tmpl"
+
+  let repo_config_err_apply_requirements_approved_all_of_match_parse_err =
+    read "repo_config_err_apply_requirements_approved_all_of_match_parse_err.tmpl"
+
+  let repo_config_err_apply_requirements_approved_any_of_match_parse_err =
+    read "repo_config_err_apply_requirements_approved_any_of_match_parse_err.tmpl"
+
+  let repo_config_err_apply_requirements_check_tag_query_err =
+    read "repo_config_err_apply_requirements_check_tag_query_err.tmpl"
+
+  let repo_config_err_depends_on_err = read "repo_config_err_depends_on_err.tmpl"
+  let repo_config_err_drift_schedule_err = read "repo_config_err_drift_schedule_err.tmpl"
+  let repo_config_err_drift_tag_query_err = read "repo_config_err_drift_tag_query_err.tmpl"
+  let repo_config_err_glob_parse_err = read "repo_config_err_glob_parse_err.tmpl"
+
+  let repo_config_err_hooks_unknown_run_on_err =
+    read "repo_config_err_hooks_unknown_run_on_err.tmpl"
+
+  let repo_config_err_hooks_unknown_visible_on_err =
+    read "repo_config_err_hooks_unknown_visible_on_err.tmpl"
+
+  let repo_config_err_pattern_parse_err = read "repo_config_err_pattern_parse_err.tmpl"
+  let repo_config_err_unknown_lock_policy_err = read "repo_config_err_unknown_lock_policy_err.tmpl"
+
+  let repo_config_err_window_parse_timezone_err =
+    read "repo_config_err_window_parse_timezone_err.tmpl"
+
+  let repo_config_err_workflows_apply_unknown_run_on_err =
+    read "repo_config_err_workflows_apply_unknown_run_on_err.tmpl"
+
+  let repo_config_err_workflows_apply_unknown_visible_on_err =
+    read "repo_config_err_workflows_apply_unknown_visible_on_err.tmpl"
+
+  let repo_config_err_workflows_plan_unknown_run_on_err =
+    read "repo_config_err_workflows_plan_unknown_run_on_err.tmpl"
+
+  let repo_config_err_workflows_plan_unknown_visible_on_err =
+    read "repo_config_err_workflows_plan_unknown_visible_on_err.tmpl"
+
+  let repo_config_err_workflows_tag_query_parse_err =
+    read "repo_config_err_workflows_tag_query_parse_err.tmpl"
+
+  let plan_complete = read "plan_complete.tmpl"
+  let apply_complete = read "apply_complete.tmpl"
+  let plan_complete2 = read "plan_complete2.tmpl"
+  let apply_complete2 = read "apply_complete2.tmpl"
+  let automerge_failure = read "automerge_error.tmpl"
+  let premium_feature_err_access_control = read "premium_feature_err_access_control.tmpl"
+
+  let premium_feature_err_multiple_drift_schedules =
+    read "premium_feature_err_multiple_drift_schedules.tmpl"
+
+  let premium_feature_err_gatekeeping = read "premium_feature_err_gatekeeping.tmpl"
+  let repo_config_merge_err = read "repo_config_merge_err.tmpl"
+  let gate_check_failure = read "gate_check_failure.tmpl"
+  let tier_check = read "tier_check.tmpl"
+  let build_tree_failure = read "build_tree_failure.tmpl"
+end
+
+module Ui = struct
+  let work_manifest_url config account = raise (Failure "nyi")
+end

--- a/code/src/terrat_vcs_service_gitlab/terrat_vcs_service_gitlab_comment.ml
+++ b/code/src/terrat_vcs_service_gitlab/terrat_vcs_service_gitlab_comment.ml
@@ -1,0 +1,103 @@
+module Api = Terrat_vcs_api_gitlab
+module By_scope = Terrat_vcs_service_gitlab_scope.By_scope
+module Publisher_tools = Terrat_vcs_service_gitlab_publishers.Publisher_tools
+module Output = Terrat_vcs_service_gitlab_publishers.Output
+module Scope = Terrat_vcs_service_gitlab_scope.Scope
+module Tmpl = Terrat_vcs_service_gitlab_assets.Tmpl
+module Ui = Terrat_vcs_service_gitlab_assets.Ui
+module Visible_on = Terrat_base_repo_config_v1.Workflow_step.Visible_on
+
+module S = struct
+  type t = {
+    account_status : Terrat_vcs_provider2.Account_status.t;
+    client : Api.Client.t;
+    config : Api.Config.t;
+    is_layered_run : bool;
+    hooks : (Scope.t * Terrat_api_components_workflow_step_output.t list) list;
+    pull_request : (unit, unit) Api.Pull_request.t;
+    request_id : string;
+    remaining_layers : Terrat_change_match3.Dirspace_config.t list list;
+    result : Terrat_api_components_work_manifest_tf_operation_result2.t;
+    work_manifest : (Api.Account.t, unit) Terrat_work_manifest3.Existing.t;
+  }
+
+  type el = {
+    dirspace : Terrat_dirspace.t;
+    steps : Terrat_api_components_workflow_step_output.t list;
+    strategy : Terrat_vcs_comment.Strategy.t;
+  }
+  [@@deriving show]
+
+  (*TODO: fix this later*)
+  type comment_id = unit [@@deriving ord, show]
+
+  module Cmp = struct
+    type t = bool * bool * Terrat_dirspace.t [@@deriving ord]
+  end
+
+  let query_comment_id t el = raise (Failure "nyi")
+  let query_els_for_comment_id t cid = raise (Failure "nyi")
+  let upsert_comment_id t els cid = Abb.Future.return (Ok ())
+  let delete_comment t comment_id = raise (Failure "nyi")
+  let minimize_comment t comment_id = raise (Failure "nyi")
+
+  let post_comment t els =
+    let open Abbs_future_combinators.Infix_result_monad in
+    let module R2 = Terrat_api_components.Work_manifest_tf_operation_result2 in
+    let gates = t.result.R2.gates in
+    let by_dirspace = CCList.map (fun el -> (Scope.Dirspace el.dirspace, el.steps)) els in
+    let by_scope = t.hooks @ by_dirspace in
+    let body =
+      Publisher_tools.create_run_output
+        ~view:`Full
+        t.request_id
+        t.account_status
+        t.config
+        t.is_layered_run
+        t.remaining_layers
+        by_scope
+        gates
+        t.work_manifest
+    in
+    let request_id = t.request_id in
+    let msg_type = "GITLAB COMMENT" in
+    let open Abbs_future_combinators.Infix_result_monad in
+    Api.comment_on_pull_request ~request_id t.client t.pull_request body
+    >>= fun () ->
+    Logs.info (fun m -> m "%s : PUBLISHED_COMMENT : %s" request_id msg_type);
+    Abb.Future.return (Ok ())
+
+  let rendered_length t els =
+    let module R2 = Terrat_api_components.Work_manifest_tf_operation_result2 in
+    let gates = t.result.R2.gates in
+    let by_dirspace = CCList.map (fun el -> (Scope.Dirspace el.dirspace, el.steps)) els in
+    let by_scope = t.hooks @ by_dirspace in
+    let out =
+      Publisher_tools.create_run_output
+        ~view:`Full
+        t.request_id
+        t.account_status
+        t.config
+        t.is_layered_run
+        t.remaining_layers
+        by_scope
+        gates
+        t.work_manifest
+    in
+    CCString.length out
+
+  let strategy el = el.strategy
+
+  (* TODO: For testing purposes only, will change this later *)
+  (* TODO: Wirte with proper templates on Tmpl later *)
+  let compact el = el
+
+  let compare_el el1 el2 =
+    let module P = Terrat_vcs_service_gitlab_publishers in
+    P.dirspace_compare (el1.dirspace, el1.steps) (el2.dirspace, el2.steps)
+
+  (* Gitlab Limits it to either 1MB or 10^6 characters
+     https://docs.gitlab.com/administration/instance_limits/#size-of-comments-and-descriptions-of-issues-merge-requests-and-epics
+     I set it to a smaller value *)
+  let max_comment_length = 1000000 / 2
+end

--- a/code/src/terrat_vcs_service_gitlab/terrat_vcs_service_gitlab_provider.ml
+++ b/code/src/terrat_vcs_service_gitlab/terrat_vcs_service_gitlab_provider.ml
@@ -1,6 +1,11 @@
 let src = Logs.Src.create "vcs_service_gitlab_provider"
 
+module Api = Terrat_vcs_api_gitlab
+module By_scope = Terrat_vcs_service_gitlab_scope.By_scope
 module Logs = (val Logs.src_log src : Logs.LOG)
+module Scope = Terrat_vcs_service_gitlab_scope.Scope
+module Tmpl = Terrat_vcs_service_gitlab_assets.Tmpl
+module Ui = Terrat_vcs_service_gitlab_assets.Ui
 
 let not_a_bad_chunk_size = 500
 let replace_nul_byte = CCString.replace ~which:`All ~sub:"\x00" ~by:"\\0"
@@ -40,38 +45,7 @@ module Metrics = struct
       "run_overall_result_count"
 end
 
-module Scope = struct
-  type t =
-    | Dirspace of Terrat_dirspace.t
-    | Run of {
-        flow : string;
-        subflow : string;
-      }
-  [@@deriving eq, ord]
-
-  let of_terrat_api_scope =
-    let module S = Terrat_api_components.Workflow_step_output_scope in
-    let module Ds = Terrat_api_components.Workflow_step_output_scope_dirspace in
-    let module R = Terrat_api_components.Workflow_step_output_scope_run in
-    function
-    | S.Workflow_step_output_scope_dirspace { Ds.dir; workspace; _ } ->
-        Dirspace { Terrat_dirspace.dir; workspace }
-    | S.Workflow_step_output_scope_run { R.flow; subflow; _ } -> Run { flow; subflow }
-end
-
-module By_scope = Terrat_data.Group_by (struct
-  module T = Terrat_api_components.Workflow_step_output
-
-  type t = T.t
-  type key = Scope.t
-
-  let compare = Scope.compare
-  let key { T.scope; _ } = Scope.of_terrat_api_scope scope
-end)
-
 let name = "gitlab"
-
-module Api = Terrat_vcs_api_gitlab
 
 module Unlock_id = struct
   type t =
@@ -2172,209 +2146,6 @@ module Gate = struct
 end
 
 module Comment = struct
-  module Tmpl = struct
-    module Transformers = struct
-      let money =
-        ( "money",
-          Snabela.Kv.(
-            function
-            | F num -> S (Printf.sprintf "%01.02f" num)
-            | any -> any) )
-
-      let plan_diff =
-        ( "plan_diff",
-          Snabela.Kv.(
-            function
-            | S plan -> S (Terrat_plan_diff.transform plan)
-            | any -> any) )
-
-      let compact_plan =
-        ( "compact_plan",
-          Snabela.Kv.(
-            function
-            | S plan ->
-                S
-                  (plan
-                  |> CCString.split_on_char '\n'
-                  |> CCList.filter (fun s -> CCString.find ~sub:"= (known after apply)" s = -1)
-                  |> CCString.concat "\n")
-            | any -> any) )
-
-      let minus_one =
-        ( "minus_one",
-          Snabela.Kv.(
-            function
-            | I v -> I (v - 1)
-            | F v -> F (v -. 1.0)
-            | any -> any) )
-    end
-
-    let read fname =
-      fname
-      |> Terrat_files_gitlab_tmpl.read
-      |> CCOption.get_exn_or fname
-      |> Snabela.Template.of_utf8_string
-      |> (function
-      | Ok tmpl -> tmpl
-      | Error (#Snabela.Template.err as err) -> failwith (Snabela.Template.show_err err))
-      |> fun tmpl ->
-      Snabela.of_template tmpl Transformers.[ money; compact_plan; plan_diff; minus_one ]
-
-    let terrateam_comment_help = read "terrateam_comment_help.tmpl"
-
-    let apply_requirements_config_err_tag_query =
-      read "apply_requirements_config_err_tag_query.tmpl"
-
-    let apply_requirements_config_err_invalid_query =
-      read "apply_requirements_config_err_invalid_query.tmpl"
-
-    let apply_requirements_validation_err = read "apply_requirements_validation_err.tmpl"
-    let mismatched_refs = read "mismatched_refs.tmpl"
-    let missing_plans = read "missing_plans.tmpl"
-    let dirspaces_owned_by_other_pull_requests = read "dirspaces_owned_by_other_pull_requests.tmpl"
-    let conflicting_work_manifests = read "conflicting_work_manifests.tmpl"
-    let depends_on_cycle = read "depends_on_cycle.tmpl"
-    let maybe_stale_work_manifests = read "maybe_stale_work_manifests.tmpl"
-    let repo_config_parse_failure = read "repo_config_parse_failure.tmpl"
-    let repo_config_schema_err = read "repo_config_schema_err.tmpl"
-    let repo_config_generic_failure = read "repo_config_generic_failure.tmpl"
-    let pull_request_not_appliable = read "pull_request_not_appliable.tmpl"
-    let pull_request_not_mergeable = read "pull_request_not_mergeable.tmpl"
-    let apply_no_matching_dirspaces = read "apply_no_matching_dirspaces.tmpl"
-    let plan_no_matching_dirspaces = read "plan_no_matching_dirspaces.tmpl"
-    let base_branch_not_default_branch = read "dest_branch_no_match.tmpl"
-    let auto_apply_running = read "auto_apply_running.tmpl"
-    let bad_custom_branch_tag_pattern = read "bad_custom_branch_tag_pattern.tmpl"
-    let bad_glob = read "bad_glob.tmpl"
-    let unlock_success = read "unlock_success.tmpl"
-    let access_control_all_dirspaces_denied = read "access_control_all_dirspaces_denied.tmpl"
-    let access_control_dirspaces_denied = read "access_control_dirspaces_denied.tmpl"
-    let access_control_files_denied = read "access_control_files_denied.tmpl"
-    let access_control_unlock_denied = read "access_control_unlock_denied.tmpl"
-    let access_control_ci_config_update_denied = read "access_control_ci_config_update_denied.tmpl"
-
-    let access_control_terrateam_config_update_denied =
-      read "access_control_terrateam_config_update_denied.tmpl"
-
-    let access_control_lookup_err = read "access_control_lookup_err.tmpl"
-    let tag_query_error = read "tag_query_error.tmpl"
-    let account_expired_err = read "account_expired_err.tmpl"
-    let repo_config = read "repo_config.tmpl"
-    let unexpected_temporary_err = read "unexpected_temporary_err.tmpl"
-    let failed_to_start_workflow = read "failed_to_start_workflow.tmpl"
-    let failed_to_find_workflow = read "failed_to_find_workflow.tmpl"
-    let comment_too_large = read "comment_too_large.tmpl"
-    let index_complete = read "index_complete.tmpl"
-    let invalid_lock_id = read "unlock_failed_bad_id.tmpl"
-
-    (* Repo config errors *)
-    let repo_config_err_access_control_policy_apply_autoapprove_match_parse_err =
-      read "repo_config_err_access_control_policy_apply_autoapprove_match_parse_err.tmpl"
-
-    let repo_config_err_access_control_policy_apply_force_match_parse_err =
-      read "repo_config_err_access_control_policy_apply_force_match_parse_err.tmpl"
-
-    let repo_config_err_access_control_policy_apply_match_parse_err =
-      read "repo_config_err_access_control_policy_apply_match_parse_err.tmpl"
-
-    let repo_config_err_access_control_policy_apply_with_superapproval_match_parse_err =
-      read "repo_config_err_access_control_policy_apply_with_supperapproval_match_parse_err.tmpl"
-
-    let repo_config_err_access_control_policy_plan_match_parse_err =
-      read "repo_config_err_access_control_policy_plan_match_parse_err.tmpl"
-
-    let repo_config_err_access_control_policy_superapproval_match_parse_err =
-      read "repo_config_err_access_control_policy_superapproval_match_parse_err.tmpl"
-
-    let repo_config_err_access_control_policy_tag_query_err =
-      read "repo_config_err_access_control_policy_tag_query_err.tmpl"
-
-    let repo_config_err_access_control_terrateam_config_update_match_parse_err =
-      read "repo_config_err_access_control_terrateam_config_update_match_parse_err.tmpl"
-
-    let repo_config_err_access_control_ci_config_update_match_parse_err =
-      read "repo_config_err_access_control_ci_config_update_match_parse_err.tmpl"
-
-    let repo_config_err_access_control_file_match_parse_err =
-      read "repo_config_err_access_control_file_match_parse_err.tmpl"
-
-    let repo_config_err_access_control_unlock_match_parse_err =
-      read "repo_config_err_access_control_unlock_match_parse_err.tmpl"
-
-    let repo_config_err_apply_requirements_approved_all_of_match_parse_err =
-      read "repo_config_err_apply_requirements_approved_all_of_match_parse_err.tmpl"
-
-    let repo_config_err_apply_requirements_approved_any_of_match_parse_err =
-      read "repo_config_err_apply_requirements_approved_any_of_match_parse_err.tmpl"
-
-    let repo_config_err_apply_requirements_check_tag_query_err =
-      read "repo_config_err_apply_requirements_check_tag_query_err.tmpl"
-
-    let repo_config_err_depends_on_err = read "repo_config_err_depends_on_err.tmpl"
-    let repo_config_err_drift_schedule_err = read "repo_config_err_drift_schedule_err.tmpl"
-    let repo_config_err_drift_tag_query_err = read "repo_config_err_drift_tag_query_err.tmpl"
-    let repo_config_err_glob_parse_err = read "repo_config_err_glob_parse_err.tmpl"
-
-    let repo_config_err_hooks_unknown_run_on_err =
-      read "repo_config_err_hooks_unknown_run_on_err.tmpl"
-
-    let repo_config_err_hooks_unknown_visible_on_err =
-      read "repo_config_err_hooks_unknown_visible_on_err.tmpl"
-
-    let repo_config_err_pattern_parse_err = read "repo_config_err_pattern_parse_err.tmpl"
-
-    let repo_config_err_unknown_lock_policy_err =
-      read "repo_config_err_unknown_lock_policy_err.tmpl"
-
-    let repo_config_err_window_parse_timezone_err =
-      read "repo_config_err_window_parse_timezone_err.tmpl"
-
-    let repo_config_err_workflows_apply_unknown_run_on_err =
-      read "repo_config_err_workflows_apply_unknown_run_on_err.tmpl"
-
-    let repo_config_err_workflows_apply_unknown_visible_on_err =
-      read "repo_config_err_workflows_apply_unknown_visible_on_err.tmpl"
-
-    let repo_config_err_workflows_plan_unknown_run_on_err =
-      read "repo_config_err_workflows_plan_unknown_run_on_err.tmpl"
-
-    let repo_config_err_workflows_plan_unknown_visible_on_err =
-      read "repo_config_err_workflows_plan_unknown_visible_on_err.tmpl"
-
-    let repo_config_err_workflows_tag_query_parse_err =
-      read "repo_config_err_workflows_tag_query_parse_err.tmpl"
-
-    let plan_complete = read "plan_complete.tmpl"
-    let apply_complete = read "apply_complete.tmpl"
-    let plan_complete2 = read "plan_complete2.tmpl"
-    let apply_complete2 = read "apply_complete2.tmpl"
-    let automerge_failure = read "automerge_error.tmpl"
-    let premium_feature_err_access_control = read "premium_feature_err_access_control.tmpl"
-
-    let premium_feature_err_multiple_drift_schedules =
-      read "premium_feature_err_multiple_drift_schedules.tmpl"
-
-    let premium_feature_err_gatekeeping = read "premium_feature_err_gatekeeping.tmpl"
-    let repo_config_merge_err = read "repo_config_merge_err.tmpl"
-    let gate_check_failure = read "gate_check_failure.tmpl"
-    let tier_check = read "tier_check.tmpl"
-    let build_tree_failure = read "build_tree_failure.tmpl"
-  end
-
-  let comment_on_pull_request ~request_id client pull_request msg_type body =
-    let open Abbs_future_combinators.Infix_result_monad in
-    Api.comment_on_pull_request ~request_id client pull_request body
-    >>= fun () ->
-    Logs.info (fun m -> m "%s : PUBLISHED_COMMENT : %s" request_id msg_type);
-    Abb.Future.return (Ok ())
-
-  let apply_template_and_publish ~request_id client pull_request msg_type template kv =
-    match Snabela.apply template kv with
-    | Ok body -> comment_on_pull_request ~request_id client pull_request msg_type body
-    | Error (#Snabela.err as err) ->
-        Logs.err (fun m -> m "%s : TEMPLATE_ERROR : %a" request_id Snabela.pp_err err);
-        Abb.Future.return (Error `Error)
-
   module Result = struct
     let steps_has_changes steps =
       let module P = struct
@@ -2404,444 +2175,6 @@ module Comment = struct
       CCList.for_all (fun { O.success; ignore_errors; _ } -> success || ignore_errors) steps
 
     module Publisher2 = struct
-      module Visible_on = Terrat_base_repo_config_v1.Workflow_step.Visible_on
-
-      module Output = struct
-        type t = {
-          cmd : string option;
-          name : string;
-          success : bool;
-          text : string;
-          text_decorator : string option;
-          visible_on : Visible_on.t;
-        }
-
-        let make ?cmd ?text_decorator ~name ~success ~text ~visible_on () =
-          (* If name looks like <namespace>/<action> then remove the namespace *)
-          let name = CCOption.map_or ~default:name snd (CCString.Split.right ~by:"/" name) in
-          { cmd; name; success; text; text_decorator; visible_on }
-
-        let to_kv { cmd; name; success; text; text_decorator; visible_on } =
-          Snabela.Kv.(
-            Map.of_list
-              (CCList.flatten
-                 [
-                   [
-                     ("name", string name);
-                     ("text", string text);
-                     ("success", bool success);
-                     ("text_decorator", string (CCOption.get_or ~default:"" text_decorator));
-                   ];
-                   CCOption.map_or ~default:[] (fun cmd -> [ ("cmd", string cmd) ]) cmd;
-                 ]))
-
-        let filter ~overall_success =
-          CCList.filter (fun { visible_on; _ } ->
-              visible_on = Visible_on.Always
-              || (overall_success && visible_on = Visible_on.Success)
-              || ((not overall_success) && visible_on = Visible_on.Failure))
-      end
-
-      let kv_of_cost_estimation changed_dirspaces output =
-        let module P = struct
-          module S = struct
-            type t = {
-              prev_monthly_cost : float;
-              total_monthly_cost : float;
-              diff_monthly_cost : float;
-            }
-            [@@deriving of_yojson { strict = false }]
-          end
-
-          module Ds = struct
-            type t = {
-              dir : string;
-              workspace : string;
-              prev_monthly_cost : float;
-              total_monthly_cost : float;
-              diff_monthly_cost : float;
-            }
-            [@@deriving yojson { strict = false }]
-          end
-
-          type t = {
-            summary : S.t;
-            dirspaces : Ds.t list;
-            currency : string;
-          }
-          [@@deriving of_yojson { strict = false }]
-        end in
-        let module O = Terrat_api_components.Workflow_step_output in
-        if output.O.success then
-          let open CCResult.Infix in
-          P.of_yojson (O.Payload.to_yojson output.O.payload)
-          >>= fun payload ->
-          let summary = payload.P.summary in
-          let changed_dirspaces = Terrat_data.Dirspace_set.of_list changed_dirspaces in
-          Ok
-            Snabela.Kv.(
-              Map.of_list
-                [
-                  ("name", string "cost_estimation");
-                  ("success", bool output.O.success);
-                  ("prev_monthly_cost", float summary.P.S.prev_monthly_cost);
-                  ("total_monthly_cost", float summary.P.S.total_monthly_cost);
-                  ("diff_monthly_cost", float summary.P.S.diff_monthly_cost);
-                  ("currency", string payload.P.currency);
-                  ( "dirspaces",
-                    list
-                      (CCList.filter_map
-                         (fun {
-                                P.Ds.dir;
-                                workspace;
-                                total_monthly_cost;
-                                prev_monthly_cost;
-                                diff_monthly_cost;
-                              }
-                            ->
-                           if
-                             Terrat_data.Dirspace_set.mem
-                               { Terrat_dirspace.dir; workspace }
-                               changed_dirspaces
-                           then
-                             Some
-                               (Map.of_list
-                                  [
-                                    ("dir", string dir);
-                                    ("workspace", string workspace);
-                                    ("prev_monthly_cost", float prev_monthly_cost);
-                                    ("total_monthly_cost", float total_monthly_cost);
-                                    ("diff_monthly_cost", float diff_monthly_cost);
-                                  ])
-                           else None)
-                         payload.P.dirspaces) );
-                ])
-        else
-          let module P = struct
-            type t = { text : string } [@@deriving of_yojson { strict = false }]
-          end in
-          let open CCResult.Infix in
-          P.of_yojson (O.Payload.to_yojson output.O.payload)
-          >>= fun { P.text } ->
-          Ok Snabela.Kv.(Map.of_list [ ("success", bool output.O.success); ("text", string text) ])
-
-      let output_of_run ?(default_visible_on = Visible_on.Failure) output =
-        let module P = struct
-          type t = {
-            cmd : string list option; [@default None]
-            text : string option; [@default None]
-            visible_on : string option;
-          }
-          [@@deriving of_yojson { strict = false }]
-        end in
-        let module O = Terrat_api_components.Workflow_step_output in
-        let open CCResult.Infix in
-        P.of_yojson (O.Payload.to_yojson output.O.payload)
-        >>= fun { P.cmd; text; visible_on } ->
-        Ok
-          (Output.make
-             ?cmd:(CCOption.map (CCString.concat " ") cmd)
-             ~name:output.O.step
-             ~success:output.O.success
-             ~text:(CCOption.get_or ~default:"" text)
-             ~visible_on:
-               (CCOption.map_or
-                  ~default:default_visible_on
-                  (function
-                    | "always" -> Visible_on.Always
-                    | "failure" -> Visible_on.Failure
-                    | "success" -> Visible_on.Success
-                    | _ -> Visible_on.Failure)
-                  visible_on)
-             ())
-
-      let output_of_plan output =
-        let module P = struct
-          type t = {
-            cmd : string list option; [@default None]
-            text : string;
-            plan : string option; [@default None]
-            has_changes : bool option; [@default None]
-          }
-          [@@deriving of_yojson { strict = false }]
-        end in
-        let module O = Terrat_api_components.Workflow_step_output in
-        let open CCResult.Infix in
-        P.of_yojson (O.Payload.to_yojson output.O.payload)
-        >>= fun { P.cmd; text; has_changes; plan } ->
-        if output.O.success then
-          Ok
-            (Output.make
-               ?cmd:(CCOption.map (CCString.concat " ") cmd)
-               ~name:output.O.step
-               ~success:output.O.success
-               ~text:(CCOption.get_or ~default:text plan)
-               ~text_decorator:"diff"
-               ~visible_on:Visible_on.Always
-               ())
-        else
-          Ok
-            (Output.make
-               ?cmd:(CCOption.map (CCString.concat " ") cmd)
-               ~name:output.O.step
-               ~success:output.O.success
-               ~text
-               ~visible_on:Visible_on.Always
-               ())
-
-      let output_of_workflow_output output =
-        let module O = Terrat_api_components.Workflow_step_output in
-        match output.O.step with
-        | "run" | "env" -> output_of_run output
-        | "tf/init" | "pulumi/init" | "custom/init" | "fly/init" ->
-            output_of_run ~default_visible_on:Visible_on.Failure output
-        | "tf/apply" | "pulumi/apply" | "custom/apply" | "fly/apply" ->
-            output_of_run ~default_visible_on:Visible_on.Always output
-        | "tf/plan" | "pulumi/plan" | "custom/plan" | "fly/plan" -> output_of_plan output
-        | step -> output_of_run output
-
-      let output_of_raw output =
-        let module O = Terrat_api_components.Workflow_step_output in
-        let { O.step; success; payload; _ } = output in
-        Output.make
-          ~name:step
-          ~success
-          ~text:(Yojson.Safe.pretty_to_string (O.Payload.to_yojson payload))
-          ~visible_on:Visible_on.Failure
-          ()
-
-      let output_of_steps steps =
-        let module O = Terrat_api_components.Workflow_step_output in
-        CCList.filter_map
-          (fun output ->
-            match output.O.step with
-            | "tf/cost-estimation" -> None
-            | _ -> (
-                match output_of_workflow_output output with
-                | Ok output -> Some output
-                | Error _ -> Some (output_of_raw output)))
-          steps
-
-      let kv_of_outputs outputs = CCList.map Output.to_kv outputs
-
-      let dirspace_compare (dirspace1, steps1) (dirspace2, steps2) =
-        let module Cmp = struct
-          type t = bool * bool * Terrat_dirspace.t [@@deriving ord]
-        end in
-        let has_changes1 = steps_has_changes steps1 in
-        let success1 = steps_success steps1 in
-        let has_changes2 = steps_has_changes steps2 in
-        let success2 = steps_success steps2 in
-        (* Negate has_changes because the order of [bool] is [false]
-             before [true]. *)
-        Cmp.compare (not has_changes1, success1, dirspace1) (not has_changes2, success2, dirspace2)
-
-      let create_run_output
-          ~view
-          request_id
-          account_status
-          config
-          is_layered_run
-          remaining_dirspace_configs
-          by_scope
-          gates
-          work_manifest =
-        let module Wm = Terrat_work_manifest3 in
-        let module R2 = Terrat_api_components.Work_manifest_tf_operation_result2 in
-        let module O = Terrat_api_components.Workflow_step_output in
-        let module Sds = Terrat_api_components.Workflow_step_output_scope_dirspace in
-        let module Sr = Terrat_api_components.Workflow_step_output_scope_run in
-        let hooks_pre =
-          CCList.Assoc.get ~eq:Scope.equal (Scope.Run { flow = "hooks"; subflow = "pre" }) by_scope
-        in
-        let hooks_post =
-          CCList.Assoc.get ~eq:Scope.equal (Scope.Run { flow = "hooks"; subflow = "post" }) by_scope
-        in
-        let dirspaces =
-          by_scope
-          |> CCList.filter_map (function
-               | Scope.Dirspace dirspace, steps -> Some (dirspace, steps)
-               | _ -> None)
-          |> CCList.sort dirspace_compare
-        in
-        let overall_success =
-          CCList.for_all
-            (fun (_, steps) ->
-              CCList.for_all (fun { O.success; ignore_errors; _ } -> success || ignore_errors) steps)
-            by_scope
-        in
-        let num_remaining_layers = CCList.length remaining_dirspace_configs in
-        let denied_dirspaces =
-          match work_manifest.Wm.denied_dirspaces with
-          | [] -> []
-          | dirspaces ->
-              Snabela.Kv.
-                [
-                  ( "denied_dirspaces",
-                    list
-                      (CCList.map
-                         (fun { Wm.Deny.dirspace = { Terrat_dirspace.dir; workspace }; policy } ->
-                           Map.of_list
-                             (CCList.flatten
-                                [
-                                  [ ("dir", string dir); ("workspace", string workspace) ];
-                                  (match policy with
-                                  | Some policy ->
-                                      [
-                                        ( "policy",
-                                          list
-                                            (CCList.map
-                                               (fun p ->
-                                                 Map.of_list
-                                                   [
-                                                     ( "item",
-                                                       string
-                                                         (Terrat_base_repo_config_v1.Access_control
-                                                          .Match
-                                                          .to_string
-                                                            p) );
-                                                   ])
-                                               policy) );
-                                      ]
-                                  | None -> []);
-                                ]))
-                         dirspaces) );
-                ]
-        in
-        let cost_estimation =
-          hooks_pre
-          |> CCOption.get_or ~default:[]
-          |> CCList.filter (fun { O.step; _ } -> CCString.equal step "tf/cost-estimation")
-          |> function
-          | [] -> []
-          | o :: _ -> (
-              let changed_dirspaces =
-                CCList.map
-                  (fun { Terrat_change.Dirspaceflow.dirspace; _ } -> dirspace)
-                  work_manifest.Wm.changes
-              in
-              match kv_of_cost_estimation changed_dirspaces o with
-              | Ok kv -> [ ("cost_estimation", Snabela.Kv.list [ kv ]) ]
-              | Error _ ->
-                  [ ("cost_estimation", Snabela.Kv.list [ Output.to_kv (output_of_raw o) ]) ])
-        in
-        let kv =
-          Snabela.Kv.(
-            Map.of_list
-              (CCList.flatten
-                 [
-                   (* CCOption.map_or *)
-                   (*   ~default:[] *)
-                   (*   (fun work_manifest_url -> *)
-                   (*     [ ("work_manifest_url", string (Uri.to_string work_manifest_url)) ]) *)
-                   (*   (S.work_manifest_url config work_manifest.Wm.account work_manifest); *)
-                   CCOption.map_or
-                     ~default:[]
-                     (fun env -> [ ("environment", string env) ])
-                     work_manifest.Wm.environment;
-                   [
-                     ( "account_status",
-                       string
-                         (match account_status with
-                         | `Trial_ending duration when Duration.to_day duration < 15 ->
-                             (* Only mark as trial ending if less than two weeks from now *)
-                             "trial_ending"
-                         | `Trial_ending _ | `Active -> "active"
-                         | `Expired -> "expired"
-                         | `Disabled -> "disabled") );
-                     ( "trial_end_days",
-                       match account_status with
-                       | `Trial_ending duration -> int (Duration.to_day duration)
-                       | _ -> int 0 );
-                     ("is_layered_run", bool is_layered_run);
-                     ("num_more_layers", int num_remaining_layers);
-                     ("overall_success", bool overall_success);
-                     ( "pre_hooks",
-                       hooks_pre
-                       |> CCOption.get_or ~default:[]
-                       |> output_of_steps
-                       |> Output.filter ~overall_success
-                       |> kv_of_outputs
-                       |> list );
-                     ( "post_hooks",
-                       hooks_post
-                       |> CCOption.get_or ~default:[]
-                       |> output_of_steps
-                       |> Output.filter ~overall_success
-                       |> kv_of_outputs
-                       |> list );
-                     ("compact_view", bool (view = `Compact));
-                     ("compact_dirspaces", bool (CCList.length dirspaces > 5));
-                     ( "dirspaces",
-                       list
-                         (CCList.map
-                            (fun ({ Terrat_dirspace.dir; workspace }, steps) ->
-                              let has_changes = steps_has_changes steps in
-                              let success = steps_success steps in
-                              Map.of_list
-                                (CCList.flatten
-                                   [
-                                     [
-                                       ("dir", string dir);
-                                       ("workspace", string workspace);
-                                       ("success", bool success);
-                                       ( "steps",
-                                         list
-                                           (kv_of_outputs
-                                              (Output.filter
-                                                 ~overall_success
-                                                 (output_of_steps steps))) );
-                                       ("has_changes", bool has_changes);
-                                     ];
-                                   ]))
-                            dirspaces) );
-                     ( "gates",
-                       let module G = Terrat_api_components.Gate in
-                       list
-                       @@ CCList.map
-                            (fun { G.all_of; any_of; any_of_count; dir; token; workspace } ->
-                              let all_of = CCOption.get_or ~default:[] all_of in
-                              let any_of = CCOption.get_or ~default:[] any_of in
-                              let any_of_count = CCOption.get_or ~default:0 any_of_count in
-                              let dir = CCOption.get_or ~default:"" dir in
-                              let workspace = CCOption.get_or ~default:"" workspace in
-                              Map.of_list
-                                [
-                                  ("token", string token);
-                                  ("dir", string dir);
-                                  ("workspace", string workspace);
-                                  ( "all_of",
-                                    list
-                                    @@ CCList.map (fun q -> Map.of_list [ ("q", string q) ]) all_of
-                                  );
-                                  ( "any_of",
-                                    list
-                                    @@ CCList.map
-                                         (fun q -> Map.of_list [ ("q", string q) ])
-                                         (if any_of_count = 0 then [] else any_of) );
-                                  ("any_of_count", int any_of_count);
-                                ])
-                       @@ CCList.sort (fun { G.token = t1; _ } { G.token = t2; _ } ->
-                              CCString.compare t1 t2)
-                       @@ CCOption.get_or ~default:[] gates );
-                   ];
-                   denied_dirspaces;
-                   cost_estimation;
-                 ]))
-        in
-        let tmpl =
-          match CCList.rev work_manifest.Wm.steps with
-          | [] | Wm.Step.Index :: _ | Wm.Step.Build_config :: _ | Wm.Step.Build_tree :: _ ->
-              assert false
-          | Wm.Step.Plan :: _ -> Tmpl.plan_complete2
-          | Wm.Step.(Apply | Unsafe_apply) :: _ -> Tmpl.apply_complete2
-        in
-        match Snabela.apply tmpl kv with
-        | Ok body -> body
-        | Error (#Snabela.err as err) ->
-            Logs.err (fun m -> m "%s : ERROR : %a" request_id Snabela.pp_err err);
-            assert false
-
       let rec iterate_comment_posts
           ?(view = `Full)
           request_id
@@ -2855,10 +2188,12 @@ module Comment = struct
           work_manifest =
         let module Wm = Terrat_work_manifest3 in
         let module R2 = Terrat_api_components.Work_manifest_tf_operation_result2 in
+        let module Comment_api = Terrat_vcs_service_gitlab_publishers.Comment_api in
+        let module Publisher_tools = Terrat_vcs_service_gitlab_publishers.Publisher_tools in
         let by_scope = By_scope.group results.R2.steps in
         let gates = results.R2.gates in
         let output =
-          create_run_output
+          Publisher_tools.create_run_output
             ~view
             request_id
             account_status
@@ -2905,13 +2240,69 @@ module Comment = struct
                     (*     [ ("work_manifest_url", string (Uri.to_string work_manifest_url)) ]) *)
                     (*   (S.work_manifest_url config work_manifest.Wm.account work_manifest) *))
                 in
-                apply_template_and_publish
+                Comment_api.apply_template_and_publish
                   ~request_id
                   client
                   pull_request
                   "ITERATE_COMMENT_POST2"
                   Tmpl.comment_too_large
                   kv)
+    end
+
+    module Publisher3 = struct
+      module Gcm = Terrat_vcs_comment.Make (Terrat_vcs_service_gitlab_comment.S)
+
+      let create_els results =
+        let module R2 = Terrat_api_components.Work_manifest_tf_operation_result2 in
+        let module Tcm = Terrat_vcs_service_gitlab_comment in
+        let by_scope = By_scope.group results.R2.steps in
+        let strategy = Terrat_vcs_comment.Strategy.Append in
+        by_scope
+        |> CCList.filter_map (function
+             | Scope.Dirspace dirspace, steps ->
+                 Some { Terrat_vcs_service_gitlab_comment.S.dirspace; steps; strategy }
+             | Scope.Run _, _ -> None)
+
+      let post_comment
+          request_id
+          account_status
+          config
+          client
+          is_layered_run
+          remaining_layers
+          result
+          pull_request
+          work_manifest =
+        let module Tcm = Terrat_vcs_service_gitlab_comment in
+        let module R2 = Terrat_api_components.Work_manifest_tf_operation_result2 in
+        let pull_request =
+          Api.Pull_request.set_diff () pull_request |> Api.Pull_request.set_checks ()
+        in
+        let work_manifest = { work_manifest with Terrat_work_manifest3.target = () } in
+        let by_scope = By_scope.group result.R2.steps in
+        let hooks =
+          CCList.filter_map
+            (function
+              | (Scope.Run _, _) as run -> Some run
+              | _ -> None)
+            by_scope
+        in
+        let t =
+          {
+            Tcm.S.request_id;
+            account_status;
+            config;
+            client;
+            hooks;
+            is_layered_run;
+            remaining_layers;
+            result;
+            pull_request;
+            work_manifest;
+          }
+        in
+        let els = create_els result in
+        Gcm.run t els
     end
   end
 
@@ -3163,9 +2554,10 @@ module Comment = struct
   let repo_config_failure ~request_id ~client ~pull_request ~title err =
     (* A bit of a cheap trick here to make it look like a code section in this
          context *)
+    let module Comment_api = Terrat_vcs_service_gitlab_publishers.Comment_api in
     let err = "```\n" ^ err ^ "\n```" in
     let kv = Snabela.Kv.(Map.of_list [ ("title", string title); ("msg", string err) ]) in
-    apply_template_and_publish
+    Comment_api.apply_template_and_publish
       ~request_id
       client
       pull_request
@@ -3174,6 +2566,7 @@ module Comment = struct
       kv
 
   let repo_config_err ~request_id ~client ~pull_request ~title err =
+    let open Terrat_vcs_service_gitlab_publishers.Comment_api in
     match err with
     | `Access_control_ci_config_update_match_parse_err m ->
         let kv = Snabela.Kv.(Map.of_list [ ("match", string m) ]) in
@@ -3445,8 +2838,11 @@ module Comment = struct
           "REPO_CONFIG_SCHEMA_ERR"
           Tmpl.repo_config_schema_err
           kv
+    | `Notification_policy_comment_strategy_err err -> raise (Failure "nyi")
+    | `Notification_policy_tag_query_err err -> raise (Failure "nyi")
 
   let publish_comment ~request_id client user pull_request =
+    let open Terrat_vcs_service_gitlab_publishers.Comment_api in
     let module Msg = Terrat_vcs_provider2.Msg in
     function
     | Msg.Access_control_denied (default_branch, `All_dirspaces denies) ->
@@ -4280,7 +3676,7 @@ module Comment = struct
     | Msg.Tf_op_result2
         { account_status; config; is_layered_run; remaining_layers; result; work_manifest } -> (
         let open Abb.Future.Infix_monad in
-        Result.Publisher2.iterate_comment_posts
+        Result.Publisher3.post_comment
           request_id
           account_status
           config
@@ -4978,8 +4374,4 @@ module Work_manifest = struct
       post_hooks_success;
       dirspaces_success;
     }
-end
-
-module Ui = struct
-  let work_manifest_url config account = raise (Failure "nyi")
 end

--- a/code/src/terrat_vcs_service_gitlab/terrat_vcs_service_gitlab_publishers.ml
+++ b/code/src/terrat_vcs_service_gitlab/terrat_vcs_service_gitlab_publishers.ml
@@ -1,0 +1,479 @@
+module Api = Terrat_vcs_api_gitlab
+module Scope = Terrat_vcs_service_gitlab_scope.Scope
+module By_scope = Terrat_vcs_service_gitlab_scope.By_scope
+module Tmpl = Terrat_vcs_service_gitlab_assets.Tmpl
+module Visible_on = Terrat_base_repo_config_v1.Workflow_step.Visible_on
+module Ui = Terrat_vcs_service_gitlab_assets.Ui
+
+module Output = struct
+  type t = {
+    cmd : string option;
+    name : string;
+    success : bool;
+    text : string;
+    text_decorator : string option;
+    visible_on : Visible_on.t;
+  }
+
+  let make ?cmd ?text_decorator ~name ~success ~text ~visible_on () =
+    (* If name looks like <namespace>/<action> then remove the namespace *)
+    let name = CCOption.map_or ~default:name snd (CCString.Split.right ~by:"/" name) in
+    { cmd; name; success; text; text_decorator; visible_on }
+
+  let to_kv { cmd; name; success; text; text_decorator; visible_on } =
+    Snabela.Kv.(
+      Map.of_list
+        (CCList.flatten
+           [
+             [
+               ("name", string name);
+               ("text", string text);
+               ("success", bool success);
+               ("text_decorator", string (CCOption.get_or ~default:"" text_decorator));
+             ];
+             CCOption.map_or ~default:[] (fun cmd -> [ ("cmd", string cmd) ]) cmd;
+           ]))
+
+  let filter ~overall_success =
+    CCList.filter (fun { visible_on; _ } ->
+        visible_on = Visible_on.Always
+        || (overall_success && visible_on = Visible_on.Success)
+        || ((not overall_success) && visible_on = Visible_on.Failure))
+end
+
+let steps_has_changes steps =
+  let module P = struct
+    type t = { has_changes : bool [@default false] } [@@deriving of_yojson { strict = false }]
+  end in
+  let module O = Terrat_api_components.Workflow_step_output in
+  match
+    CCList.find_map
+      (function
+        | { O.step = "tf/plan" | "pulumi/plan" | "custom/plan" | "fly/plan"; payload; success; _ }
+          -> (
+            match P.of_yojson (O.Payload.to_yojson payload) with
+            | Ok { P.has_changes } -> Some has_changes
+            | _ -> None)
+        | _ -> None)
+      steps
+  with
+  | Some has_changes -> has_changes
+  | None -> false
+
+let steps_success steps =
+  let module O = Terrat_api_components.Workflow_step_output in
+  CCList.for_all (fun { O.success; ignore_errors; _ } -> success || ignore_errors) steps
+
+let kv_of_cost_estimation changed_dirspaces output =
+  let module P = struct
+    module S = struct
+      type t = {
+        prev_monthly_cost : float;
+        total_monthly_cost : float;
+        diff_monthly_cost : float;
+      }
+      [@@deriving of_yojson { strict = false }]
+    end
+
+    module Ds = struct
+      type t = {
+        dir : string;
+        workspace : string;
+        prev_monthly_cost : float;
+        total_monthly_cost : float;
+        diff_monthly_cost : float;
+      }
+      [@@deriving yojson { strict = false }]
+    end
+
+    type t = {
+      summary : S.t;
+      dirspaces : Ds.t list;
+      currency : string;
+    }
+    [@@deriving of_yojson { strict = false }]
+  end in
+  let module O = Terrat_api_components.Workflow_step_output in
+  if output.O.success then
+    let open CCResult.Infix in
+    P.of_yojson (O.Payload.to_yojson output.O.payload)
+    >>= fun payload ->
+    let summary = payload.P.summary in
+    let changed_dirspaces = Terrat_data.Dirspace_set.of_list changed_dirspaces in
+    Ok
+      Snabela.Kv.(
+        Map.of_list
+          [
+            ("name", string "cost_estimation");
+            ("success", bool output.O.success);
+            ("prev_monthly_cost", float summary.P.S.prev_monthly_cost);
+            ("total_monthly_cost", float summary.P.S.total_monthly_cost);
+            ("diff_monthly_cost", float summary.P.S.diff_monthly_cost);
+            ("currency", string payload.P.currency);
+            ( "dirspaces",
+              list
+                (CCList.filter_map
+                   (fun {
+                          P.Ds.dir;
+                          workspace;
+                          total_monthly_cost;
+                          prev_monthly_cost;
+                          diff_monthly_cost;
+                        }
+                      ->
+                     if
+                       Terrat_data.Dirspace_set.mem
+                         { Terrat_dirspace.dir; workspace }
+                         changed_dirspaces
+                     then
+                       Some
+                         (Map.of_list
+                            [
+                              ("dir", string dir);
+                              ("workspace", string workspace);
+                              ("prev_monthly_cost", float prev_monthly_cost);
+                              ("total_monthly_cost", float total_monthly_cost);
+                              ("diff_monthly_cost", float diff_monthly_cost);
+                            ])
+                     else None)
+                   payload.P.dirspaces) );
+          ])
+  else
+    let module P = struct
+      type t = { text : string } [@@deriving of_yojson { strict = false }]
+    end in
+    let open CCResult.Infix in
+    P.of_yojson (O.Payload.to_yojson output.O.payload)
+    >>= fun { P.text } ->
+    Ok Snabela.Kv.(Map.of_list [ ("success", bool output.O.success); ("text", string text) ])
+
+let output_of_run ?(default_visible_on = Visible_on.Failure) output =
+  let module P = struct
+    type t = {
+      cmd : string list option; [@default None]
+      text : string option; [@default None]
+      visible_on : string option;
+    }
+    [@@deriving of_yojson { strict = false }]
+  end in
+  let module O = Terrat_api_components.Workflow_step_output in
+  let open CCResult.Infix in
+  P.of_yojson (O.Payload.to_yojson output.O.payload)
+  >>= fun { P.cmd; text; visible_on } ->
+  Ok
+    (Output.make
+       ?cmd:(CCOption.map (CCString.concat " ") cmd)
+       ~name:output.O.step
+       ~success:output.O.success
+       ~text:(CCOption.get_or ~default:"" text)
+       ~visible_on:
+         (CCOption.map_or
+            ~default:default_visible_on
+            (function
+              | "always" -> Visible_on.Always
+              | "failure" -> Visible_on.Failure
+              | "success" -> Visible_on.Success
+              | _ -> Visible_on.Failure)
+            visible_on)
+       ())
+
+let output_of_plan output =
+  let module P = struct
+    type t = {
+      cmd : string list option; [@default None]
+      text : string;
+      plan : string option; [@default None]
+      has_changes : bool option; [@default None]
+    }
+    [@@deriving of_yojson { strict = false }]
+  end in
+  let module O = Terrat_api_components.Workflow_step_output in
+  let open CCResult.Infix in
+  P.of_yojson (O.Payload.to_yojson output.O.payload)
+  >>= fun { P.cmd; text; has_changes; plan } ->
+  if output.O.success then
+    Ok
+      (Output.make
+         ?cmd:(CCOption.map (CCString.concat " ") cmd)
+         ~name:output.O.step
+         ~success:output.O.success
+         ~text:(CCOption.get_or ~default:text plan)
+         ~text_decorator:"diff"
+         ~visible_on:Visible_on.Always
+         ())
+  else
+    Ok
+      (Output.make
+         ?cmd:(CCOption.map (CCString.concat " ") cmd)
+         ~name:output.O.step
+         ~success:output.O.success
+         ~text
+         ~visible_on:Visible_on.Always
+         ())
+
+let output_of_workflow_output output =
+  let module O = Terrat_api_components.Workflow_step_output in
+  match output.O.step with
+  | "run" | "env" -> output_of_run output
+  | "tf/init" | "pulumi/init" | "custom/init" | "fly/init" ->
+      output_of_run ~default_visible_on:Visible_on.Failure output
+  | "tf/apply" | "pulumi/apply" | "custom/apply" | "fly/apply" ->
+      output_of_run ~default_visible_on:Visible_on.Always output
+  | "tf/plan" | "pulumi/plan" | "custom/plan" | "fly/plan" -> output_of_plan output
+  | step -> output_of_run output
+
+let output_of_raw output =
+  let module O = Terrat_api_components.Workflow_step_output in
+  let { O.step; success; payload; _ } = output in
+  Output.make
+    ~name:step
+    ~success
+    ~text:(Yojson.Safe.pretty_to_string (O.Payload.to_yojson payload))
+    ~visible_on:Visible_on.Failure
+    ()
+
+let output_of_steps steps =
+  let module O = Terrat_api_components.Workflow_step_output in
+  CCList.filter_map
+    (fun output ->
+      match output.O.step with
+      | "tf/cost-estimation" -> None
+      | _ -> (
+          match output_of_workflow_output output with
+          | Ok output -> Some output
+          | Error _ -> Some (output_of_raw output)))
+    steps
+
+let kv_of_outputs outputs = CCList.map Output.to_kv outputs
+
+let dirspace_compare (dirspace1, steps1) (dirspace2, steps2) =
+  let module Cmp = struct
+    type t = bool * bool * Terrat_dirspace.t [@@deriving ord]
+  end in
+  let has_changes1 = steps_has_changes steps1 in
+  let success1 = steps_success steps1 in
+  let has_changes2 = steps_has_changes steps2 in
+  let success2 = steps_success steps2 in
+  (* Negate has_changes because the order of [bool] is [false]
+             before [true]. *)
+  Cmp.compare (not has_changes1, success1, dirspace1) (not has_changes2, success2, dirspace2)
+
+module Comment_api = struct
+  let comment_on_pull_request ~request_id client pull_request msg_type body =
+    let open Abbs_future_combinators.Infix_result_monad in
+    Api.comment_on_pull_request ~request_id client pull_request body
+    >>= fun () ->
+    Logs.info (fun m -> m "%s : PUBLISHED_COMMENT : %s" request_id msg_type);
+    Abb.Future.return (Ok ())
+
+  let apply_template_and_publish ~request_id client pull_request msg_type template kv =
+    match Snabela.apply template kv with
+    | Ok body -> comment_on_pull_request ~request_id client pull_request msg_type body
+    | Error (#Snabela.err as err) ->
+        Logs.err (fun m -> m "%s : TEMPLATE_ERROR : %a" request_id Snabela.pp_err err);
+        Abb.Future.return (Error `Error)
+end
+
+module Publisher_tools = struct
+  let create_run_output
+      ~view
+      request_id
+      account_status
+      config
+      is_layered_run
+      remaining_dirspace_configs
+      by_scope
+      gates
+      work_manifest =
+    let module Wm = Terrat_work_manifest3 in
+    let module R2 = Terrat_api_components.Work_manifest_tf_operation_result2 in
+    let module O = Terrat_api_components.Workflow_step_output in
+    let module Sds = Terrat_api_components.Workflow_step_output_scope_dirspace in
+    let module Sr = Terrat_api_components.Workflow_step_output_scope_run in
+    let hooks_pre =
+      CCList.Assoc.get ~eq:Scope.equal (Scope.Run { flow = "hooks"; subflow = "pre" }) by_scope
+    in
+    let hooks_post =
+      CCList.Assoc.get ~eq:Scope.equal (Scope.Run { flow = "hooks"; subflow = "post" }) by_scope
+    in
+    let dirspaces =
+      by_scope
+      |> CCList.filter_map (function
+           | Scope.Dirspace dirspace, steps -> Some (dirspace, steps)
+           | _ -> None)
+      |> CCList.sort dirspace_compare
+    in
+    let overall_success =
+      CCList.for_all
+        (fun (_, steps) ->
+          CCList.for_all (fun { O.success; ignore_errors; _ } -> success || ignore_errors) steps)
+        by_scope
+    in
+    let num_remaining_layers = CCList.length remaining_dirspace_configs in
+    let denied_dirspaces =
+      match work_manifest.Wm.denied_dirspaces with
+      | [] -> []
+      | dirspaces ->
+          Snabela.Kv.
+            [
+              ( "denied_dirspaces",
+                list
+                  (CCList.map
+                     (fun { Wm.Deny.dirspace = { Terrat_dirspace.dir; workspace }; policy } ->
+                       Map.of_list
+                         (CCList.flatten
+                            [
+                              [ ("dir", string dir); ("workspace", string workspace) ];
+                              (match policy with
+                              | Some policy ->
+                                  [
+                                    ( "policy",
+                                      list
+                                        (CCList.map
+                                           (fun p ->
+                                             Map.of_list
+                                               [
+                                                 ( "item",
+                                                   string
+                                                     (Terrat_base_repo_config_v1.Access_control
+                                                      .Match
+                                                      .to_string
+                                                        p) );
+                                               ])
+                                           policy) );
+                                  ]
+                              | None -> []);
+                            ]))
+                     dirspaces) );
+            ]
+    in
+    let cost_estimation =
+      hooks_pre
+      |> CCOption.get_or ~default:[]
+      |> CCList.filter (fun { O.step; _ } -> CCString.equal step "tf/cost-estimation")
+      |> function
+      | [] -> []
+      | o :: _ -> (
+          let changed_dirspaces =
+            CCList.map
+              (fun { Terrat_change.Dirspaceflow.dirspace; _ } -> dirspace)
+              work_manifest.Wm.changes
+          in
+          match kv_of_cost_estimation changed_dirspaces o with
+          | Ok kv -> [ ("cost_estimation", Snabela.Kv.list [ kv ]) ]
+          | Error _ -> [ ("cost_estimation", Snabela.Kv.list [ Output.to_kv (output_of_raw o) ]) ])
+    in
+    let kv =
+      Snabela.Kv.(
+        Map.of_list
+          (CCList.flatten
+             [
+               CCOption.map_or
+                 ~default:[]
+                 (fun work_manifest_url ->
+                   [ ("work_manifest_url", string (Uri.to_string work_manifest_url)) ])
+                 (Ui.work_manifest_url config work_manifest.Wm.account work_manifest);
+               CCOption.map_or
+                 ~default:[]
+                 (fun env -> [ ("environment", string env) ])
+                 work_manifest.Wm.environment;
+               [
+                 ( "account_status",
+                   string
+                     (match account_status with
+                     | `Trial_ending duration when Duration.to_day duration < 15 ->
+                         (* Only mark as trial ending if less than two weeks from now *)
+                         "trial_ending"
+                     | `Trial_ending _ | `Active -> "active"
+                     | `Expired -> "expired"
+                     | `Disabled -> "disabled") );
+                 ( "trial_end_days",
+                   match account_status with
+                   | `Trial_ending duration -> int (Duration.to_day duration)
+                   | _ -> int 0 );
+                 ("is_layered_run", bool is_layered_run);
+                 ("num_more_layers", int num_remaining_layers);
+                 ("overall_success", bool overall_success);
+                 ( "pre_hooks",
+                   hooks_pre
+                   |> CCOption.get_or ~default:[]
+                   |> output_of_steps
+                   |> Output.filter ~overall_success
+                   |> kv_of_outputs
+                   |> list );
+                 ( "post_hooks",
+                   hooks_post
+                   |> CCOption.get_or ~default:[]
+                   |> output_of_steps
+                   |> Output.filter ~overall_success
+                   |> kv_of_outputs
+                   |> list );
+                 ("compact_view", bool (view = `Compact));
+                 ("compact_dirspaces", bool (CCList.length dirspaces > 5));
+                 ( "dirspaces",
+                   list
+                     (CCList.map
+                        (fun ({ Terrat_dirspace.dir; workspace }, steps) ->
+                          let has_changes = steps_has_changes steps in
+                          let success = steps_success steps in
+                          Map.of_list
+                            (CCList.flatten
+                               [
+                                 [
+                                   ("dir", string dir);
+                                   ("workspace", string workspace);
+                                   ("success", bool success);
+                                   ( "steps",
+                                     list
+                                       (kv_of_outputs
+                                          (Output.filter ~overall_success (output_of_steps steps)))
+                                   );
+                                   ("has_changes", bool has_changes);
+                                 ];
+                               ]))
+                        dirspaces) );
+                 ( "gates",
+                   let module G = Terrat_api_components.Gate in
+                   list
+                   @@ CCList.map (fun { G.all_of; any_of; any_of_count; dir; token; workspace } ->
+                          let all_of = CCOption.get_or ~default:[] all_of in
+                          let any_of = CCOption.get_or ~default:[] any_of in
+                          let any_of_count = CCOption.get_or ~default:0 any_of_count in
+                          let dir = CCOption.get_or ~default:"" dir in
+                          let workspace = CCOption.get_or ~default:"" workspace in
+                          Map.of_list
+                            [
+                              ("token", string token);
+                              ("dir", string dir);
+                              ("workspace", string workspace);
+                              ( "all_of",
+                                list @@ CCList.map (fun q -> Map.of_list [ ("q", string q) ]) all_of
+                              );
+                              ( "any_of",
+                                list
+                                @@ CCList.map
+                                     (fun q -> Map.of_list [ ("q", string q) ])
+                                     (if any_of_count = 0 then [] else any_of) );
+                              ("any_of_count", int any_of_count);
+                            ])
+                   @@ CCList.sort (fun { G.token = t1; _ } { G.token = t2; _ } ->
+                          CCString.compare t1 t2)
+                   @@ CCOption.get_or ~default:[] gates );
+               ];
+               denied_dirspaces;
+               cost_estimation;
+             ]))
+    in
+    let tmpl =
+      match CCList.rev work_manifest.Wm.steps with
+      | [] | Wm.Step.Index :: _ | Wm.Step.Build_config :: _ | Wm.Step.Build_tree :: _ ->
+          assert false
+      | Wm.Step.Plan :: _ -> Tmpl.plan_complete2
+      | Wm.Step.(Apply | Unsafe_apply) :: _ -> Tmpl.apply_complete2
+    in
+    match Snabela.apply tmpl kv with
+    | Ok body -> body
+    | Error (#Snabela.err as err) ->
+        Logs.err (fun m -> m "%s : ERROR : %a" request_id Snabela.pp_err err);
+        assert false
+end

--- a/code/src/terrat_vcs_service_gitlab/terrat_vcs_service_gitlab_scope.ml
+++ b/code/src/terrat_vcs_service_gitlab/terrat_vcs_service_gitlab_scope.ml
@@ -1,0 +1,28 @@
+module Scope = struct
+  type t =
+    | Dirspace of Terrat_dirspace.t
+    | Run of {
+        flow : string;
+        subflow : string;
+      }
+  [@@deriving eq, ord]
+
+  let of_terrat_api_scope =
+    let module S = Terrat_api_components.Workflow_step_output_scope in
+    let module Ds = Terrat_api_components.Workflow_step_output_scope_dirspace in
+    let module R = Terrat_api_components.Workflow_step_output_scope_run in
+    function
+    | S.Workflow_step_output_scope_dirspace { Ds.dir; workspace; _ } ->
+        Dirspace { Terrat_dirspace.dir; workspace }
+    | S.Workflow_step_output_scope_run { R.flow; subflow; _ } -> Run { flow; subflow }
+end
+
+module By_scope = Terrat_data.Group_by (struct
+  module T = Terrat_api_components.Workflow_step_output
+
+  type t = T.t
+  type key = Scope.t
+
+  let compare = Scope.compare
+  let key { T.scope; _ } = Scope.of_terrat_api_scope scope
+end)

--- a/code/tests/terrat_vcs_comment/test.ml
+++ b/code/tests/terrat_vcs_comment/test.ml
@@ -1,0 +1,690 @@
+module Oth_abb = Oth_abb.Make (Abb)
+
+module Eh = struct
+  type el = {
+    rendered_length : int;
+    dirspace : Terrat_dirspace.t;
+    is_success : bool;
+    strategy : Terrat_vcs_comment.Strategy.t;
+  }
+  [@@deriving show]
+
+  type comment_id = int [@@deriving ord, show]
+
+  type t =
+    | Query_comment_id of el * (comment_id option, [ `Error ]) result
+    | Query_els_for_comment_id of comment_id * (el list, [ `Error ]) result
+    | Upsert_comment_id of el list * comment_id * (unit, [ `Error ]) result
+    | Delete_comment of comment_id * (unit, [ `Error ]) result
+    | Minimize_comment of comment_id * (unit, [ `Error ]) result
+    | Post_comment of el list * (comment_id, [ `Error ]) result
+  [@@deriving show]
+
+  type commands = t list [@@deriving show]
+end
+
+module API_id = struct
+  type t = int Atomic.t
+
+  let create start = Atomic.make start
+  let get counter = Atomic.get counter
+  let next counter = Atomic.fetch_and_add counter 1 + 1
+end
+
+module H = struct
+  type t = Eh.commands ref
+  type el = Eh.el [@@deriving show]
+  type comment_id = Eh.comment_id [@@deriving ord, show]
+
+  module Cmp = struct
+    type t = bool * Terrat_dirspace.t [@@deriving ord]
+  end
+
+  let query_comment_id t el1 =
+    match !t with
+    (* | Eh.Query_comment_id (el2, cmd_result) :: rest when el1 = el2 -> *)
+    | Eh.Query_comment_id (el2, cmd_result) :: rest ->
+        t := rest;
+        let abb_result = Abb.Future.return cmd_result in
+        (abb_result : ('a, [ `Error ]) result Abb.Future.t :> ('a, [> `Error ]) result Abb.Future.t)
+    | es ->
+        Printf.printf "\n\tQUERY COMMENT_ID LOG: %s%!\n" (Eh.show_commands es);
+        assert false
+
+  let query_els_for_comment_id t cid =
+    match !t with
+    | Eh.Query_els_for_comment_id (cid2, cmd_result) :: rest when cid = cid2 ->
+        t := rest;
+        let abb_result = Abb.Future.return cmd_result in
+        (abb_result : ('a, [ `Error ]) result Abb.Future.t :> ('a, [> `Error ]) result Abb.Future.t)
+    | es ->
+        Printf.printf "\n\tQUERY ELS FOR COMMENT_ID LOG: %s%!\n" (Eh.show_commands es);
+        assert false
+
+  let upsert_comment_id t els cid =
+    match !t with
+    | Eh.Upsert_comment_id (els2, cid2, cmd_result) :: rest when cid = cid2 ->
+        t := rest;
+        let abb_result = Abb.Future.return cmd_result in
+        (abb_result : ('a, [ `Error ]) result Abb.Future.t :> ('a, [> `Error ]) result Abb.Future.t)
+    | es ->
+        Printf.printf "\n\tUPSERT LOG: %s%!\n" (Eh.show_commands es);
+        assert false
+
+  let delete_comment t cid =
+    match !t with
+    | Eh.Delete_comment (cid2, cmd_result) :: rest when cid = cid2 ->
+        t := rest;
+        let abb_result = Abb.Future.return cmd_result in
+        (abb_result : ('a, [ `Error ]) result Abb.Future.t :> ('a, [> `Error ]) result Abb.Future.t)
+    | es ->
+        Printf.printf "\n\tDELETE LOG: %s%!\n" (Eh.show_commands es);
+        assert false
+
+  let minimize_comment t cid =
+    match !t with
+    | Eh.Minimize_comment (cid2, cmd_result) :: rest when cid = cid2 ->
+        t := rest;
+        let abb_result = Abb.Future.return cmd_result in
+        (abb_result : ('a, [ `Error ]) result Abb.Future.t :> ('a, [> `Error ]) result Abb.Future.t)
+    | es ->
+        Printf.printf "\n\tMINIMIZE LOG: %s%!\nCID_INPUT=%d\n%!" (Eh.show_commands es) cid;
+        assert false
+
+  let post_comment t els =
+    match !t with
+    | Eh.Post_comment (els2, cmd_result) :: rest when els = els2 ->
+        t := rest;
+        let abb_result = Abb.Future.return cmd_result in
+        (abb_result : ('a, [ `Error ]) result Abb.Future.t :> ('a, [> `Error ]) result Abb.Future.t)
+    | es ->
+        let show = [%show: Eh.el list] in
+        Printf.printf "\n\tPOST COMMENT INPUTS: %s%!\n" (show els);
+        Printf.printf "\n\tPOST COMMENT LOG: %s%!\n" (Eh.show_commands es);
+        assert false
+
+  let rendered_length _ els = CCList.fold_left (fun acc el -> acc + el.Eh.rendered_length) 0 els
+  let strategy el = el.Eh.strategy
+  let compact el = { el with Eh.rendered_length = 1 }
+
+  let compare_el el1 el2 =
+    Cmp.compare (el1.Eh.is_success, el1.Eh.dirspace) (el2.Eh.is_success, el2.Eh.dirspace)
+
+  let max_comment_length = 100
+end
+
+module Shared = struct
+  let random_string n =
+    let chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789" in
+    let len = String.length chars in
+    let result = Bytes.create n in
+    for i = 0 to n - 1 do
+      let random_index = Random.int len in
+      Bytes.set result i chars.[random_index]
+    done;
+    Bytes.to_string result
+
+  let random_el min_len max_len =
+    let module C = Terrat_vcs_comment in
+    let module D = Terrat_dirspace in
+    let rendered_length = Random.int_in_range ~min:min_len ~max:max_len in
+    let dirspace = D.{ dir = random_string 10; workspace = random_string 10 } in
+    let is_success = Random.bool () in
+    let strategy =
+      match Random.int_in_range ~min:0 ~max:2 with
+      | 0 -> C.Strategy.Append
+      | _ -> C.Strategy.Append
+    in
+    Eh.{ rendered_length; dirspace; is_success; strategy }
+
+  let create_el dir workspace is_success rendered_length strategy =
+    let module D = Terrat_dirspace in
+    let dirspace = D.{ dir; workspace } in
+    Eh.{ rendered_length; dirspace; is_success; strategy }
+
+  let gen_els n min max = CCList.init n (fun _ -> random_el min max)
+end
+
+module Make_wrapper = struct
+  let run t els =
+    let open Abb.Future.Infix_monad in
+    let module C = Terrat_vcs_comment in
+    let module D = Terrat_dirspace in
+    let module Cm = Terrat_vcs_comment.Make (H) in
+    Cm.run t els
+    >>= function
+    | Ok () -> (
+        match !t with
+        | [] -> Abb.Future.return (Ok ())
+        | es ->
+            Printf.printf "\n\tT: %s%!\n" (Eh.show_commands es);
+            assert false)
+    | Error e -> Abb.Future.return (Error e)
+end
+
+let test_basic =
+  let _empty_els =
+    Oth_abb.test ~desc:"Noop flow" ~name:"[Basic] Empty elements" (fun () ->
+        let open Abb.Future.Infix_monad in
+        let module Cm = Terrat_vcs_comment.Make (H) in
+        let els = [] in
+        let t = ref [] in
+        Make_wrapper.run t els
+        >>= function
+        | Ok () -> Abb.Future.return ()
+        | Error _ -> assert false)
+  in
+  let simple_post =
+    Oth_abb.test ~name:"[Basic] Single post comment flow" (fun () ->
+        let open Abb.Future.Infix_monad in
+        let module Cm = Terrat_vcs_comment.Make (H) in
+        let module Shr = Shared in
+        (* TODO: Remove this random data gen *)
+        let els = Shared.gen_els 1 10 20 in
+        let counter = API_id.create 0 in
+        let cid1 = API_id.next counter in
+        let t = ref [ Eh.Post_comment (els, Ok cid1); Eh.Upsert_comment_id (els, cid1, Ok ()) ] in
+        Make_wrapper.run t els
+        >>= function
+        | Ok r -> Abb.Future.return ()
+        | Error _ -> assert false)
+  in
+  Oth_abb.parallel [ simple_post ]
+
+let test_errors =
+  let post_comment =
+    Oth_abb.test
+      ~desc:"Errors during post_comment are handled correctly"
+      ~name:"[Error] Check error handling"
+      (fun () ->
+        let open Abb.Future.Infix_monad in
+        let module Cm = Terrat_vcs_comment.Make (H) in
+        (* TODO: Remove this random data gen *)
+        let els = Shared.gen_els 1 10 20 in
+        let t = ref [ Eh.Post_comment (els, Error `Error) ] in
+        Make_wrapper.run t els
+        >>= function
+        | Ok _ -> assert false
+        | Error `Error -> Abb.Future.return ()
+        | Error _ -> assert false)
+  in
+  Oth_abb.parallel [ post_comment ]
+
+let test_append_strategy =
+  let multiple_small =
+    Oth_abb.test
+      ~desc:
+        "Given 3 elements with rendered length smaller than the ceiling, but that can't be \
+         combined into a single cluster, we will generate 3 comments"
+      ~name:"[Append] Multiple Small #1"
+      (fun () ->
+        let open Abb.Future.Infix_monad in
+        let module C = Terrat_vcs_comment in
+        let module D = Terrat_dirspace in
+        let module Cm = Terrat_vcs_comment.Make (H) in
+        let len = H.max_comment_length - 1 in
+        let st = C.Strategy.Append in
+        let el1 = Shared.create_el "A" "A" false len st in
+        let el2 = Shared.create_el "B" "B" true len st in
+        let el3 = Shared.create_el "C" "C" false len st in
+        let els = [ el1; el2; el3 ] in
+        let counter = API_id.create 0 in
+        let cid1 = API_id.next counter in
+        let cid2 = API_id.next counter in
+        let cid3 = API_id.next counter in
+        let t =
+          ref
+            [
+              Eh.Post_comment ([ el1 ], Ok cid1);
+              Eh.Upsert_comment_id ([ el1 ], cid1, Ok ());
+              Eh.Post_comment ([ el3 ], Ok cid2);
+              Eh.Upsert_comment_id ([ el3 ], cid2, Ok ());
+              Eh.Post_comment ([ el2 ], Ok cid3);
+              Eh.Upsert_comment_id ([ el2 ], cid3, Ok ());
+            ]
+        in
+        Make_wrapper.run t els
+        >>= function
+        | Ok () -> Abb.Future.return ()
+        | Error _ -> assert false)
+  in
+  let multiple_big =
+    Oth_abb.test
+      ~desc:
+        "Given 3 elements with rendered length bigger than the ceiling, but will be compacted to \
+         fit into a single cluster, generate a single comment"
+      ~name:"[Append] Multiple Big #1"
+      (fun () ->
+        let open Abb.Future.Infix_monad in
+        let module C = Terrat_vcs_comment in
+        let module D = Terrat_dirspace in
+        let module Cm = Terrat_vcs_comment.Make (H) in
+        let len = H.max_comment_length + 1 in
+        let st = C.Strategy.Append in
+        let el1 = Shared.create_el "A" "A" false len st in
+        let el2 = Shared.create_el "B" "B" true len st in
+        let el3 = Shared.create_el "C" "C" false len st in
+        let els = [ el1; el2; el3 ] in
+        let elsc = CCList.map H.compact [ el1; el3; el2 ] in
+        let counter = API_id.create 0 in
+        let cid1 = API_id.next counter in
+        let t = ref [ Eh.Post_comment (elsc, Ok cid1); Eh.Upsert_comment_id (elsc, cid1, Ok ()) ] in
+        Make_wrapper.run t els
+        >>= function
+        | Ok r -> Abb.Future.return ()
+        | Error _ -> assert false)
+  in
+  let multiple_mixed =
+    Oth_abb.test
+      ~desc:
+        "Given 4 elements with mixed rendered lengths, get smaller comments into a single cluster, \
+         compact the big ones and also fit them into a smaller cluster"
+      ~name:"[Append] Mixed #1"
+      (fun () ->
+        let open Abb.Future.Infix_monad in
+        let module C = Terrat_vcs_comment in
+        let module D = Terrat_dirspace in
+        let module Cm = Terrat_vcs_comment.Make (H) in
+        let half = H.max_comment_length / 2 in
+        let st = C.Strategy.Append in
+        let el1 = Shared.create_el "A" "A" false half st in
+        let el2 = Shared.create_el "B" "B" true (half - 1) st in
+        let el3 = Shared.create_el "C" "C" false (half - 1) st in
+        let el4 = Shared.create_el "D" "D" true (H.max_comment_length + 1) st in
+        let els = [ el1; el2; el3; el4 ] in
+        let el4c = H.compact el4 in
+        let counter = API_id.create 0 in
+        let cid1 = API_id.next counter in
+        let cid2 = API_id.next counter in
+        let t =
+          ref
+            [
+              Eh.Post_comment ([ el1; el3 ], Ok cid1);
+              Eh.Upsert_comment_id ([ el1; el3 ], cid1, Ok ());
+              Eh.Post_comment ([ el2; el4c ], Ok cid2);
+              Eh.Upsert_comment_id ([ el2; el4c ], cid2, Ok ());
+            ]
+        in
+        Make_wrapper.run t els
+        >>= function
+        | Ok () -> Abb.Future.return ()
+        | Error _ -> assert false)
+  in
+  Oth_abb.parallel [ multiple_small; multiple_big; multiple_mixed ]
+
+let _test_delete_strategy =
+  let multiple_small =
+    Oth_abb.test
+      ~desc:
+        "Given 3 elements with rendered length smaller than the ceiling, but that can't be \
+         combined into a single cluster, we will generate 3 comments"
+      ~name:"[Delete] Multiple Small #1"
+      (fun () ->
+        let open Abb.Future.Infix_monad in
+        let module C = Terrat_vcs_comment in
+        let module D = Terrat_dirspace in
+        let module Cm = Terrat_vcs_comment.Make (H) in
+        let len = H.max_comment_length - 1 in
+        let st = C.Strategy.Delete in
+        let el1 = Shared.create_el "A" "A" false len st in
+        let el2 = Shared.create_el "B" "B" true len st in
+        let el3 = Shared.create_el "C" "C" false len st in
+        let els = [ el1; el2; el3 ] in
+        let counter = API_id.create 0 in
+        let cid1 = API_id.next counter in
+        let cid2 = API_id.next counter in
+        let cid3 = API_id.next counter in
+        let t =
+          ref
+            [
+              Eh.Query_comment_id (el1, Ok None);
+              Eh.Post_comment ([ el1 ], Ok cid1);
+              Eh.Upsert_comment_id ([ el1 ], cid1, Ok ());
+              Eh.Query_comment_id (el3, Ok None);
+              Eh.Post_comment ([ el3 ], Ok cid3);
+              Eh.Upsert_comment_id ([ el3 ], cid3, Ok ());
+              Eh.Query_comment_id (el2, Ok None);
+              Eh.Post_comment ([ el2 ], Ok cid2);
+              Eh.Upsert_comment_id ([ el2 ], cid2, Ok ());
+            ]
+        in
+        Make_wrapper.run t els
+        >>= function
+        | Ok () -> Abb.Future.return ()
+        | Error _ -> assert false)
+  in
+  let multiple_big =
+    Oth_abb.test
+      ~desc:
+        "Given 3 elements with rendered length bigger than the ceiling, but will be compacted to \
+         fit into a single cluster, generate a single comment"
+      ~name:"[Delete] Multiple Big #1"
+      (fun () ->
+        let open Abb.Future.Infix_monad in
+        let module C = Terrat_vcs_comment in
+        let module D = Terrat_dirspace in
+        let module Cm = Terrat_vcs_comment.Make (H) in
+        let len = H.max_comment_length + 1 in
+        let st = C.Strategy.Delete in
+        let el1 = Shared.create_el "A" "A" false len st in
+        let el2 = Shared.create_el "B" "B" true len st in
+        let el3 = Shared.create_el "C" "C" false len st in
+        let els = [ el1; el2; el3 ] in
+        let elsc = CCList.map H.compact [ el1; el3; el2 ] in
+        let counter = API_id.create 0 in
+        let cid1 = API_id.next counter in
+        let t =
+          ref
+            [
+              Eh.Query_comment_id (el1, Ok None);
+              Eh.Query_comment_id (el3, Ok None);
+              Eh.Query_comment_id (el2, Ok None);
+              Eh.Post_comment (elsc, Ok cid1);
+              Eh.Upsert_comment_id (elsc, cid1, Ok ());
+            ]
+        in
+        Make_wrapper.run t els
+        >>= function
+        | Ok r -> Abb.Future.return ()
+        | Error _ -> assert false)
+  in
+  let multiple_mixed =
+    Oth_abb.test
+      ~desc:
+        "Given 4 elements with mixed rendered lengths, get smaller comments into a single cluster, \
+         compact the big ones and also fit them into a smaller cluster"
+      ~name:"[Delete] Mixed #1"
+      (fun () ->
+        let open Abb.Future.Infix_monad in
+        let module C = Terrat_vcs_comment in
+        let module D = Terrat_dirspace in
+        let module Cm = Terrat_vcs_comment.Make (H) in
+        let half = H.max_comment_length / 2 in
+        let st = C.Strategy.Delete in
+        let el1 = Shared.create_el "A" "A" false half st in
+        let el2 = Shared.create_el "B" "B" true (half - 1) st in
+        let el3 = Shared.create_el "C" "C" false (half - 1) st in
+        let el4 = Shared.create_el "D" "D" true (H.max_comment_length + 1) st in
+        let els = [ el1; el2; el3; el4 ] in
+        let el4c = H.compact el4 in
+        let counter = API_id.create 0 in
+        let cid1 = API_id.next counter in
+        let cid2 = API_id.next counter in
+        let t =
+          ref
+            [
+              Eh.Query_comment_id (el1, Ok None);
+              Eh.Query_comment_id (el3, Ok None);
+              Eh.Post_comment ([ el1; el3 ], Ok cid1);
+              Eh.Upsert_comment_id ([ el1; el3 ], cid1, Ok ());
+              Eh.Query_comment_id (el2, Ok None);
+              Eh.Query_comment_id (el4, Ok None);
+              Eh.Post_comment ([ el2; el4c ], Ok cid2);
+              Eh.Upsert_comment_id ([ el2; el4c ], cid2, Ok ());
+            ]
+        in
+        Make_wrapper.run t els
+        >>= function
+        | Ok () -> Abb.Future.return ()
+        | Error _ -> assert false)
+  in
+  Oth_abb.parallel [ multiple_small; multiple_big; multiple_mixed ]
+
+let _test_minimize_strategy =
+  let multiple_small =
+    Oth_abb.test
+      ~desc:
+        "Given 3 elements with rendered length smaller than the ceiling, but that can't be \
+         combined into a single cluster, we will generate 3 comments"
+      ~name:"[Minimize] Multiple Small #1"
+      (fun () ->
+        let open Abb.Future.Infix_monad in
+        let module C = Terrat_vcs_comment in
+        let module D = Terrat_dirspace in
+        let module Cm = Terrat_vcs_comment.Make (H) in
+        let len = H.max_comment_length - 1 in
+        let st = C.Strategy.Minimize in
+        let el1 = Shared.create_el "A" "A" false len st in
+        let el2 = Shared.create_el "B" "B" true len st in
+        let el3 = Shared.create_el "C" "C" false len st in
+        let els = [ el1; el2; el3 ] in
+        let counter = API_id.create 0 in
+        let cid1 = API_id.next counter in
+        let cid2 = API_id.next counter in
+        let cid3 = API_id.next counter in
+        let t =
+          ref
+            [
+              Eh.Query_comment_id (el1, Ok None);
+              Eh.Post_comment ([ el1 ], Ok cid1);
+              Eh.Upsert_comment_id ([ el1 ], cid1, Ok ());
+              Eh.Query_comment_id (el3, Ok None);
+              Eh.Post_comment ([ el3 ], Ok cid3);
+              Eh.Upsert_comment_id ([ el3 ], cid3, Ok ());
+              Eh.Query_comment_id (el2, Ok None);
+              Eh.Post_comment ([ el2 ], Ok cid2);
+              Eh.Upsert_comment_id ([ el2 ], cid2, Ok ());
+            ]
+        in
+        Make_wrapper.run t els
+        >>= function
+        | Ok () -> Abb.Future.return ()
+        | Error _ -> assert false)
+  in
+  let multiple_small_with_old_comment =
+    Oth_abb.test
+      ~desc:
+        "Given 2 elements with rendered length smaller than the ceiling, but that can't be \
+         combined into a single cluster, and 1 comment that is an older version of the first one, \
+         We'll generate two new comments and minimize the old one."
+      ~name:"[Minimize] Multiple Small #2"
+      (fun () ->
+        let open Abb.Future.Infix_monad in
+        let module C = Terrat_vcs_comment in
+        let module D = Terrat_dirspace in
+        let module Cm = Terrat_vcs_comment.Make (H) in
+        let len = H.max_comment_length - 1 in
+        let st = C.Strategy.Minimize in
+        let el1 = Shared.create_el "A" "A" false len st in
+        let el2 = Shared.create_el "B" "B" true len st in
+        let els1 = [ el1; el2 ] in
+        let counter = API_id.create 0 in
+        let cid1 = API_id.next counter in
+        let cid2 = API_id.next counter in
+        let t1 =
+          ref
+            [
+              Eh.Query_comment_id (el1, Ok None);
+              Eh.Post_comment ([ el1 ], Ok cid1);
+              Eh.Upsert_comment_id ([ el1 ], cid1, Ok ());
+              Eh.Query_comment_id (el2, Ok None);
+              Eh.Post_comment ([ el2 ], Ok cid2);
+              Eh.Upsert_comment_id ([ el2 ], cid2, Ok ());
+            ]
+        in
+        Make_wrapper.run t1 els1
+        >>= function
+        | Ok () -> (
+            (* Dirspace A/A is re-run and now evaluates to true *)
+            let el3 = Shared.create_el "A" "A" true len st in
+            (* TODO: Check if we really repost C2 as well? *)
+            let els2 = [ el3; el2 ] in
+            let cid3 = API_id.next counter in
+            let t2 =
+              ref
+                [
+                  (* Check that C1 is already posted, minimize it *)
+                  Eh.Query_comment_id (el3, Ok (Some cid1));
+                  Eh.Minimize_comment (cid1, Ok ());
+                  Eh.Post_comment ([ el3 ], Ok cid3);
+                  Eh.Upsert_comment_id ([ el3 ], cid3, Ok ());
+                  (* Re-Post C2 *)
+                  Eh.Query_comment_id (el2, Ok (Some cid2));
+                  Eh.Minimize_comment (cid2, Ok ());
+                  Eh.Post_comment ([ el2 ], Ok cid2);
+                  Eh.Upsert_comment_id ([ el2 ], cid2, Ok ());
+                ]
+            in
+            Make_wrapper.run t2 els2
+            >>= function
+            | Ok () -> Abb.Future.return ()
+            | Error _ -> assert false)
+        | Error _ -> assert false)
+  in
+  let multiple_big =
+    Oth_abb.test
+      ~desc:
+        "Given 3 elements with rendered length bigger than the ceiling, but that will be compacted \
+         to fit into a single cluster, generate a single comment"
+      ~name:"[Minimize] Multiple Big #1"
+      (fun () ->
+        let open Abb.Future.Infix_monad in
+        let module C = Terrat_vcs_comment in
+        let module D = Terrat_dirspace in
+        let module Cm = Terrat_vcs_comment.Make (H) in
+        let len = H.max_comment_length + 1 in
+        let st = C.Strategy.Minimize in
+        let el1 = Shared.create_el "A" "A" false len st in
+        let el2 = Shared.create_el "B" "B" true len st in
+        let el3 = Shared.create_el "C" "C" false len st in
+        let els = [ el1; el2; el3 ] in
+        let elsc = CCList.map H.compact [ el1; el3; el2 ] in
+        let counter = API_id.create 0 in
+        let cid1 = API_id.next counter in
+        let t =
+          ref
+            [
+              Eh.Query_comment_id (el1, Ok None);
+              Eh.Query_comment_id (el3, Ok None);
+              Eh.Query_comment_id (el2, Ok None);
+              Eh.Post_comment (elsc, Ok cid1);
+              Eh.Upsert_comment_id (elsc, cid1, Ok ());
+            ]
+        in
+        Make_wrapper.run t els
+        >>= function
+        | Ok r -> Abb.Future.return ()
+        | Error _ -> assert false)
+  in
+  let multiple_big_with_old_comment =
+    Oth_abb.test
+      ~desc:
+        "Given 3 elements with rendered length bigger than the ceiling, but that will be compacted \
+         to fit into a single cluster, generate a single comment"
+      ~name:"[Minimize] Multiple Big #2"
+      (fun () ->
+        let open Abb.Future.Infix_monad in
+        let module C = Terrat_vcs_comment in
+        let module D = Terrat_dirspace in
+        let module Cm = Terrat_vcs_comment.Make (H) in
+        let len = H.max_comment_length + 1 in
+        let st = C.Strategy.Minimize in
+        let el1 = Shared.create_el "A" "A" false len st in
+        let el2 = Shared.create_el "B" "B" true len st in
+        let el3 = Shared.create_el "C" "C" false len st in
+        let els1 = [ el1; el2; el3 ] in
+        let elsc = CCList.map H.compact [ el1; el3; el2 ] in
+        let counter = API_id.create 0 in
+        let cid1 = API_id.next counter in
+        let t1 =
+          ref
+            [
+              Eh.Query_comment_id (el1, Ok None);
+              Eh.Query_comment_id (el3, Ok None);
+              Eh.Query_comment_id (el2, Ok None);
+              Eh.Post_comment (elsc, Ok cid1);
+              Eh.Upsert_comment_id (elsc, cid1, Ok ());
+            ]
+        in
+        Make_wrapper.run t1 els1
+        >>= function
+        | Ok () -> (
+            (* Dirspaces A/A and C/C are re-run and now evaluate to true *)
+            let el1t = Shared.create_el "A" "A" true len st in
+            let el3t = Shared.create_el "C" "C" true len st in
+            (* TODO: Check how we are supposed to "assemble" C2 back *)
+            let els2 = [ el1t; el2; el3t ] in
+            let els_expected = [ el1t; el2; el3t ] in
+            let els2c = CCList.map H.compact els_expected in
+            let cid2 = API_id.next counter in
+            let t2 =
+              ref
+                [
+                  (* New Elements, but this does not make sense *)
+                  Eh.Query_comment_id (el1t, Ok None);
+                  Eh.Query_comment_id (el2, Ok (Some cid1));
+                  Eh.Query_comment_id (el3t, Ok None);
+                  (* Minimize old compacted comment *)
+                  Eh.Minimize_comment (cid1, Ok ());
+                  Eh.Post_comment (els2c, Ok cid2);
+                  Eh.Upsert_comment_id (els2c, cid2, Ok ());
+                ]
+            in
+            Make_wrapper.run t2 els2
+            >>= function
+            | Ok () -> Abb.Future.return ()
+            | Error _ -> assert false)
+        | Error _ -> assert false)
+  in
+  let multiple_mixed =
+    Oth_abb.test
+      ~desc:
+        "Given 4 elements with mixed rendered lengths, get smaller comments into a single cluster, \
+         compact the big ones and also fit them into a smaller cluster"
+      ~name:"[Minimize] Mixed #1"
+      (fun () ->
+        let open Abb.Future.Infix_monad in
+        let module C = Terrat_vcs_comment in
+        let module D = Terrat_dirspace in
+        let module Cm = Terrat_vcs_comment.Make (H) in
+        let half = H.max_comment_length / 2 in
+        let st = C.Strategy.Delete in
+        let el1 = Shared.create_el "A" "A" false half st in
+        let el2 = Shared.create_el "B" "B" true (half - 1) st in
+        let el3 = Shared.create_el "C" "C" false (half - 1) st in
+        let el4 = Shared.create_el "D" "D" true (H.max_comment_length + 1) st in
+        let els = [ el1; el2; el3; el4 ] in
+        let el4c = H.compact el4 in
+        let counter = API_id.create 0 in
+        let cid1 = API_id.next counter in
+        let cid2 = API_id.next counter in
+        let t =
+          ref
+            [
+              Eh.Query_comment_id (el1, Ok None);
+              Eh.Query_comment_id (el3, Ok None);
+              Eh.Post_comment ([ el1; el3 ], Ok cid1);
+              Eh.Upsert_comment_id ([ el1; el3 ], cid1, Ok ());
+              Eh.Query_comment_id (el2, Ok None);
+              Eh.Query_comment_id (el4, Ok None);
+              Eh.Post_comment ([ el2; el4c ], Ok cid2);
+              Eh.Upsert_comment_id ([ el2; el4c ], cid2, Ok ());
+            ]
+        in
+        Make_wrapper.run t els
+        >>= function
+        | Ok () -> Abb.Future.return ()
+        | Error _ -> assert false)
+  in
+  Oth_abb.parallel
+    [
+      multiple_small;
+      multiple_small_with_old_comment;
+      multiple_big;
+      multiple_big_with_old_comment;
+      multiple_mixed;
+    ]
+
+let test =
+  Oth_abb.(
+    to_sync_test
+      (parallel
+         [
+           test_basic;
+           test_errors;
+           test_append_strategy;
+         ]))
+
+let () =
+  Random.self_init ();
+  Oth.run test


### PR DESCRIPTION
## Description

- Related to #561 
- `Append` is an option that is supposed to mimic the current comment behavior, while at the same time setting up the plumping for more interesting options to come.

This PR got broken from #562 and only adds the infrastructure to support "Appends" for now.

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (explain):

## Checklist

- [X] I have read the [contributing guidelines](https://github.com/terrateamio/terrateam/blob/main/CONTRIBUTING.md)
- [x] The pull request title follows this format:
      `ISSUE_NUMBER ACTION_TYPE Short description` (e.g., `123 ADD Feature description`)
- [x] I have added tests and documentation (if applicable)
- [ ] My changes generate no new warnings/errors and do not break existing functionality

## Additional context (optional)

<!-- Add any additional context here, e.g., screenshots, dependencies, etc. -->
