### PR TITLE
#840 FIX Do not consider a drift schedule missing if it is 'queued'

### DIFF
--- a/code/src/terrat_files/github/sql/select_missing_drift_scheduled_runs.sql
+++ b/code/src/terrat_files/github/sql/select_missing_drift_scheduled_runs.sql
@@ -72,7 +72,7 @@ left join latest_drift_manifests as ldm
     on ldm.repository = ds.repository
 left join drift_schedule_windows as dsw
     on (dsw.repository, dsw.name) = (ds.repository, ds.name)
-where (ldm.state is null or ldm.state <> 'running')
+where (ldm.state is null or ldm.state not in ('queued', 'running'))
       and ((ldm.repository is null
             or ds.schedule < (current_timestamp - ldm.created_at)
             or ldm.created_at < ds.updated_at)

--- a/code/src/terrat_files_gitlab/sql/select_missing_drift_scheduled_runs.sql
+++ b/code/src/terrat_files_gitlab/sql/select_missing_drift_scheduled_runs.sql
@@ -72,7 +72,7 @@ left join latest_drift_manifests as ldm
     on ldm.repository = ds.repository
 left join drift_schedule_windows as dsw
     on (dsw.repository, dsw.name) = (ds.repository, ds.name)
-where (ldm.state is null or ldm.state <> 'running')
+where (ldm.state is null or ldm.state not in ('queued', 'running'))
       and ((ldm.repository is null
             or ds.schedule < (current_timestamp - ldm.created_at)
             or ldm.created_at < ds.updated_at)

--- a/docker/terrat/nginx.conf.template
+++ b/docker/terrat/nginx.conf.template
@@ -80,7 +80,7 @@ http {
             proxy_busy_buffers_size 256k;
 
             # This is the limit of how large we of input we allow.
-            client_max_body_size 50m;
+            client_max_body_size 100m;
 
             # Add a long timeout to match the timeouts on the server side.
             proxy_read_timeout 120;


### PR DESCRIPTION
This prevents multiple drifts from being created if the created one is waiting on another run to finish before it can run

## Description

<!-- Briefly describe the changes and the issue it fixes. -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (explain):

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/terrateamio/terrateam/blob/main/CONTRIBUTING.md)
- [x] The pull request title follows this format:
      `ISSUE_NUMBER ACTION_TYPE Short description` (e.g., `123 ADD Feature description`)
- [x] I have added tests and documentation (if applicable)
- [x] My changes generate no new warnings/errors and do not break existing functionality

## Additional context (optional)

<!-- Add any additional context here, e.g., screenshots, dependencies, etc. -->
