### PR TITLE
#1281 Attach GitLab `terrateam apply` status to merge_request_event head pipeline

### DIFF
--- a/api_schemas/gitlab_api/api.json
+++ b/api_schemas/gitlab_api/api.json
@@ -68531,13 +68531,17 @@
         ],
         "responses": {
           "200": {
-            "description": "Get all Pipelines of the project",
-            "schema": {
-              "items": {
-                "$ref": "#/components/schemas/API_Entities_Ci_PipelineBasic"
-              },
-              "type": "array"
-            }
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/API_Entities_Ci_PipelineBasic"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Get all Pipelines of the project"
           },
           "401": {
             "description": "Unauthorized"

--- a/code/src/gitlabc/gitlabc_projects_pipelines.ml
+++ b/code/src/gitlabc/gitlabc_projects_pipelines.ml
@@ -213,12 +213,16 @@ module GetApiV4ProjectsIdPipelines = struct
   end
 
   module Responses = struct
-    module OK = struct end
+    module OK = struct
+      type t = Gitlabc_components.API_Entities_Ci_PipelineBasic.t list
+      [@@deriving yojson { strict = false; meta = false }, show, eq]
+    end
+
     module Unauthorized = struct end
     module Forbidden = struct end
 
     type t =
-      [ `OK
+      [ `OK of OK.t
       | `Unauthorized
       | `Forbidden
       ]
@@ -226,7 +230,9 @@ module GetApiV4ProjectsIdPipelines = struct
 
     let t =
       [
-        ("200", fun _ -> Ok `OK); ("401", fun _ -> Ok `Unauthorized); ("403", fun _ -> Ok `Forbidden);
+        ("200", Openapi.of_json_body (fun v -> `OK v) OK.of_yojson);
+        ("401", fun _ -> Ok `Unauthorized);
+        ("403", fun _ -> Ok `Forbidden);
       ]
   end
 

--- a/code/src/terrat_vcs_api_gitlab/terrat_vcs_api_gitlab.ml
+++ b/code/src/terrat_vcs_api_gitlab/terrat_vcs_api_gitlab.ml
@@ -654,6 +654,8 @@ let create_commit_checks ~request_id client repo ref_ checks =
     let open Abbs_future_combinators.Infix_result_monad in
     let module Glg = Gitlabc_projects_repository.GetApiV4ProjectsIdRepositoryCommitsShaStatuses in
     let module Glc = Gitlabc_components_api_entities_commitstatus in
+    let module Glp = Gitlabc_projects_pipelines.GetApiV4ProjectsIdPipelines in
+    let module Glpb = Gitlabc_components_api_entities_ci_pipelinebasic in
     let module Tcc = Terrat_commit_check in
     (* For GitLab, we only care about the terrateam apply status checks.  Status
        checks do not show the same as in GitHub, so creating the extras is not
@@ -661,26 +663,69 @@ let create_commit_checks ~request_id client repo ref_ checks =
     let checks =
       CCList.filter (fun { Tcc.title; _ } -> CCString.equal title "terrateam apply") checks
     in
-    Openapic_abb.collect_all
-      ~page:Openapic_abb.Page.gitlab
-      client.Client.client
-      Glg.(
-        make
-          (Parameters.make
-             ~id:(CCInt.to_string @@ Repo.id repo)
-             ~sha:ref_
-             ~name:(Some "terrateam apply")
-             ()))
-    >>= fun existing_checks ->
-    let pipeline_id =
-      match existing_checks with
-      | { Glc.pipeline_id; _ } :: _ -> pipeline_id
-      | _ -> None
+    let lookup_mr_pipeline_id () =
+      let open Abb.Future.Infix_monad in
+      call
+        client.Client.client
+        Glp.(
+          make
+            (Parameters.make
+               ~id:(CCInt.to_string @@ Repo.id repo)
+               ~sha:(Some ref_)
+               ~source:(Some `Merge_request_event)
+               ~per_page:1
+               ()))
+      >>= function
+      | Ok resp -> (
+          match Openapi.Response.value resp with
+          | `OK ({ Glpb.id; _ } :: _) -> Abb.Future.return (Ok id)
+          | `OK [] -> Abb.Future.return (Ok None)
+          | `Unauthorized | `Forbidden ->
+              Logs.info (fun m ->
+                  m "%s : CREATE_COMMIT_CHECKS : MR_PIPELINE_LOOKUP_FAILED : auth" request_id);
+              Abb.Future.return (Ok None))
+      | Error err ->
+          Logs.info (fun m ->
+              m
+                "%s : CREATE_COMMIT_CHECKS : MR_PIPELINE_LOOKUP_FAILED : %a"
+                request_id
+                Openapic_abb.pp_call_err
+                err);
+          Abb.Future.return (Ok None)
     in
+    lookup_mr_pipeline_id ()
+    >>= fun mr_pipeline_id ->
+    (match mr_pipeline_id with
+    | Some _ -> Abb.Future.return (Ok (mr_pipeline_id, "mr_pipeline"))
+    | None ->
+        Openapic_abb.collect_all
+          ~page:Openapic_abb.Page.gitlab
+          client.Client.client
+          Glg.(
+            make
+              (Parameters.make
+                 ~id:(CCInt.to_string @@ Repo.id repo)
+                 ~sha:ref_
+                 ~name:(Some "terrateam apply")
+                 ()))
+        >>= fun existing_checks ->
+        let pipeline_id =
+          match existing_checks with
+          | { Glc.pipeline_id; _ } :: _ -> pipeline_id
+          | _ -> None
+        in
+        let source =
+          match pipeline_id with
+          | Some _ -> "existing_status"
+          | None -> "none"
+        in
+        Abb.Future.return (Ok (pipeline_id, source)))
+    >>= fun (pipeline_id, source) ->
     Logs.info (fun m ->
         m
-          "%s : CREATE_COMMIT_CHECKS : UPDATING_WITH_PIPELINE_ID : pipeline_id=%s"
+          "%s : CREATE_COMMIT_CHECKS : UPDATING_WITH_PIPELINE_ID : source=%s : pipeline_id=%s"
           request_id
+          source
           (CCOption.map_or ~default:"" CCInt.to_string pipeline_id));
     let module C = Terrat_commit_check in
     let module Body = Gitlabc_components_postapiv4projectsidstatusessha in


### PR DESCRIPTION
Closes #1281.

Posts the `terrateam apply` commit status against the MR's `merge_request_event` head pipeline (when one exists for the SHA), so GitLab's MR widget surfaces it and `only_allow_merge_if_pipeline_succeeds` can gate on it.

## Changes

1. **`api_schemas/gitlab_api/api.json`**: convert the `/api/v4/projects/{id}/pipelines` GET 200 response from OAS2-style (`responses.200.schema`) to OAS3-style (`responses.200.content."application/json".schema`). The codegen only emits typed response bodies for the OAS3 shape, so without this the generated client discards the pipeline list.
2. **`code/src/gitlabc/gitlabc_projects_pipelines.ml`**: regenerated via `make gitlab-api`. Only `GetApiV4ProjectsIdPipelines.Responses` changes (typed `OK` body); every other generated file is byte-identical after ocamlformat.
3. **`code/src/terrat_vcs_api_gitlab/terrat_vcs_api_gitlab.ml`**: in `create_commit_checks`, look up the most recent `merge_request_event` pipeline for the SHA and use its `id`. Fall back to the existing prior-status anchor, then to `None`. New `source=mr_pipeline|existing_status|none` tag on `UPDATING_WITH_PIPELINE_ID` for observability.

## Interaction with #1286

This change, on its own, triggers a self-deadlock in default configs (`merge_conflicts: true` + `create_pending_apply_check: true`): the pending `terrateam apply` becomes part of `detailed_merge_status`, which makes the strict `mergeable` check fail. See #1286 for the proposed allowlist fix. **Please merge #1286 first**, or accept the brief regression window.

## Test plan

- [x] `dune build code/src/gitlabc` and `dune build code/src/terrat_vcs_api_gitlab` pass locally.
- [x] `ocamlformat --check code/src/terrat_vcs_api_gitlab/terrat_vcs_api_gitlab.ml` passes.
- [x] `docker build --target build-base -f docker/terrat/Dockerfile` (runs `make -C code test-terrat terrat` inside the image) exits 0.
- [x] Manual verification per #1281's reproduction: open a GitLab MR with `config_builder.enabled: true`, confirm `terrateam apply` attaches to the `merge_request_event` pipeline.

Explicit confirmation:
<img width="213" height="128" alt="image" src="https://github.com/user-attachments/assets/ee952e6e-b2ee-4538-9bc3-b565e8e21222" />
<img width="218" height="140" alt="image" src="https://github.com/user-attachments/assets/5464a0d6-131d-460d-9417-329d45b6e6e6" />
