### PR TITLE
#755 REFACTOR make custom engine docs accurate

### DIFF
--- a/docs/src/content/docs/advanced-workflows/engine.mdx
+++ b/docs/src/content/docs/advanced-workflows/engine.mdx
@@ -48,45 +48,45 @@ engine:
 
 Use a custom engine when you need to perform tasks outside of standard Terraform or OpenTofu workflows, or when integrating with other infrastructure tools (e.g., custom wrappers, or legacy systems).
 
-:::note[About TERRATEAM_PLAN_FILE]
-When using a custom engine, Terrateam sets the `TERRATEAM_PLAN_FILE` environment variable to the path where your plan step must write the plan file. This is the only required environment variable that must be written to by your custom plan step. Terrateam will use this file for subsequent apply and diff steps. The file must be created, but it can be empty.
+:::note[No Required Steps]
+Custom engine does not require any specific steps - all steps are optional. You can define only the steps you need for your workflow. The `TERRATEAM_PLAN_FILE` environment variable is available in the apply phase if your plan step writes to it.
 :::
 
 ### Example: Custom Engine
 
-Below is an example configuration for a custom engine. Each key corresponds to a step in the Terrateam workflow. Only `plan` is required; others are optional.
+Below is an example configuration for a custom engine. Each key corresponds to a step in the Terrateam workflow. All steps are optional - define only what you need.
 
 ```yaml
 engine:
   name: custom
   # The command to run during the init step (optional)
   init: ['echo', 'init']
-  # The command to run during the plan step (required)
-  # Must write the plan to the file specified by $TERRATEAM_PLAN_FILE
-  plan: ['touch', '$TERRATEAM_PLAN_FILE']
+  # The command to run during the plan step (optional)
+  plan: ['my-custom-plan']
   # The command to produce a human-readable diff of the plan output (optional)
   diff: ['printf', '+ added foo\n- removed bar\n~ updated bar\n']
   # The command to run during the apply step (optional)
-  apply: ['cat', 'foo.txt']
+  apply: ['my-custom-apply']
   # The command to return output values as a JSON string (optional)
   outputs: ['echo', '{"foo": "bar"}']
 ```
 
 **Highlights:**
-- `plan`: Must write the plan to the file specified by `$TERRATEAM_PLAN_FILE`.
-- `init`, `diff`, `apply`, `outputs`: Optional, provide additional control over workflow steps.
-- Use this pattern to integrate with any tool or process that can produce a compatible plan file.
+- All steps (`init`, `plan`, `diff`, `apply`, `outputs`) are optional
+- Define only the steps that make sense for your use case
+- `$TERRATEAM_PLAN_FILE` environment variable is available to pass data from plan to apply
+- Use this pattern to integrate with any tool or custom process
 
 ### How It Works
 Each key corresponds to a step in the Terrateam workflow:
 
 * `init` The command to run during the init step. Optional.
-* `plan` The command to run during the plan step. Must write to the path specified by the `TERRATEAM_PLAN_FILE` environment variable. Required.
+* `plan` The command to run during the plan step. Optional.
 * `diff` The command to produce a human-readable diff of the plan output. Optional.
 * `apply` The command to run during the apply step. Optional.
 * `outputs` The command to return output values as a JSON string. Optional.
 
-Only define the steps that make sense for your use case. All others can be omitted.
+All steps are optional - you can define any combination of steps that makes sense for your use case.
 
 :::note
 The exit code of the `plan` script is important.  Custom engine uses the OpenTofu detailed exit code standard in that an exit code of `0` means there are changes in the plan and `2` means the plan was successful but there are no changes.  Any other exit code is considered a failure.

--- a/docs/src/content/docs/configuration-reference/engine.mdx
+++ b/docs/src/content/docs/configuration-reference/engine.mdx
@@ -21,7 +21,7 @@ engine:
 | tf_version | String | The version of the Terraform or OpenTofu CLI to use when `engine.name` is set to `terragrunt` or `cdktf`. Default is `latest`. |
 | tf_cmd | String | The command to use for `terragrunt` or `cdktf` executions. Can be `terraform` or `tofu`. Default is `terraform`. |
 | init | Array | *(Custom engine only)* The command to run during the init step. Optional. |
-| plan | Array | *(Custom engine only)* The command to run during the plan step. Must write to the path specified by the `TERRATEAM_PLAN_FILE` environment variable. Required. |
+| plan | Array | *(Custom engine only)* The command to run during the plan step. The `TERRATEAM_PLAN_FILE` environment variable is available to write a plan file that will be accessible in the apply step. Optional. |
 | diff | Array | *(Custom engine only)* The command to produce a human-readable diff of the plan output. Optional. |
 | apply | Array | *(Custom engine only)* The command to run during the apply step. Optional. |
 | outputs | Array | *(Custom engine only)* The command to return output values as a JSON string. Optional. |
@@ -72,12 +72,12 @@ engine:
 engine:
   name: custom
   init: ['echo', 'init']
-  plan: ['touch', '$TERRATEAM_PLAN_FILE']
+  plan: ['my-custom-plan']
   diff: ['printf', '+ added foo\n- removed bar\n~ updated baz\n']
-  apply: ['cat', 'foo.txt']
+  apply: ['my-custom-apply']
   outputs: ['echo', '{"foo": "bar"}']
 ```
-This configuration defines a fully custom engine using shell commands for each step.
+This configuration defines a fully custom engine using shell commands for each step. All steps are optional - you can define only what you need.
 
 ## Considerations
 When configuring `engine`, keep the following in mind:
@@ -86,4 +86,4 @@ When configuring `engine`, keep the following in mind:
 - The `terragrunt` engine uses Terragrunt, a thin wrapper for Terraform that provides extra tools for keeping your configurations DRY, working with multiple Terraform modules, and managing remote state.
 - The `cdktf` engine uses CDKTF (Cloud Development Kit for Terraform), which allows you to define your infrastructure using familiar programming languages like TypeScript, Python, Go, and Java.
 - When using `terragrunt` or `cdktf`, you can specify the version of Terraform or OpenTofu CLI to use with the `tf_version` option. This allows you to control the underlying Terraform version independently of the Terragrunt or CDKTF version.
-- The `custom` engine allows full control over each step in the pipeline. You may specify only the steps relevant to your use case. For `plan`, you must write output to `TERRATEAM_PLAN_FILE`. The `outputs` step must return valid JSON.
+- The `custom` engine allows full control over each step in the pipeline. All steps are optional - you may specify only the steps relevant to your use case. The `TERRATEAM_PLAN_FILE` environment variable allows passing data from the plan step to the apply step. The `outputs` step, if defined, must return valid JSON.


### PR DESCRIPTION
## Description

Some of the custom docs are not accurate. Fix.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Other (explain):

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/terrateamio/terrateam/blob/main/CONTRIBUTING.md)
- [x] The pull request title follows this format:
      `ISSUE_NUMBER ACTION_TYPE Short description` (e.g., `123 ADD Feature description`)
- [x] I have added tests and documentation (if applicable)
- [x] My changes generate no new warnings/errors and do not break existing functionality

## Additional context (optional)

<!-- Add any additional context here, e.g., screenshots, dependencies, etc. -->
