### PR TITLE
#792 FIX update terrateam config jsonschema from draft-04 to draft-07

### DIFF
--- a/api_schemas/terrat/config-schema.json
+++ b/api_schemas/terrat/config-schema.json
@@ -1,6 +1,6 @@
 {
   "$ref": "#/definitions/version-1",
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "access-control": {
       "additionalProperties": false,


### PR DESCRIPTION
## Description

This updates the config-schema.json jsonschema file to use draft-07 instead of draft-04. It is the only schema defined with draft-04, every other in the project is draft-07. It uses a feature that does not work in draft-04, and once changed to draft-07, passes the draft-07 validation meta-schema.

```
$ check-jsonschema --schemafile <(curl https://json-schema.org/draft-07/schema 2>/dev/null) terrat/config-schema.json
ok -- validation done
```

```
$ git co main
Switched to branch 'main'
Your branch is up to date with 'origin/main'.
$ rg -HIo 'draft-0\d' . | sort | uniq -c
      1 draft-04
    318 draft-07
```

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (explain):

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/terrateamio/terrateam/blob/main/CONTRIBUTING.md)
- [x] The pull request title follows this format:
      `ISSUE_NUMBER ACTION_TYPE Short description` (e.g., `123 ADD Feature description`)
- [x] I have added tests and documentation (if applicable)
- [x] My changes generate no new warnings/errors and do not break existing functionality

## Additional context (optional)

I hit this when trying to use config_builder and getting an error that was never returned with a static config file. The error it reported was from a stanza that my script doesn't modify from the static config input (aside, does this mean there are different validations of the final config when using a static config or config_builder?)

```
Key
.workflows.0.apply.3

Error
{"extra_args":["-backend-config=config/${TERRATEAM_WORKSPACE}/backend.conf","-var-file=config/${TERRATEAM_WORKSPACE}/variables.tfvars"],"type":"init"} is valid under more than one of the schemas listed in the 'oneOf' keyword
```

The schemas its matching multiples of rely on the value of the "type" property to be matched uniquely. 
```
        "type": {
          "const": "init",
          "type": "string"
        }
```

But ["const" was only introduced in draft-06](https://www.learnjsonschema.com/2020-12/validation/const/). Changing to draft-07 to match the rest of the repo or using a single-value enum both fix the issue, so the latter is the fallback if this can't be bumped to 07 for some reason.

```
$ cat json
{
  "type": "apply"
}

$ cat schema
{
  "$schema": "http://json-schema.org/draft-04/schema#",
  "type": "object",
  "properties": {
    "type": {
      "const": "init"
    }
  }
}
$ check-jsonschema --schemafile schema json  
ok -- validation done    # incorrect, false-pass

-------------------------------------------------------
$ cat schema
{
  "$schema": "http://json-schema.org/draft-07/schema#",
  "type": "object",
  "properties": {
    "type": {
      "const": "init"
    }
  }
}

$ check-jsonschema --schemafile schema json
Schema validation errors were encountered.
  json::$.type: 'init' was expected

-------------------------------------------------------
$ cat schema
{
  "$schema": "http://json-schema.org/draft-04/schema#",
  "type": "object",
  "properties": {
    "type": {
      "enum": ["init"]
    }
  }
}

$ check-jsonschema --schemafile schema json
Schema validation errors were encountered.
  json::$.type: 'apply' is not one of ['init']
```
