### PR TITLE
#784 ADD Update env label and make repo name clickable

### DIFF
--- a/code/src/iris/src/lib/Analytics.svelte
+++ b/code/src/iris/src/lib/Analytics.svelte
@@ -2,7 +2,7 @@
   import { onMount } from 'svelte';
   // Auth handled by PageLayout
   import { api } from './api';
-  import { selectedInstallation } from './stores';
+  import { selectedInstallation, currentVCSProvider } from './stores';
   import { repositoryService } from './services/repository-service';
   import PageLayout from './components/layout/PageLayout.svelte';
   import Card from './components/ui/Card.svelte';
@@ -1069,7 +1069,7 @@
                 <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Success Rate</th>
                 <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Avg Duration</th>
                 <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Last Activity</th>
-                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Environments</th>
+                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{$currentVCSProvider === 'gitlab' ? 'GitLab' : 'GitHub'} Environments</th>
               </tr>
             </thead>
             <tbody class="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
@@ -1800,7 +1800,7 @@
                         </div>
                         {#if drift.environment}
                           <div class="flex justify-between">
-                            <span class="text-gray-600 dark:text-gray-400">Environment:</span>
+                            <span class="text-gray-600 dark:text-gray-400">{$currentVCSProvider === 'gitlab' ? 'GitLab' : 'GitHub'} Environment:</span>
                             <span class="font-mono text-gray-900 dark:text-gray-100">{drift.environment}</span>
                           </div>
                         {/if}

--- a/code/src/iris/src/lib/Configuration.svelte
+++ b/code/src/iris/src/lib/Configuration.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   // Auth handled by PageLayout
   import PageLayout from './components/layout/PageLayout.svelte';
-  import { selectedInstallation, installations } from './stores';
+  import { selectedInstallation, installations, currentVCSProvider } from './stores';
   import { Icon } from './components';
   import hljs from 'highlight.js/lib/core';
   import yamlLang from 'highlight.js/lib/languages/yaml';
@@ -466,7 +466,7 @@
                     </li>
                     <li class="text-sm text-gray-600 dark:text-gray-400 flex items-start">
                       <span class="text-green-500 mr-2 mt-0.5">✓</span>
-                      <span>Multi-environment support</span>
+                      <span>Multi-{$currentVCSProvider === 'gitlab' ? 'GitLab environment' : 'GitHub environment'} support</span>
                     </li>
                     <li class="text-sm text-gray-600 dark:text-gray-400 flex items-start">
                       <span class="text-green-500 mr-2 mt-0.5">✓</span>
@@ -890,7 +890,7 @@
                   </div>
                 </div>
 
-                <!-- Multiple Environments -->
+                <!-- Multiple {$currentVCSProvider === 'gitlab' ? 'GitLab' : 'GitHub'} Environments -->
                 <div>
                   <button
                     on:click={() => configOptions = { ...configOptions, multipleEnvironments: !configOptions.multipleEnvironments }}
@@ -905,14 +905,14 @@
                         <div class="flex items-center">
                           <div class="text-lg mr-3">🏗️</div>
                           <div class="flex items-center gap-3">
-                            <span class="text-sm font-medium">Multiple Environments</span>
+                            <span class="text-sm font-medium">Multiple {$currentVCSProvider === 'gitlab' ? 'GitLab' : 'GitHub'} Environments</span>
                             <a 
                               href="https://docs.terrateam.io/advanced-workflows/multiple-environments/"
                               target="_blank"
                               rel="noopener noreferrer"
                               on:click|stopPropagation
                               class="text-gray-400 hover:text-blue-600 dark:hover:text-blue-400 transition-colors"
-                              title="Learn more about Multiple Environments (opens in new tab)"
+                              title="Learn more about Multiple {$currentVCSProvider === 'gitlab' ? 'GitLab' : 'GitHub'} Environments (opens in new tab)"
                             >
                               <Icon icon="mdi:open-in-new" width="16" height="16" />
                             </a>

--- a/code/src/iris/src/lib/Repositories.svelte
+++ b/code/src/iris/src/lib/Repositories.svelte
@@ -514,7 +514,13 @@
                   </div>
                   <div class="ml-4 min-w-0 flex-1">
                     <div class="flex items-center">
-                      <h3 class="text-base md:text-lg font-medium text-gray-900 dark:text-gray-100 truncate">{repo.name}</h3>
+                      <button
+                        on:click={() => handleRepoClick(repo)}
+                        class="text-base md:text-lg font-medium text-gray-900 dark:text-gray-100 hover:text-blue-600 dark:hover:text-blue-400 truncate text-left transition-colors cursor-pointer"
+                        aria-label="View {repo.name} details"
+                      >
+                        {repo.name}
+                      </button>
                     </div>
                     {#if repo.setup}
                       <div class="mt-1 flex items-center text-sm text-green-600 dark:text-green-400">

--- a/code/src/iris/src/lib/RunDetail.svelte
+++ b/code/src/iris/src/lib/RunDetail.svelte
@@ -828,7 +828,7 @@
           </h2>
           <div class="flex flex-col sm:flex-row sm:items-center sm:space-x-4 space-y-1 sm:space-y-0 text-sm text-gray-600 dark:text-gray-400">
             <span>Dirspaces: <span class="font-medium">{run.dirspaces.length}</span></span>
-            <span>Environment: <span class="font-medium">{run.environment || 'default'}</span></span>
+            <span>{$currentVCSProvider === 'gitlab' ? 'GitLab' : 'GitHub'} Environment: <span class="font-medium">{run.environment || 'default'}</span></span>
           </div>
         </div>
         <div class="flex flex-col items-start lg:items-end space-y-2">

--- a/code/src/iris/src/lib/Runs.svelte
+++ b/code/src/iris/src/lib/Runs.svelte
@@ -1767,7 +1767,7 @@
 
                 <!-- Environment Filter -->
                 <div>
-                  <label for="environment-filter" class="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">Environment</label>
+                  <label for="environment-filter" class="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">{$currentVCSProvider === 'gitlab' ? 'GitLab' : 'GitHub'} Environment</label>
                   <input
                     id="environment-filter"
                     type="text"
@@ -1892,8 +1892,8 @@
                           <div><code class="bg-white dark:bg-gray-800 px-2 py-1 rounded border border-gray-200 dark:border-gray-600 text-gray-900 dark:text-gray-100">branch:main</code> - Operations on main branch</div>
                           <div><code class="bg-white dark:bg-gray-800 px-2 py-1 rounded border border-gray-200 dark:border-gray-600 text-gray-900 dark:text-gray-100">workspace:production</code> - Operations in production workspace</div>
                           <div><code class="bg-white dark:bg-gray-800 px-2 py-1 rounded border border-gray-200 dark:border-gray-600 text-gray-900 dark:text-gray-100">dir:infra/s3</code> - Operations that processed the infra/s3 directory</div>
-                          <div><code class="bg-white dark:bg-gray-800 px-2 py-1 rounded border border-gray-200 dark:border-gray-600 text-gray-900 dark:text-gray-100">environment:production</code> - Operations in production environment</div>
-                          <div><code class="bg-white dark:bg-gray-800 px-2 py-1 rounded border border-gray-200 dark:border-gray-600 text-gray-900 dark:text-gray-100">environment:</code> - Operations with no environment specified</div>
+                          <div><code class="bg-white dark:bg-gray-800 px-2 py-1 rounded border border-gray-200 dark:border-gray-600 text-gray-900 dark:text-gray-100">environment:production</code> - Operations in production {$currentVCSProvider === 'gitlab' ? 'GitLab' : 'GitHub'} environment</div>
+                          <div><code class="bg-white dark:bg-gray-800 px-2 py-1 rounded border border-gray-200 dark:border-gray-600 text-gray-900 dark:text-gray-100">environment:</code> - Operations with no {$currentVCSProvider === 'gitlab' ? 'GitLab' : 'GitHub'} environment specified</div>
                         </div>
                       </div>
                       

--- a/code/src/iris/src/lib/WorkspaceDetail.svelte
+++ b/code/src/iris/src/lib/WorkspaceDetail.svelte
@@ -443,7 +443,7 @@
             <div class="space-y-1">
               <div class="truncate"><span class="text-gray-600 dark:text-gray-400">Owner:</span> <span class="font-mono">{workspace.owner}</span></div>
               <div class="truncate"><span class="text-gray-600 dark:text-gray-400">Repo:</span> <span class="font-mono">{workspace.repo}</span></div>
-              <div class="truncate"><span class="text-gray-600 dark:text-gray-400">Environment:</span> <span class="font-mono">{workspace.environment || 'default'}</span></div>
+              <div class="truncate"><span class="text-gray-600 dark:text-gray-400">{$currentVCSProvider === 'gitlab' ? 'GitLab' : 'GitHub'} Environment:</span> <span class="font-mono">{workspace.environment || 'default'}</span></div>
             </div>
           </div>
           <div>

--- a/code/src/iris/src/lib/Workspaces.svelte
+++ b/code/src/iris/src/lib/Workspaces.svelte
@@ -527,7 +527,7 @@
                       
                       <div class="grid grid-cols-1 sm:grid-cols-3 gap-2 md:gap-4 text-xs md:text-sm text-gray-600 dark:text-gray-400">
                         <div class="truncate">
-                          <span class="font-medium">Environment:</span>
+                          <span class="font-medium">{$currentVCSProvider === 'gitlab' ? 'GitLab' : 'GitHub'} Environment:</span>
                           <span class="ml-1">{workspace.environment || 'default'}</span>
                         </div>
                         <div class="truncate">


### PR DESCRIPTION
## Description

Environment → GitHub/GitLab Environment: Update label to be more precise.
Repositories screen: Repository names should be clickable to allow quick access to details.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (explain):

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/terrateamio/terrateam/blob/main/CONTRIBUTING.md)
- [x] The pull request title follows this format:
      `ISSUE_NUMBER ACTION_TYPE Short description` (e.g., `123 ADD Feature description`)
- [x] I have added tests and documentation (if applicable)
- [x] My changes generate no new warnings/errors and do not break existing functionality

## Additional context (optional)

<!-- Add any additional context here, e.g., screenshots, dependencies, etc. -->
