### PR TITLE
#885 FIX Runs pagination

### DIFF
--- a/code/src/iris/src/lib/Runs.svelte
+++ b/code/src/iris/src/lib/Runs.svelte
@@ -61,7 +61,6 @@
   let hasMoreResults: boolean = false;
   let isLoadingMore: boolean = false;
   let nextPageUrl: string | null = null; // URL for next page from Link header
-  let allLoadedIds: Set<string> = new Set(); // Track all loaded IDs to prevent duplicates
   
   // Basic mode filter state
   let basicFilters = {
@@ -483,7 +482,6 @@
       currentPage = 1;
       hasMoreResults = false;
       nextPageUrl = null;
-      allLoadedIds.clear();
     }
     error = null;
     
@@ -561,23 +559,11 @@
         const actualResults = dirspaces;
         
         if (loadMore) {
-          // With proper Link header pagination, we shouldn't get duplicates
-          // but let's still check just in case
-          const newResults = actualResults.filter(r => !allLoadedIds.has(r.id));
-          
-          
-          // Add new IDs to our tracking set
-          newResults.forEach(r => allLoadedIds.add(r.id));
-          
           // Append to existing results
-          workManifests = [...workManifests, ...newResults];
+          workManifests = [...workManifests, ...actualResults];
         } else {
           // Replace results for new search
           workManifests = actualResults;
-          
-          // Reset and track IDs
-          allLoadedIds.clear();
-          actualResults.forEach(r => allLoadedIds.add(r.id));
         }
         
         currentPage = loadMore ? currentPage + 1 : 1;
@@ -902,7 +888,6 @@
     currentPage = 1;
     hasMoreResults = false;
     nextPageUrl = null;
-    allLoadedIds.clear();
   }
 
   // Store search context when navigating to run detail


### PR DESCRIPTION
Remove the unique id check.  This is not necessary in pagination because the cursor guarantees that the next page is after the existing one.  Additionally, using the work manifest id does not work here because this is a "dirspace" centric view, so multiple rows in the output have the same work manfiest id, so we were actually removing valid duplication in this check.

## Description

<!-- Briefly describe the changes and the issue it fixes. -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (explain):

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/terrateamio/terrateam/blob/main/CONTRIBUTING.md)
- [x] The pull request title follows this format:
      `ISSUE_NUMBER ACTION_TYPE Short description` (e.g., `123 ADD Feature description`)
- [x] I have added tests and documentation (if applicable)
- [x] My changes generate no new warnings/errors and do not break existing functionality

## Additional context (optional)

<!-- Add any additional context here, e.g., screenshots, dependencies, etc. -->
