### PR TITLE
#1286 Tolerate CI-pending states in GitLab `mergeable` for `merge_conflicts` check

### DIFF
--- a/code/src/terrat_vcs_api_gitlab/terrat_vcs_api_gitlab.ml
+++ b/code/src/terrat_vcs_api_gitlab/terrat_vcs_api_gitlab.ml
@@ -556,7 +556,12 @@ let fetch_pull_request ~request_id account client repo merge_request_iid =
     } =
       mr
     in
-    let mergeable = CCOption.map (CCString.equal "mergeable") detailed_merge_status in
+    let mergeable =
+      CCOption.map
+        (fun status ->
+          CCList.mem ~eq:CCString.equal status [ "mergeable"; "ci_still_running"; "ci_must_pass" ])
+        detailed_merge_status
+    in
     let checks =
       state = "merged"
       || CCOption.map_or


### PR DESCRIPTION
Closes #1286.

Replaces the strict `detailed_merge_status == "mergeable"` test with an allowlist `[ mergeable; ci_still_running; ci_must_pass ]` in `terrat_vcs_api_gitlab.ml:559`. The `merge_conflicts` apply requirement now tests "no real git conflict" rather than "CI fully green", fixing the self-deadlock where Terrateam's own pending apply status keeps `detailed_merge_status` at `ci_still_running` and blocks Terrateam from running apply.

GitLab's `only_allow_merge_if_pipeline_succeeds` still gates the actual merge until `terrateam apply` succeeds, so unapplied IaC changes remain blocked. CI-gating remains the job of the `status_checks` apply requirement.

Allowlist mirrors what Atlantis settled on in `gitlabIsMergeable` (runatlantis/atlantis#5867). `need_rebase` is deliberately excluded because under fast-forward / semi-linear merge methods GitLab treats it as unmergeable.

## Test plan

- [x] `dune build code/src/terrat_vcs_api_gitlab` passes locally.
- [x] `ocamlformat --check` clean.
- [ ] CI runs `make test-terrat` (no targeted unit tests for this path; the function makes live HTTP calls).
- [ ] Manual verification per #1286 reproduction.