### PR TITLE
#718 FIX Drift not respecting tag query when config builder enabled

### DIFF
--- a/code/src/terrat_vcs_event_evaluator/terrat_vcs_event_evaluator.ml
+++ b/code/src/terrat_vcs_event_evaluator/terrat_vcs_event_evaluator.ml
@@ -3568,7 +3568,7 @@ module Make (S : Terrat_vcs_provider2.S) = struct
         <*> Dv.working_branch_ref ctx state
         <*> Dv.matches ctx state `Plan)
       >>= fun (repo_config, base_ref, branch_ref, working_branch_ref, matches) ->
-      let all_matches = CCList.flatten matches.Dv.Matches.all_matches in
+      let all_matches = CCList.flatten matches.Dv.Matches.all_tag_query_matches in
       Abb.Future.return (dirspaceflows_of_changes_with_branch_target repo_config all_matches)
       >>= fun all_dirspaceflows ->
       store_dirspaceflows


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes and the issue it fixes. -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (explain):

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/terrateamio/terrateam/blob/main/CONTRIBUTING.md)
- [x] The pull request title follows this format:
      `ISSUE_NUMBER ACTION_TYPE Short description` (e.g., `123 ADD Feature description`)
- [x] I have added tests and documentation (if applicable)
- [x] My changes generate no new warnings/errors and do not break existing functionality

## Additional context (optional)

<!-- Add any additional context here, e.g., screenshots, dependencies, etc. -->
