### PR TITLE
#752 ADD Changes tab to Apply screen with mobile-responsive layouts a…

### DIFF
--- a/code/src/iris/src/lib/RunDetail.svelte
+++ b/code/src/iris/src/lib/RunDetail.svelte
@@ -98,9 +98,6 @@
     });
   }
   
-  // Keep track of whether we have plan/apply outputs for changes visualization
-  let hasPlanOrApplyOutputs: boolean = false;
-  
   async function loadRunData(runId: string): Promise<void> {
     if (!$selectedInstallation) return;
     

--- a/code/src/iris/src/lib/components/terraform/ApplyChanges.svelte
+++ b/code/src/iris/src/lib/components/terraform/ApplyChanges.svelte
@@ -1,58 +1,57 @@
-<!-- Terraform Plan Changes Component -->
+<!-- Terraform Apply Changes Component -->
 <script lang="ts">
-  // import { onMount } from 'svelte'; // Reserved for future use
   import ResourceDiff from './ResourceDiff.svelte';
   import Card from '../ui/Card.svelte';
   import LoadingSpinner from '../ui/LoadingSpinner.svelte';
-  import { parseTerraformPlan, getPlanSummary } from '../../utils/terraformPlanParser';
+  import { parseTerraformApply, getApplySummary } from '../../utils/terraformApplyParser';
   import type { ParsedPlan } from '../../types/terraform';
 
   // Props
-  export let planOutput: string;
+  export let applyOutput: string;
   export let workManifestId: string = '';
   export let showHeader: boolean = true;
 
   // State
-  let parsedPlan: ParsedPlan | null = null;
+  let parsedApply: ParsedPlan | null = null;
   let isLoading = true;
   let parseError: string | null = null;
 
-  // Parse plan on mount or when planOutput changes
-  $: if (planOutput) {
-    parsePlan();
+  // Parse apply output on mount or when applyOutput changes
+  $: if (applyOutput) {
+    parseApply();
   }
 
-  function parsePlan(): void {
+  function parseApply(): void {
     isLoading = true;
     parseError = null;
     
     try {
-      parsedPlan = parseTerraformPlan(planOutput);
+      parsedApply = parseTerraformApply(applyOutput);
       
-      if (parsedPlan.resources.length === 0) {
-        parseError = 'No resources found in plan output';
+      if (parsedApply.resources.length === 0) {
+        parseError = 'No resource changes found in apply output';
       }
     } catch (error) {
-      console.error('Failed to parse plan:', error);
-      parseError = error instanceof Error ? error.message : 'Failed to parse plan output';
+      console.error('Failed to parse apply output:', error);
+      parseError = error instanceof Error ? error.message : 'Failed to parse apply output';
     } finally {
       isLoading = false;
     }
   }
 </script>
 
-<div class="plan-changes">
+<div class="apply-changes">
   {#if showHeader}
     <div class="header mb-4">
       <h2 class="text-lg sm:text-2xl font-bold text-gray-900 dark:text-white">
-        Plan Changes
+        Apply Changes
         {#if workManifestId}
           <span class="text-gray-500 text-sm sm:text-lg ml-2">#{workManifestId}</span>
         {/if}
       </h2>
-      {#if parsedPlan && !parseError}
+      {#if parsedApply && !parseError}
         <p class="text-sm sm:text-base text-gray-600 dark:text-gray-400 mt-1">
-          {getPlanSummary(parsedPlan)}
+          {getApplySummary(parsedApply)}
         </p>
       {/if}
     </div>
@@ -62,53 +61,53 @@
     <Card padding="lg">
       <div class="flex flex-col items-center justify-center py-12">
         <LoadingSpinner size="lg" />
-        <p class="mt-4 text-gray-600 dark:text-gray-400">Parsing Terraform plan...</p>
+        <p class="mt-4 text-gray-600 dark:text-gray-400">Parsing apply output...</p>
       </div>
     </Card>
   {:else if parseError}
     <Card padding="lg">
       <div class="text-center py-8">
-        <div class="text-red-500 mb-4">
+        <div class="text-yellow-500 mb-4">
           <svg class="w-12 h-12 mx-auto" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" 
                   d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
           </svg>
         </div>
         <h3 class="text-lg font-semibold text-gray-900 dark:text-white mb-2">
-          Unable to Parse Plan
+          Limited Change Details Available
         </h3>
         <p class="text-gray-600 dark:text-gray-400">{parseError}</p>
         <p class="text-sm text-gray-500 dark:text-gray-500 mt-4">
-          Make sure the plan output is in valid Terraform JSON or text format
+          You can still view the full apply output in the "All Steps" or "Raw" tab
         </p>
       </div>
     </Card>
-  {:else if parsedPlan}
+  {:else if parsedApply}
     <!-- Simplified header with Changes count -->
     <div class="mb-4">
       <h3 class="text-base sm:text-lg font-semibold text-gray-900 dark:text-white">
-        Changes ({parsedPlan.changes.total})
+        Applied Changes ({parsedApply.changes.total})
       </h3>
     </div>
 
     <!-- Content Area - Show ResourceDiff directly -->
     <div class="content-area">
       <ResourceDiff 
-        resources={parsedPlan.resources}
-        changes={parsedPlan.changes}
+        resources={parsedApply.resources}
+        changes={parsedApply.changes}
       />
     </div>
   {:else}
     <Card padding="lg">
       <div class="text-center py-8">
-        <p class="text-gray-600 dark:text-gray-400">No plan data available</p>
+        <p class="text-gray-600 dark:text-gray-400">No apply data available</p>
       </div>
     </Card>
   {/if}
 </div>
 
 <style>
-  .plan-changes {
+  .apply-changes {
     width: 100%;
   }
 

--- a/code/src/iris/src/lib/components/terraform/ResourceDiff.svelte
+++ b/code/src/iris/src/lib/components/terraform/ResourceDiff.svelte
@@ -113,71 +113,89 @@ ${changes.map(c => `  ${c.key}: ${formatValue(c.before)} → ${formatValue(c.aft
     link.click();
     URL.revokeObjectURL(url);
   }
+  
+  // Format resource data for display, handling escaped strings
+  function formatResourceData(data: unknown): string {
+    if (!data || typeof data !== 'object') {
+      if (typeof data === 'string') {
+        // Clean up escaped quotes in strings
+        return data.replace(/\\"/g, '"');
+      }
+      return JSON.stringify(data, null, 2);
+    }
+    
+    // Use a custom replacer to clean up escaped quotes
+    return JSON.stringify(data, (key, value) => {
+      if (typeof value === 'string') {
+        // Clean up any escaped quotes
+        return value.replace(/\\"/g, '"');
+      }
+      return value;
+    }, 2);
+  }
 </script>
 
 <div class="resource-diff">
   <!-- Controls -->
   <Card padding="sm">
-    <div class="flex flex-wrap items-center justify-between gap-4">
-      <!-- Search -->
-      <div class="flex items-center gap-2">
-        <div class="relative">
-          <input
-            type="text"
-            placeholder="Search resources..."
-            bind:value={searchQuery}
-            class="pl-10 pr-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg
-                   bg-white dark:bg-gray-800 text-gray-900 dark:text-white
-                   focus:ring-2 focus:ring-brand-primary focus:border-transparent"
-          />
-          <svg class="absolute left-3 top-2.5 w-5 h-5 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-          </svg>
-        </div>
-
-        <!-- Filter buttons -->
-        <div class="flex gap-1">
-          <button
-            class="px-3 py-2 rounded-lg text-sm font-medium transition-colors
-                   {filterType === 'all' ? 'bg-brand-primary text-white' : 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300'}"
-            on:click={() => filterType = 'all'}
-          >
-            All ({resources.length})
-          </button>
-          <button
-            class="px-3 py-2 rounded-lg text-sm font-medium transition-colors
-                   {filterType === 'create' ? 'bg-green-500 text-white' : 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300'}"
-            on:click={() => filterType = 'create'}
-          >
-            Create ({changes.create.length})
-          </button>
-          <button
-            class="px-3 py-2 rounded-lg text-sm font-medium transition-colors
-                   {filterType === 'update' ? 'bg-yellow-500 text-white' : 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300'}"
-            on:click={() => filterType = 'update'}
-          >
-            Update ({changes.update.length})
-          </button>
-          <button
-            class="px-3 py-2 rounded-lg text-sm font-medium transition-colors
-                   {filterType === 'delete' ? 'bg-red-500 text-white' : 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300'}"
-            on:click={() => filterType = 'delete'}
-          >
-            Delete ({changes.delete.length})
-          </button>
-          <button
-            class="px-3 py-2 rounded-lg text-sm font-medium transition-colors
-                   {filterType === 'replace' ? 'bg-purple-500 text-white' : 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300'}"
-            on:click={() => filterType = 'replace'}
-          >
-            Replace ({changes.replace.length})
-          </button>
-        </div>
+    <div class="space-y-4">
+      <!-- Search Bar -->
+      <div class="relative w-full">
+        <input
+          type="text"
+          placeholder="Search resources..."
+          bind:value={searchQuery}
+          class="w-full pl-10 pr-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg
+                 bg-white dark:bg-gray-800 text-gray-900 dark:text-white
+                 focus:ring-2 focus:ring-brand-primary focus:border-transparent"
+        />
+        <svg class="absolute left-3 top-2.5 w-5 h-5 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+        </svg>
       </div>
 
-      <!-- Actions -->
-      <div class="flex items-center gap-2">
-        <label class="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-400">
+      <!-- Filter buttons - Horizontal scroll on mobile -->
+      <div class="flex items-center gap-2 overflow-x-auto pb-2 -mx-2 px-2">
+        <button
+          class="flex-shrink-0 px-3 py-1.5 rounded-lg text-xs sm:text-sm font-medium transition-colors whitespace-nowrap
+                 {filterType === 'all' ? 'bg-brand-primary text-white' : 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300'}"
+          on:click={() => filterType = 'all'}
+        >
+          All ({resources.length})
+        </button>
+        <button
+          class="flex-shrink-0 px-3 py-1.5 rounded-lg text-xs sm:text-sm font-medium transition-colors whitespace-nowrap
+                 {filterType === 'create' ? 'bg-green-500 text-white' : 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300'}"
+          on:click={() => filterType = 'create'}
+        >
+          Create ({changes.create.length})
+        </button>
+        <button
+          class="flex-shrink-0 px-3 py-1.5 rounded-lg text-xs sm:text-sm font-medium transition-colors whitespace-nowrap
+                 {filterType === 'update' ? 'bg-yellow-500 text-white' : 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300'}"
+          on:click={() => filterType = 'update'}
+        >
+          Update ({changes.update.length})
+        </button>
+        <button
+          class="flex-shrink-0 px-3 py-1.5 rounded-lg text-xs sm:text-sm font-medium transition-colors whitespace-nowrap
+                 {filterType === 'delete' ? 'bg-red-500 text-white' : 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300'}"
+          on:click={() => filterType = 'delete'}
+        >
+          Delete ({changes.delete.length})
+        </button>
+        <button
+          class="flex-shrink-0 px-3 py-1.5 rounded-lg text-xs sm:text-sm font-medium transition-colors whitespace-nowrap
+                 {filterType === 'replace' ? 'bg-purple-500 text-white' : 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300'}"
+          on:click={() => filterType = 'replace'}
+        >
+          Replace ({changes.replace.length})
+        </button>
+      </div>
+
+      <!-- Actions - Stack on mobile -->
+      <div class="flex flex-col sm:flex-row sm:items-center gap-2">
+        <label class="flex items-center gap-2 text-xs sm:text-sm text-gray-600 dark:text-gray-400">
           <input
             type="checkbox"
             bind:checked={showOnlyChangedAttributes}
@@ -186,11 +204,12 @@ ${changes.map(c => `  ${c.key}: ${formatValue(c.before)} → ${formatValue(c.aft
           Only show changes
         </label>
         <button
-          class="px-3 py-2 rounded-lg text-sm font-medium bg-gray-100 dark:bg-gray-700 
-                 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600"
+          class="px-3 py-1.5 rounded-lg text-xs sm:text-sm font-medium bg-gray-100 dark:bg-gray-700 
+                 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600
+                 inline-flex items-center justify-center"
           on:click={exportDiff}
         >
-          <svg class="w-4 h-4 inline mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg class="w-4 h-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" 
                   d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
           </svg>
@@ -202,7 +221,7 @@ ${changes.map(c => `  ${c.key}: ${formatValue(c.before)} → ${formatValue(c.aft
 
   <!-- Summary Statistics -->
   {#if filteredResources.length > 0}
-    <div class="mt-4 grid grid-cols-4 gap-4">
+    <div class="mt-4 grid grid-cols-2 sm:grid-cols-4 gap-2 sm:gap-4">
       <Card padding="sm">
         <div class="text-center">
           <div class="text-2xl font-bold text-green-600 dark:text-green-400">
@@ -261,22 +280,22 @@ ${changes.map(c => `  ${c.key}: ${formatValue(c.before)} → ${formatValue(c.aft
             tabindex="0"
           >
             <!-- Resource Header -->
-            <div class="flex items-start justify-between">
-              <div class="flex items-center gap-3">
-                <span class="text-2xl font-bold {getChangeColor(resource.changeType)} px-2 py-1 rounded">
+            <div class="flex items-start justify-between gap-2">
+              <div class="flex items-start gap-2 sm:gap-3 min-w-0 flex-1">
+                <span class="flex-shrink-0 text-lg sm:text-2xl font-bold {getChangeColor(resource.changeType)} px-1.5 sm:px-2 py-0.5 sm:py-1 rounded">
                   {getChangeIcon(resource.changeType)}
                 </span>
-                <div>
-                  <h3 class="font-semibold text-gray-900 dark:text-white">
+                <div class="min-w-0 flex-1">
+                  <h3 class="font-semibold text-sm sm:text-base text-gray-900 dark:text-white break-all">
                     {resource.id}
                   </h3>
-                  <p class="text-sm text-gray-600 dark:text-gray-400">
+                  <p class="text-xs sm:text-sm text-gray-600 dark:text-gray-400">
                     Type: {resource.type} | Provider: {resource.provider}
                   </p>
                 </div>
               </div>
               <svg 
-                class="w-5 h-5 text-gray-400 transform transition-transform
+                class="flex-shrink-0 w-4 h-4 sm:w-5 sm:h-5 text-gray-400 transform transition-transform
                        {selectedResource?.id === resource.id ? 'rotate-180' : ''}"
                 fill="none" 
                 stroke="currentColor" 
@@ -294,7 +313,7 @@ ${changes.map(c => `  ${c.key}: ${formatValue(c.before)} → ${formatValue(c.aft
                     <h4 class="text-sm font-semibold text-gray-700 dark:text-gray-300">New Resource</h4>
                     <div class="bg-green-50 dark:bg-green-900/20 p-3 rounded-lg">
                       <pre class="text-xs text-green-800 dark:text-green-200 overflow-x-auto">
-{JSON.stringify(resource.after, null, 2)}
+{formatResourceData(resource.after)}
                       </pre>
                     </div>
                   </div>
@@ -303,7 +322,7 @@ ${changes.map(c => `  ${c.key}: ${formatValue(c.before)} → ${formatValue(c.aft
                     <h4 class="text-sm font-semibold text-gray-700 dark:text-gray-300">Removed Resource</h4>
                     <div class="bg-red-50 dark:bg-red-900/20 p-3 rounded-lg">
                       <pre class="text-xs text-red-800 dark:text-red-200 overflow-x-auto">
-{JSON.stringify(resource.before, null, 2)}
+{formatResourceData(resource.before)}
                       </pre>
                     </div>
                   </div>
@@ -315,22 +334,22 @@ ${changes.map(c => `  ${c.key}: ${formatValue(c.before)} → ${formatValue(c.aft
                     </h4>
                     {#each getChangedAttributes(resource) as change}
                       <div class="border-l-4 border-yellow-400 pl-4 py-2">
-                        <div class="text-sm font-medium text-gray-900 dark:text-white">
+                        <div class="text-xs sm:text-sm font-medium text-gray-900 dark:text-white break-all">
                           {change.key}
                         </div>
-                        <div class="mt-1 grid grid-cols-2 gap-4">
+                        <div class="mt-1 grid grid-cols-1 sm:grid-cols-2 gap-2 sm:gap-4">
                           <div>
                             <span class="text-xs text-gray-500 dark:text-gray-400">Before:</span>
-                            <div class="mt-1 p-2 bg-red-50 dark:bg-red-900/20 rounded text-xs">
-                              <code class="text-red-700 dark:text-red-300">
+                            <div class="mt-1 p-2 bg-red-50 dark:bg-red-900/20 rounded text-xs overflow-x-auto">
+                              <code class="text-red-700 dark:text-red-300 break-all">
                                 {formatValue(change.before)}
                               </code>
                             </div>
                           </div>
                           <div>
                             <span class="text-xs text-gray-500 dark:text-gray-400">After:</span>
-                            <div class="mt-1 p-2 bg-green-50 dark:bg-green-900/20 rounded text-xs">
-                              <code class="text-green-700 dark:text-green-300">
+                            <div class="mt-1 p-2 bg-green-50 dark:bg-green-900/20 rounded text-xs overflow-x-auto">
+                              <code class="text-green-700 dark:text-green-300 break-all">
                                 {formatValue(change.after)}
                               </code>
                             </div>
@@ -345,7 +364,7 @@ ${changes.map(c => `  ${c.key}: ${formatValue(c.before)} → ${formatValue(c.aft
                       </h4>
                       <div class="bg-gray-50 dark:bg-gray-800 p-3 rounded-lg">
                         <pre class="text-xs text-gray-600 dark:text-gray-400 overflow-x-auto">
-{JSON.stringify(resource.after, null, 2)}
+{formatResourceData(resource.after)}
                         </pre>
                       </div>
                     {/if}

--- a/code/src/iris/src/lib/components/terraform/ResourceDiff.svelte
+++ b/code/src/iris/src/lib/components/terraform/ResourceDiff.svelte
@@ -125,7 +125,7 @@ ${changes.map(c => `  ${c.key}: ${formatValue(c.before)} → ${formatValue(c.aft
     }
     
     // Use a custom replacer to clean up escaped quotes
-    return JSON.stringify(data, (key, value) => {
+    return JSON.stringify(data, (_key, value) => {
       if (typeof value === 'string') {
         // Clean up any escaped quotes
         return value.replace(/\\"/g, '"');

--- a/code/src/iris/src/lib/components/ui/SafeOutput.svelte
+++ b/code/src/iris/src/lib/components/ui/SafeOutput.svelte
@@ -133,11 +133,13 @@
 
 {#if !showContent}
   <!-- Size warning with options -->
-  <div class="border border-yellow-200 bg-yellow-50 rounded-lg p-4">
-    <div class="flex items-start space-x-3">
-      <div class="text-yellow-600 text-xl">⚠️</div>
+  <div class="border border-yellow-200 dark:border-yellow-700 bg-yellow-50 dark:bg-yellow-900/20 rounded-lg p-4">
+    <div class="flex items-start gap-3">
+      <svg class="w-5 h-5 text-yellow-600 dark:text-yellow-400 flex-shrink-0 mt-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+      </svg>
       <div class="flex-1">
-        <h4 class="font-medium text-yellow-800 mb-2">
+        <h4 class="font-medium text-yellow-800 dark:text-yellow-200 mb-2 text-sm sm:text-base">
           {#if isMedium}
             Large Output Detected
           {:else if isLarge}
@@ -146,7 +148,7 @@
             Extremely Large Output Detected
           {/if}
         </h4>
-        <p class="text-sm text-yellow-700 mb-3">
+        <p class="text-xs sm:text-sm text-yellow-700 dark:text-yellow-300 mb-3">
           This {title.toLowerCase()} output is {formatSize(contentSize)}.
           {#if isMedium}
             This is large but should render fine on modern browsers.
@@ -157,38 +159,50 @@
           {/if}
         </p>
         
-        <div class="flex flex-wrap gap-2">
+        <div class="flex flex-col sm:flex-row gap-2">
           {#if !isHuge}
             <button
-              class="px-3 py-1 bg-yellow-600 text-white text-sm rounded hover:bg-yellow-700 transition-colors"
+              class="px-3 py-1.5 bg-yellow-600 dark:bg-yellow-700 text-white text-xs sm:text-sm rounded hover:bg-yellow-700 dark:hover:bg-yellow-800 transition-colors inline-flex items-center justify-center"
               on:click={handleShowContent}
             >
-              📄 Show Preview ({formatSize(Math.min(contentSize, 1000000))})
+              <svg class="w-4 h-4 mr-1.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+              </svg>
+              Show Preview ({formatSize(Math.min(contentSize, 1000000))})
             </button>
           {/if}
           
           <button
-            class="px-3 py-1 bg-green-600 text-white text-sm rounded hover:bg-green-700 transition-colors"
+            class="px-3 py-1.5 bg-green-600 dark:bg-green-700 text-white text-xs sm:text-sm rounded hover:bg-green-700 dark:hover:bg-green-800 transition-colors inline-flex items-center justify-center"
             on:click={handleDownload}
           >
-            💾 Download Output
+            <svg class="w-4 h-4 mr-1.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+            </svg>
+            Download Output
           </button>
           
           {#if githubUrl}
             <button
-              class="px-3 py-1 bg-blue-600 text-white text-sm rounded hover:bg-blue-700 transition-colors"
+              class="px-3 py-1.5 bg-blue-600 dark:bg-blue-700 text-white text-xs sm:text-sm rounded hover:bg-blue-700 dark:hover:bg-blue-800 transition-colors inline-flex items-center justify-center"
               on:click={openGitHubLog}
             >
-              🔗 View in GitHub
+              <svg class="w-4 h-4 mr-1.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+              </svg>
+              View in GitHub
             </button>
           {/if}
           
           {#if !isHuge}
             <button
-              class="px-3 py-1 border border-yellow-300 text-yellow-700 text-sm rounded hover:bg-yellow-100 transition-colors"
+              class="px-3 py-1.5 border border-yellow-300 dark:border-yellow-600 text-yellow-700 dark:text-yellow-300 text-xs sm:text-sm rounded hover:bg-yellow-100 dark:hover:bg-yellow-900/30 transition-colors inline-flex items-center justify-center"
               on:click={handleShowFullContent}
             >
-              ⚡ Load Full Output (Risk: May freeze browser)
+              <svg class="w-4 h-4 mr-1.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z" />
+              </svg>
+              Load Full Output (Risk: May freeze browser)
             </button>
           {/if}
         </div>
@@ -199,30 +213,36 @@
   <!-- Content display -->
   <div class="space-y-3">
     <!-- Header with expand button and size info -->
-    <div class="flex items-center justify-between text-xs text-gray-600 bg-gray-50 px-3 py-2 rounded">
-      <span>
+    <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 text-xs text-gray-600 dark:text-gray-400 bg-gray-50 dark:bg-gray-800 px-3 py-2 rounded">
+      <span class="font-medium">
         {#if isMedium || isLarge || isHuge}
           Size: {formatSize(contentSize)}
         {:else}
           Output:
         {/if}
       </span>
-      <div class="flex items-center space-x-2">
+      <div class="flex items-center gap-2 flex-wrap">
         <button
-          class="text-blue-600 hover:text-blue-800 px-2 py-1 border border-blue-200 rounded hover:bg-blue-50 transition-colors"
+          class="text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 px-3 py-1 border border-blue-200 dark:border-blue-600 rounded hover:bg-blue-50 dark:hover:bg-blue-900/30 transition-colors inline-flex items-center justify-center"
           on:click={handleExpand}
         >
-          🔍 Expand
+          <svg class="w-4 h-4 mr-1 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+          </svg>
+          <span>Expand</span>
         </button>
         <button
-          class="text-green-600 hover:text-green-800 px-2 py-1 border border-green-200 rounded hover:bg-green-50 transition-colors"
+          class="text-green-600 dark:text-green-400 hover:text-green-800 dark:hover:text-green-300 px-3 py-1 border border-green-200 dark:border-green-600 rounded hover:bg-green-50 dark:hover:bg-green-900/30 transition-colors inline-flex items-center justify-center"
           on:click={handleDownload}
         >
-          💾 Download
+          <svg class="w-4 h-4 mr-1 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+          </svg>
+          <span>Download</span>
         </button>
         {#if githubUrl && (isMedium || isLarge || isHuge)}
           <button
-            class="text-blue-600 hover:text-blue-800 underline"
+            class="text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 underline"
             on:click={openGitHubLog}
           >
             View in GitHub
@@ -231,7 +251,7 @@
       </div>
     </div>
     
-    <pre class="text-xs bg-gray-900 text-gray-100 p-3 rounded overflow-x-auto whitespace-pre-wrap font-mono {showFullContent ? '' : 'max-h-96'}">
+    <pre class="text-xs bg-gray-900 dark:bg-gray-950 text-gray-100 dark:text-gray-200 p-3 rounded overflow-x-auto whitespace-pre-wrap font-mono {showFullContent ? '' : 'max-h-96'}">
       {showFullContent ? content : previewContent}
     </pre>
     

--- a/code/src/iris/src/lib/utils/terraformApplyParser.ts
+++ b/code/src/iris/src/lib/utils/terraformApplyParser.ts
@@ -1,0 +1,546 @@
+/**
+ * Terraform Apply Output Parser
+ * Parses Terraform apply outputs to extract resource changes
+ */
+
+import type {
+  ParsedPlan,
+  ResourceNode,
+  ChangeType,
+} from '../types/terraform';
+
+/**
+ * Parse Terraform apply output to extract resource changes
+ */
+export function parseTerraformApply(applyOutput: string): ParsedPlan {
+  if (!applyOutput || applyOutput.trim().length === 0) {
+    return createEmptyPlan();
+  }
+
+  const resources: ResourceNode[] = [];
+  const lines = applyOutput.split('\n');
+  
+  let currentResource: Partial<ResourceNode> | null = null;
+  let currentAttributes: Record<string, unknown> = {};
+  let inResourceBlock = false;
+  let captureMode: 'none' | 'creating' | 'modifying' | 'destroying' | 'reading' = 'none';
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const trimmedLine = line.trim();
+    
+    // Check for resource operation headers
+    // Examples:
+    // "google_compute_instance.this[0]: Creating..."
+    // "aws_instance.example: Modifying... [id=i-1234567890abcdef0]"
+    // "module.vpc.aws_subnet.private[0]: Destroying... [id=subnet-12345]"
+    // "data.aws_ami.ubuntu: Reading..."
+    // "aws_instance.example: Creation complete after 42s [id=i-1234567890abcdef0]"
+    // "aws_instance.example: Modifications complete after 10s [id=i-1234567890abcdef0]"
+    // "aws_instance.example: Destruction complete after 5s"
+    
+    // Check for resource operation start
+    const operationStartMatch = line.match(/^([^:]+):\s+(Creating|Modifying|Destroying|Reading|Refreshing)\.{3}/);
+    if (operationStartMatch) {
+      // Save previous resource if exists
+      if (currentResource && currentResource.id) {
+        resources.push({
+          ...currentResource as ResourceNode,
+          attributes: currentAttributes
+        });
+      }
+      
+      const [, resourceId, operation] = operationStartMatch;
+      const changeType = mapOperationToChangeType(operation);
+      
+      // Extract type and name from resource ID
+      const { type, name } = parseResourceId(resourceId.trim());
+      
+      currentResource = {
+        id: resourceId.trim(),
+        type,
+        name,
+        provider: extractProviderFromType(type),
+        changeType,
+        before: {},
+        after: {},
+      };
+      currentAttributes = {};
+      inResourceBlock = true;
+      captureMode = operation.toLowerCase() as typeof captureMode;
+      
+      // For destroying operations, we'll put any captured info in 'before'
+      if (captureMode === 'destroying') {
+        // Extract ID if present in the same line
+        const idMatch = line.match(/\[id=([^\]]+)\]/);
+        if (idMatch) {
+          currentResource.before!['id'] = idMatch[1];
+          currentAttributes['id'] = idMatch[1];
+        }
+      }
+      continue;
+    }
+    
+    // Check for resource operation completion
+    const completionMatch = line.match(/^([^:]+):\s+(Creation|Modifications?|Destruction|Read)\s+complete/);
+    if (completionMatch) {
+      const [, resourceId] = completionMatch;
+      
+      // If we have a current resource and it matches, update it
+      if (currentResource && currentResource.id === resourceId.trim()) {
+        // Extract any ID from the completion message
+        const idMatch = line.match(/\[id=([^\]]+)\]/);
+        if (idMatch) {
+          currentAttributes['id'] = idMatch[1];
+          // For destroyed resources, the ID goes in 'before', not 'after'
+          if (currentResource.changeType === 'delete') {
+            currentResource.before!['id'] = idMatch[1];
+          } else {
+            currentResource.after!['id'] = idMatch[1];
+          }
+        }
+        
+        // For destroyed resources, provide a meaningful message if no attributes were captured
+        if (currentResource.changeType === 'delete' && Object.keys(currentResource.before!).length === 0) {
+          currentResource.before = {
+            _status: 'Resource was destroyed',
+            _message: 'Details of the destroyed resource are not available in the apply output'
+          };
+          if (idMatch) {
+            currentResource.before['id'] = idMatch[1];
+          }
+        }
+        
+        // Save the resource
+        resources.push({
+          ...currentResource as ResourceNode,
+          attributes: currentAttributes
+        });
+        
+        currentResource = null;
+        currentAttributes = {};
+        inResourceBlock = false;
+        captureMode = 'none';
+      } else if (!currentResource) {
+        // Sometimes we see completion without a start (for quick operations)
+        const [, resourceId, operationType] = completionMatch;
+        const changeType = operationType.startsWith('Creation') ? 'create' :
+                          operationType.startsWith('Modif') ? 'update' :
+                          operationType.startsWith('Destruction') ? 'delete' : 'no-change';
+        
+        const { type, name } = parseResourceId(resourceId.trim());
+        
+        // Extract ID if present
+        const idMatch = line.match(/\[id=([^\]]+)\]/);
+        const attributes: Record<string, unknown> = {};
+        let after: Record<string, unknown> = {};
+        let before: Record<string, unknown> = {};
+        
+        if (idMatch) {
+          attributes['id'] = idMatch[1];
+          if (changeType === 'delete') {
+            before['id'] = idMatch[1];
+            before['_status'] = 'Resource was destroyed';
+          } else {
+            after['id'] = idMatch[1];
+          }
+        } else if (changeType === 'delete') {
+          before = {
+            _status: 'Resource was destroyed',
+            _message: 'Details of the destroyed resource are not available in the apply output'
+          };
+        }
+        
+        resources.push({
+          id: resourceId.trim(),
+          type,
+          name,
+          provider: extractProviderFromType(type),
+          changeType,
+          before,
+          after,
+          attributes
+        });
+      }
+      continue;
+    }
+    
+    // Check for "Still creating/modifying/destroying..." messages
+    if (line.match(/^([^:]+):\s+Still\s+(creating|modifying|destroying)\.{3}/)) {
+      // These are progress messages, we can skip them
+      continue;
+    }
+    
+    // Parse resource attributes during creation/modification/destruction
+    if (inResourceBlock && currentResource) {
+      // Look for attribute lines (usually indented with + or ~ or -)
+      const attrMatch = trimmedLine.match(/^([\+\~\-])\s+(\w+)\s*[:=]\s*(.+)/);
+      if (attrMatch) {
+        let [, indicator, key, value] = attrMatch;
+        
+        // Check if this is the start of a multi-line value (ends with { or [)
+        if (value.trim().endsWith('{') || value.trim().endsWith('[')) {
+          // This is a multi-line value, skip to the closing bracket
+          // For now, we'll just indicate it's a complex object/array
+          if (value.includes('->')) {
+            // Handle patterns like "null -> {" or "{ -> null"
+            const parts = value.split('->').map(p => p.trim());
+            if (parts[0] === 'null' && parts[1] === '{') {
+              value = 'null -> <object>';
+            } else if (parts[0] === '{' && parts[1] === 'null') {
+              value = '<object> -> null';
+            } else if (parts[0] === 'null' && parts[1] === '[') {
+              value = 'null -> <array>';
+            } else if (parts[0] === '[' && parts[1] === 'null') {
+              value = '<array> -> null';
+            } else {
+              value = value.replace('{', '<object>').replace('[', '<array>');
+            }
+          } else {
+            value = value.replace('{', '<object>').replace('[', '<array>');
+          }
+          
+          // Skip lines until we find the closing bracket
+          let bracketCount = 1;
+          let j = i + 1;
+          while (j < lines.length && bracketCount > 0) {
+            const nextLine = lines[j];
+            // Count opening and closing brackets
+            for (const char of nextLine) {
+              if (char === '{' || char === '[') bracketCount++;
+              if (char === '}' || char === ']') bracketCount--;
+            }
+            j++;
+          }
+          i = j - 1; // Skip to the line after the closing bracket
+        }
+        
+        // Check for special patterns first
+        // For destroy: "old_value" -> null
+        // For create: null -> "new_value" 
+        // For update: "old_value" -> "new_value"
+        // Also handle multi-line values that we've simplified to <object> or <array>
+        const destroyMatch = value.match(/^"([^"]*?)"\s*->\s*null$/);
+        const createMatch = value.match(/^null\s*->\s*"([^"]*?)"$/);
+        const quotedChangeMatch = value.match(/^"([^"]*?)"\s*->\s*"([^"]*?)"$/);
+        const simpleDestroyMatch = value.match(/^([^\s]+)\s*->\s*null$/);
+        const simpleCreateMatch = value.match(/^null\s*->\s*(\S+)$/);
+        const objectCreateMatch = value.match(/^null\s*->\s*<(object|array)>$/);
+        const objectDestroyMatch = value.match(/^<(object|array)>\s*->\s*null$/);
+        
+        if (indicator === '+' || captureMode === 'creating') {
+          if (createMatch) {
+            currentResource.after![key] = createMatch[1];
+            currentAttributes[key] = createMatch[1];
+          } else if (objectCreateMatch) {
+            currentResource.before![key] = null;
+            currentResource.after![key] = `{...}`;
+            currentAttributes[key] = `{...}`;
+          } else {
+            const cleanValue = parseAttributeValue(value);
+            currentResource.after![key] = cleanValue;
+            currentAttributes[key] = cleanValue;
+          }
+        } else if (indicator === '-' || captureMode === 'destroying') {
+          if (destroyMatch) {
+            currentResource.before![key] = destroyMatch[1];
+            currentAttributes[key] = destroyMatch[1];
+          } else if (objectDestroyMatch) {
+            currentResource.before![key] = `{...}`;
+            currentResource.after![key] = null;
+            currentAttributes[key] = `{...}`;
+          } else if (simpleDestroyMatch && simpleDestroyMatch[1] !== 'null') {
+            currentResource.before![key] = parseAttributeValue(simpleDestroyMatch[1]);
+            currentAttributes[key] = parseAttributeValue(simpleDestroyMatch[1]);
+          } else {
+            const cleanValue = parseAttributeValue(value);
+            currentResource.before![key] = cleanValue;
+            currentAttributes[key] = cleanValue;
+          }
+        } else if (indicator === '~' || captureMode === 'modifying') {
+          // For modifications, we might see old -> new format
+          if (destroyMatch) {
+            currentResource.before![key] = destroyMatch[1];
+            currentResource.after![key] = null;
+          } else if (createMatch) {
+            currentResource.before![key] = null;
+            currentResource.after![key] = createMatch[1];
+          } else if (objectCreateMatch) {
+            currentResource.before![key] = null;
+            currentResource.after![key] = `{...}`;
+          } else if (objectDestroyMatch) {
+            currentResource.before![key] = `{...}`;
+            currentResource.after![key] = null;
+          } else if (quotedChangeMatch) {
+            currentResource.before![key] = quotedChangeMatch[1];
+            currentResource.after![key] = quotedChangeMatch[2];
+          } else if (simpleDestroyMatch && simpleDestroyMatch[1] !== 'null') {
+            currentResource.before![key] = parseAttributeValue(simpleDestroyMatch[1]);
+            currentResource.after![key] = null;
+          } else if (simpleCreateMatch) {
+            currentResource.before![key] = null;
+            currentResource.after![key] = parseAttributeValue(simpleCreateMatch[1]);
+          } else {
+            // Try general unquoted change pattern: old -> new
+            const unquotedChangeMatch = value.match(/^([^\s]+)\s*->\s*(.+)$/);
+            if (unquotedChangeMatch) {
+              currentResource.before![key] = parseAttributeValue(unquotedChangeMatch[1]);
+              currentResource.after![key] = parseAttributeValue(unquotedChangeMatch[2]);
+            } else {
+              // Single value change, put it in after
+              currentResource.after![key] = parseAttributeValue(value);
+            }
+          }
+          // Store the final value in attributes
+          currentAttributes[key] = currentResource.after?.[key] || currentResource.before?.[key];
+        }
+      }
+      
+      // Also look for simple attribute format without indicators
+      const simpleAttrMatch = trimmedLine.match(/^(\w+)\s*[:=]\s*(.+)/);
+      if (simpleAttrMatch && !attrMatch) {
+        const [, key, value] = simpleAttrMatch;
+        const cleanValue = parseAttributeValue(value);
+        currentAttributes[key] = cleanValue;
+        
+        if (captureMode === 'creating') {
+          currentResource.after![key] = cleanValue;
+        } else if (captureMode === 'modifying') {
+          currentResource.after![key] = cleanValue;
+        } else if (captureMode === 'destroying') {
+          // For destroying, attributes go in 'before'
+          currentResource.before![key] = cleanValue;
+        }
+      }
+    }
+    
+    // Check for apply summary
+    if (line.startsWith('Apply complete!') || line.includes('Resources:')) {
+      // Save last resource if exists
+      if (currentResource && currentResource.id) {
+        resources.push({
+          ...currentResource as ResourceNode,
+          attributes: currentAttributes
+        });
+        currentResource = null;
+      }
+      
+      // Parse the summary if present
+      // Example: "Apply complete! Resources: 3 added, 1 changed, 2 destroyed."
+      const summaryMatch = line.match(/(\d+)\s+added|(\d+)\s+changed|(\d+)\s+destroyed/g);
+      if (summaryMatch) {
+        // We could use this to validate our parsing
+      }
+    }
+  }
+  
+  // Save last resource if not already saved
+  if (currentResource && currentResource.id) {
+    resources.push({
+      ...currentResource as ResourceNode,
+      attributes: currentAttributes
+    });
+  }
+  
+  // Calculate change set
+  const changes = calculateChangeSet(resources);
+  
+  return {
+    resources,
+    changes
+  };
+}
+
+/**
+ * Parse resource ID to extract type and name
+ */
+function parseResourceId(resourceId: string): { type: string; name: string } {
+  // Handle module resources: module.vpc.aws_subnet.private[0]
+  // Handle data resources: data.aws_ami.ubuntu
+  // Handle regular resources: aws_instance.example
+  
+  let cleanId = resourceId;
+  
+  // Remove "data." prefix if present
+  if (cleanId.startsWith('data.')) {
+    cleanId = cleanId.substring(5);
+  }
+  
+  // Remove "module." prefix and module name if present
+  if (cleanId.startsWith('module.')) {
+    const parts = cleanId.split('.');
+    // Skip "module" and the module name, keep the rest
+    cleanId = parts.slice(2).join('.');
+  }
+  
+  // Now we should have something like: aws_instance.example or aws_instance.example[0]
+  const parts = cleanId.split('.');
+  
+  if (parts.length >= 2) {
+    // First part is the resource type
+    const type = parts[0];
+    // Rest is the name (including any array indices)
+    const name = parts.slice(1).join('.');
+    return { type, name };
+  }
+  
+  // Fallback: treat the whole thing as the type
+  return { type: cleanId, name: '' };
+}
+
+/**
+ * Map operation text to change type
+ */
+function mapOperationToChangeType(operation: string): ChangeType {
+  switch (operation.toLowerCase()) {
+    case 'creating':
+      return 'create';
+    case 'modifying':
+    case 'refreshing':
+      return 'update';
+    case 'destroying':
+      return 'delete';
+    case 'reading':
+      return 'no-change';
+    default:
+      return 'no-change';
+  }
+}
+
+/**
+ * Extract provider from resource type
+ */
+function extractProviderFromType(type: string): string {
+  const parts = type.split('_');
+  return parts[0] || 'unknown';
+}
+
+/**
+ * Parse attribute value from text
+ */
+function parseAttributeValue(value: string): unknown {
+  value = value.trim();
+  
+  // This function should NOT receive "value" -> null patterns anymore
+  // Those are handled by the calling code
+  
+  // Remove quotes if present
+  if ((value.startsWith('"') && value.endsWith('"')) || 
+      (value.startsWith("'") && value.endsWith("'"))) {
+    // Remove outer quotes
+    return value.slice(1, -1);
+  }
+  
+  // Parse booleans
+  if (value === 'true') return true;
+  if (value === 'false') return false;
+  
+  // Parse numbers
+  if (/^\d+$/.test(value)) return parseInt(value, 10);
+  if (/^\d+\.\d+$/.test(value)) return parseFloat(value);
+  
+  // Parse arrays/lists
+  if (value.startsWith('[') && value.endsWith(']')) {
+    try {
+      return JSON.parse(value);
+    } catch {
+      return value;
+    }
+  }
+  
+  // Parse objects/maps
+  if (value.startsWith('{') && value.endsWith('}')) {
+    try {
+      return JSON.parse(value);
+    } catch {
+      return value;
+    }
+  }
+  
+  // Remove "known after apply" and similar placeholders
+  if (value.includes('known after apply')) {
+    return '<computed>';
+  }
+  
+  return value;
+}
+
+/**
+ * Calculate change set from resources
+ */
+function calculateChangeSet(resources: ResourceNode[]) {
+  const changes = {
+    create: [] as ResourceNode[],
+    update: [] as ResourceNode[],
+    delete: [] as ResourceNode[],
+    replace: [] as ResourceNode[],
+    unchanged: [] as ResourceNode[],
+    total: resources.length
+  };
+
+  for (const resource of resources) {
+    switch (resource.changeType) {
+      case 'create':
+        changes.create.push(resource);
+        break;
+      case 'update':
+        changes.update.push(resource);
+        break;
+      case 'delete':
+        changes.delete.push(resource);
+        break;
+      case 'replace':
+        changes.replace.push(resource);
+        break;
+      case 'no-change':
+        changes.unchanged.push(resource);
+        break;
+    }
+  }
+
+  return changes;
+}
+
+/**
+ * Create an empty plan structure
+ */
+function createEmptyPlan(): ParsedPlan {
+  return {
+    resources: [],
+    changes: {
+      create: [],
+      update: [],
+      delete: [],
+      replace: [],
+      unchanged: [],
+      total: 0
+    }
+  };
+}
+
+/**
+ * Get a summary of the apply results
+ */
+export function getApplySummary(plan: ParsedPlan): string {
+  const { changes } = plan;
+  const parts: string[] = [];
+  
+  if (changes.create.length > 0) {
+    parts.push(`${changes.create.length} added`);
+  }
+  if (changes.update.length > 0) {
+    parts.push(`${changes.update.length} changed`);
+  }
+  if (changes.delete.length > 0) {
+    parts.push(`${changes.delete.length} destroyed`);
+  }
+  if (changes.replace.length > 0) {
+    parts.push(`${changes.replace.length} replaced`);
+  }
+  
+  if (parts.length === 0) {
+    return 'No changes applied';
+  }
+  
+  return parts.join(', ');
+}


### PR DESCRIPTION
…nd improved Terraform output parsing

## Description

This change adds a "Changes" tab to the Apply screen that parses and displays Terraform apply outputs in a structured, user-friendly format - similar to the existing Changes tab on the Plan screen.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (explain):

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/terrateamio/terrateam/blob/main/CONTRIBUTING.md)
- [x] The pull request title follows this format:
      `ISSUE_NUMBER ACTION_TYPE Short description` (e.g., `123 ADD Feature description`)
- [x] I have added tests and documentation (if applicable)
- [x] My changes generate no new warnings/errors and do not break existing functionality

## Additional context (optional)

<!-- Add any additional context here, e.g., screenshots, dependencies, etc. -->
