### PR TITLE
#1291 FIX Pre-existing build warnings (unused vars, unused functor pa…

### DIFF
--- a/code/src/abb_bounded_suspendable_executor/abb_bounded_suspendable_executor.ml
+++ b/code/src/abb_bounded_suspendable_executor/abb_bounded_suspendable_executor.ml
@@ -33,7 +33,7 @@ struct
     | [], _ :: _ -> true
     | _, [] -> false
 
-  let is_key_prefix = is_prefix ~eq:(fun a b -> 0 = Key.compare a b)
+  let _is_key_prefix = is_prefix ~eq:(fun a b -> 0 = Key.compare a b)
 
   module Task = struct
     type t = Task : (Name.t * (unit -> 'a Fut.t) * 'a Fut.Promise.t * float) -> t
@@ -184,7 +184,7 @@ struct
           maybe_exec_task w t
           >>= fun t ->
           CCOption.iter
-            (fun { Logger.running_tasks = log; exec_task; _ } ->
+            (fun { Logger.running_tasks = log; exec_task = _; _ } ->
               log (Name_map.cardinal t.running_tasks))
             t.logger;
           CCOption.iter

--- a/code/src/abb_bounded_suspendable_executor/abb_bounded_suspendable_executor.mli
+++ b/code/src/abb_bounded_suspendable_executor/abb_bounded_suspendable_executor.mli
@@ -1,7 +1,4 @@
-module Make
-    (Fut : Abb_intf.Future.S)
-    (Key : Map.OrderedType)
-    (Time : Abb_time.Time_make(Fut).S) : sig
+module Make (Fut : Abb_intf.Future.S) (Key : Map.OrderedType) (_ : Abb_time.Time_make(Fut).S) : sig
   type t
 
   module Logger : sig

--- a/code/src/githubc2/dune
+++ b/code/src/githubc2/dune
@@ -1,5 +1,6 @@
 (library
  (name githubc2)
  (wrapped false)
+ (flags (:standard -w -27-67))
  (libraries containers json_schema openapi)
  (preprocess (pps ppx_deriving.eq ppx_deriving.make ppx_deriving.show ppx_deriving_yojson)))

--- a/code/src/githubc2_abb/githubc2_abb.ml
+++ b/code/src/githubc2_abb/githubc2_abb.ml
@@ -53,6 +53,7 @@ type t = {
   headers : (string * string) list;
   call_timeout : float option;
 }
+[@@warning "-69"]
 
 let create ?(user_agent = "Githubc2_abb") ?(base_url = base_url) ?call_timeout auth =
   let base_url =

--- a/code/src/gitlab_webhooks/dune
+++ b/code/src/gitlab_webhooks/dune
@@ -1,5 +1,6 @@
 (library
  (name gitlab_webhooks)
  (wrapped false)
+ (flags (:standard -w -27-67))
  (libraries containers json_schema yojson)
  (preprocess (pps ppx_deriving.eq ppx_deriving.make ppx_deriving.show ppx_deriving_yojson)))

--- a/code/src/gitlabc/dune
+++ b/code/src/gitlabc/dune
@@ -1,5 +1,6 @@
 (library
  (name gitlabc)
  (wrapped false)
+ (flags (:standard -w -27-67))
  (libraries containers json_schema openapi)
  (preprocess (pps ppx_deriving.eq ppx_deriving.make ppx_deriving.show ppx_deriving_yojson)))

--- a/code/src/oth_abb/oth_abb.ml
+++ b/code/src/oth_abb/oth_abb.ml
@@ -14,7 +14,7 @@ module Make (Abb : Abb_intf.S) = struct
       let stop = Unix.gettimeofday () in
       let duration = Duration.of_f (stop -. start) in
       match res with
-      | `Det res -> Abb.Future.return (duration, `Ok)
+      | `Det _res -> Abb.Future.return (duration, `Ok)
       | `Aborted -> assert false
       | `Exn _ as err -> Abb.Future.return (duration, err)
     with exn ->
@@ -31,16 +31,16 @@ module Make (Abb : Abb_intf.S) = struct
     Abb.Future.return (Oth.Run_result.of_test_results flat_rr)
 
   let parallel = serial
-  let timeout duration test = failwith "nyi"
+  let timeout _duration _test = failwith "nyi"
 
-  let test ?desc ~name f state =
+  let test ?desc ~name f _state =
     let open Abb.Future.Infix_monad in
     time_test f
     >>= fun (duration, res) ->
     let test_results = Oth.Test_result.[ { name; desc; duration; res } ] in
     Abb.Future.return (Oth.Run_result.of_test_results test_results)
 
-  let result_test f s = failwith "nyi"
+  let result_test _f _s = failwith "nyi"
 
   let to_sync_test test =
     Oth.raw_test (fun state ->

--- a/code/src/terrat/terrat_ep_access_token.ml
+++ b/code/src/terrat/terrat_ep_access_token.ml
@@ -20,7 +20,7 @@ module Refresh = struct
         /% Var.uuid "access_token_id")
   end
 
-  let post config storage =
+  let post _config storage =
     Brtl_ep.run_result_json ~f:(fun ctx ->
         let open Abbs_future_combinators.Infix_result_monad in
         Terrat_session.with_session ~caps:[ Terrat_user.Capability.Access_token_refresh ] ctx

--- a/code/src/terrat/terrat_ep_admin.ml
+++ b/code/src/terrat/terrat_ep_admin.ml
@@ -54,7 +54,7 @@ module Drift = struct
         unlocked;
       }
 
-    let get admin_token config storage =
+    let get admin_token _config storage =
       Brtl_ep.run_json ~f:(fun ctx ->
           Brtl_permissions.with_permissions [ admin_token_permission ] ctx admin_token (fun () ->
               let open Abb.Future.Infix_monad in

--- a/code/src/terrat/terrat_ep_infracost.ml
+++ b/code/src/terrat/terrat_ep_infracost.ml
@@ -51,7 +51,7 @@ let api_call = Exec.create ~slots:10 (fun f -> f ())
 let api_call_timeout = Duration.to_f (Duration.of_sec 10)
 let header_replace k v h = Cohttp.Header.replace h k v
 
-let post' config storage api_key infracost_uri path ctx =
+let post' _config storage api_key infracost_uri path ctx =
   let open Abb.Future.Infix_monad in
   let request = Brtl_ctx.request ctx in
   let request_id = Brtl_ctx.token ctx in

--- a/code/src/terrat/terrat_ep_tenv.ml
+++ b/code/src/terrat/terrat_ep_tenv.ml
@@ -85,7 +85,7 @@ let tenv_cache =
                  if not (Sys.file_exists body_path) then None else Some v));
     }
 
-let get config storage _origin work_manifest_id path ctx =
+let get _config storage _origin work_manifest_id path ctx =
   let open Abb.Future.Infix_monad in
   Pgsql_pool.with_conn storage ~f:(fun db ->
       Pgsql_io.Prepared_stmt.fetch db Sql.validate_work_manifest ~f:CCFun.id work_manifest_id)

--- a/code/src/terrat/terrat_ep_whoami.ml
+++ b/code/src/terrat/terrat_ep_whoami.ml
@@ -1,4 +1,4 @@
-let get config storage services =
+let get _config _storage services =
   Brtl_ep.run_result_json ~f:(fun ctx ->
       let open Abbs_future_combinators.Infix_result_monad in
       Terrat_session.with_session ctx

--- a/code/src/terrat/terrat_migrations.ml
+++ b/code/src/terrat/terrat_migrations.ml
@@ -74,7 +74,7 @@ end
 
 module Mig = Data_mig.Make (Migrate)
 
-let run_sql ?(mode = `Tx) sql_contents { Migrate.config; storage; tx = db } =
+let run_sql ?(mode = `Tx) sql_contents { Migrate.config = _; storage; tx = db } =
   let conn ~f =
     let open Abbs_future_combinators.Infix_result_monad in
     match mode with
@@ -101,7 +101,7 @@ let run_sql ?(mode = `Tx) sql_contents { Migrate.config; storage; tx = db } =
           Prepared_stmt.execute db stmt_sql)
         stmts)
 
-let add_encryption_key { Migrate.config; storage = _; tx = db } =
+let add_encryption_key { Migrate.config = _; storage = _; tx = db } =
   let open Abbs_future_combinators.Infix_result_monad in
   let key = Mirage_crypto_rng.generate 64 in
   let insert_encryption_key =

--- a/code/src/terrat/terrat_nginx_metrics.ml
+++ b/code/src/terrat/terrat_nginx_metrics.ml
@@ -86,7 +86,7 @@ let rec start uri =
   | Ok (resp, body) when Http.Response.status resp = `OK ->
       parse_and_update_metrics body;
       start uri
-  | Ok (resp, _) ->
+  | Ok (_resp, _) ->
       Logs.err (fun m -> m "NGINX_METRICS : FAILED");
       start uri
   | Error (#Cohttp_abb.request_err as err) ->

--- a/code/src/terrat/terrat_server.ml
+++ b/code/src/terrat/terrat_server.ml
@@ -12,7 +12,7 @@ module Metrics = struct
       ~namespace:"terrat"
       "http_request_duration_seconds"
 
-  let observe uri meth duration =
+  let observe _uri meth duration =
     let meth_str = Cohttp.Code.string_of_method meth in
     Histogram.observe (Histogram.labels request_duration [ meth_str ]) duration
 end

--- a/code/src/terrat_access_control2/terrat_access_control2.ml
+++ b/code/src/terrat_access_control2/terrat_access_control2.ml
@@ -56,6 +56,7 @@ module Make (S : S) = struct
       repo : S.repo;
       user : string;
     }
+    [@@warning "-69"]
 
     let make ~request_id ~client ~config ~repo ~user () = { request_id; client; config; repo; user }
     let set_user user t = { t with user }

--- a/code/src/terrat_access_token_caps/dune
+++ b/code/src/terrat_access_token_caps/dune
@@ -1,5 +1,6 @@
 (library
  (name terrat_access_token_caps)
  (wrapped false)
+ (flags (:standard -w -27-67))
  (libraries containers json_schema openapi ppx_deriving yojson)
  (preprocess (pps ppx_deriving.eq ppx_deriving.make ppx_deriving.show ppx_deriving_yojson)))

--- a/code/src/terrat_api/dune
+++ b/code/src/terrat_api/dune
@@ -1,5 +1,6 @@
 (library
  (name terrat_api)
  (wrapped false)
+ (flags (:standard -w -27-67))
  (libraries containers json_schema openapi ppx_deriving yojson)
  (preprocess (pps ppx_deriving.eq ppx_deriving.make ppx_deriving.show ppx_deriving_yojson)))

--- a/code/src/terrat_base_repo_config_v1/terrat_base_repo_config_v1.ml
+++ b/code/src/terrat_base_repo_config_v1/terrat_base_repo_config_v1.ml
@@ -3135,7 +3135,7 @@ let to_version_1_indexer indexer =
 
 let to_version_1_integrations integrations =
   let module I = Terrat_repo_config.Integrations in
-  let { Integrations.resourcely = { Integrations.Resourcely.enabled; extra_args } } =
+  let { Integrations.resourcely = { Integrations.Resourcely.enabled; extra_args = _ } } =
     integrations
   in
   { I.resourcely = Some { I.Resourcely.enabled; extra_args = Some [] } }

--- a/code/src/terrat_change_match3/terrat_change_match3.ml
+++ b/code/src/terrat_change_match3/terrat_change_match3.ml
@@ -112,7 +112,7 @@ let match_plan_after_dependency ~dependent ~dependency =
    "modified_by" configuration. *)
 let rec collect_depends_on_dependents topology dirspaces matches =
   CCList.flat_map
-    (fun ({ Dirspace_config.dirspace; stack_name; _ } as dirspace_config) ->
+    (fun ({ Dirspace_config.dirspace; stack_name = _; _ } as dirspace_config) ->
       dirspace_config
       :: collect_depends_on_dependents
            topology
@@ -132,7 +132,7 @@ let rec collect_modified_by_dependents ~path modifies_lookup dirspaces matches =
   let module S = R.Stacks.Stack in
   let module Rules = R.Stacks.Rules in
   CCList.flat_map
-    (fun ({ Dirspace_config.dirspace; stack_name; _ } as dirspace_config) ->
+    (fun ({ Dirspace_config.dirspace = _; stack_name; _ } as dirspace_config) ->
       if not (CCList.mem ~eq:CCString.equal stack_name path) then
         dirspace_config
         :: collect_modified_by_dependents
@@ -422,7 +422,7 @@ let build_modifies_lookup dirspace_configs =
     ~f:(fun
         acc
         ({
-           Dirspace_config.stack_name;
+           Dirspace_config.stack_name = _;
            stack_config = { S.Stack.rules = { S.Rules.modified_by; _ }; _ };
            _;
          } as dc)
@@ -697,7 +697,7 @@ let files_of_diff = function
 let match_dir_map dirspaces dir_map =
   snd
     (Sln_map.String.fold
-       (fun _ files ((dirspaces, matches) as acc) ->
+       (fun _ files ((dirspaces, _matches) as acc) ->
          Dirspace_map.fold
            (fun dirspace
                 ({ Dirspace_config.file_pattern_matcher; _ } as dirspace_config)

--- a/code/src/terrat_cli/terrat_cli.ml
+++ b/code/src/terrat_cli/terrat_cli.ml
@@ -20,7 +20,7 @@ module Cmdline = struct
         over ();
         k ()
       in
-      let with_stamp h tags k ppf fmt =
+      let with_stamp h _tags k ppf fmt =
         (* TODO: Make this use the proper Abb time *)
         let time = Unix.gettimeofday () in
         let time_str = ISO8601.Permissive.string_of_datetime time in

--- a/code/src/terrat_cli/terrat_cli.mli
+++ b/code/src/terrat_cli/terrat_cli.mli
@@ -1,3 +1,3 @@
 module Make
-    (Github : Terrat_vcs_service.S with type Service.vcs_config = Terrat_config.Github.t)
-    (Gitlab : Terrat_vcs_service.S with type Service.vcs_config = Terrat_config.Gitlab.t) : sig end
+    (_ : Terrat_vcs_service.S with type Service.vcs_config = Terrat_config.Github.t)
+    (_ : Terrat_vcs_service.S with type Service.vcs_config = Terrat_config.Gitlab.t) : sig end

--- a/code/src/terrat_code_indexer/terrat_code_indexer.ml
+++ b/code/src/terrat_code_indexer/terrat_code_indexer.ml
@@ -89,7 +89,7 @@ let rec process_path base path =
                   else [])
                 (Opentofu_mods.collect_modules ast)
           | Error (`Error (pos, _, err)) -> [ `Error (path, pos, err) ])
-      | path -> [])
+      | _path -> [])
     files
 
 let index paths =

--- a/code/src/terrat_comment/terrat_comment.ml
+++ b/code/src/terrat_comment/terrat_comment.ml
@@ -70,7 +70,7 @@ let parse s =
                { tokens = CCList.map CCString.trim @@ CCString.split_on_char ' ' tokens })
       | Some (action, _) -> Error (`Unknown_action action)
       | None -> Error (`Unknown_action s))
-  | Some (action, rest) -> Error (`Unknown_action action)
+  | Some (action, _rest) -> Error (`Unknown_action action)
   | None -> Error `Not_terrateam
 
 let to_string = function

--- a/code/src/terrat_github/terrat_github.ml
+++ b/code/src/terrat_github/terrat_github.ml
@@ -495,7 +495,7 @@ let delete_comment ~owner ~repo ~comment_id client =
   | Ok resp -> (
       match Openapi.Response.value resp with
       | `No_content -> Abb.Future.return (Ok ()))
-  | Error err ->
+  | Error _err ->
       (* TODO #561: Handle this properly later *)
       Abb.Future.return (Ok ())
 
@@ -846,7 +846,7 @@ module Oauth = struct
         match Response.of_yojson (Yojson.Safe.from_string body) with
         | Ok value -> Ok value
         | Error _ -> Error (`Authorize_err body))
-    | Ok (resp, body) -> Error (`Authorize_err body)
+    | Ok (_resp, body) -> Error (`Authorize_err body)
     | Error err -> Error err
 
   let refresh ~config refresh_token =
@@ -884,6 +884,6 @@ module Oauth = struct
             match Response_err.of_yojson (Yojson.Safe.from_string body) with
             | Ok { Response_err.error = "bad_refresh_token"; _ } -> Error `Bad_refresh_token
             | _ -> Error (`Refresh_err body)))
-    | Ok (resp, body) -> Error (`Refresh_err body)
+    | Ok (_resp, body) -> Error (`Refresh_err body)
     | Error err -> Error err
 end

--- a/code/src/terrat_github_webhooks/dune
+++ b/code/src/terrat_github_webhooks/dune
@@ -1,5 +1,6 @@
 (library
  (name terrat_github_webhooks)
  (wrapped false)
+ (flags (:standard -w -27-67))
  (libraries json_schema yojson)
  (preprocess (pps ppx_deriving.eq ppx_deriving.make ppx_deriving.show ppx_deriving_yojson)))

--- a/code/src/terrat_github_webhooks_decoder/terrat_github_webhooks_decoder.ml
+++ b/code/src/terrat_github_webhooks_decoder/terrat_github_webhooks_decoder.ml
@@ -7,7 +7,7 @@ type err =
   ]
 [@@deriving show]
 
-let decode headers body =
+let decode _headers body =
   try
     let json = Yojson.Safe.from_string body in
     match Terrat_github_webhooks.Event.of_yojson json with

--- a/code/src/terrat_job_context_param/dune
+++ b/code/src/terrat_job_context_param/dune
@@ -1,5 +1,6 @@
 (library
  (name terrat_job_context_param)
  (wrapped false)
+ (flags (:standard -w -27-67))
  (libraries json_schema yojson)
  (preprocess (pps ppx_deriving.eq ppx_deriving.make ppx_deriving.show ppx_deriving_yojson)))

--- a/code/src/terrat_job_type/dune
+++ b/code/src/terrat_job_type/dune
@@ -1,5 +1,6 @@
 (library
  (name terrat_job_type)
  (wrapped false)
+ (flags (:standard -w -27-67))
  (libraries json_schema yojson)
  (preprocess (pps ppx_deriving.eq ppx_deriving.make ppx_deriving.show ppx_deriving_yojson)))

--- a/code/src/terrat_migrations_ex/terrat_migrations_ex_150.ml
+++ b/code/src/terrat_migrations_ex/terrat_migrations_ex_150.ml
@@ -268,37 +268,37 @@ let while' sql db =
   | [] -> Abb.Future.return (Ok `Done)
   | _ :: _ -> Abb.Future.return (Ok `Cont)
 
-let fill_in_change_dirspace (config, storage) =
+let fill_in_change_dirspace (_config, storage) =
   fill_in storage (update' Sql.change_dirspaces_update) (while' Sql.change_dirspaces_while_)
 
-let fill_in_code_indexes (config, storage) =
+let fill_in_code_indexes (_config, storage) =
   fill_in storage (update' Sql.code_indexes_update) (while' Sql.code_indexes_while_)
 
-let fill_in_drift_schedules (config, storage) =
+let fill_in_drift_schedules (_config, storage) =
   fill_in storage (update' Sql.drift_schedules_update) (while' Sql.drift_schedules_while_)
 
-let fill_in_drift_unlocks (config, storage) =
+let fill_in_drift_unlocks (_config, storage) =
   fill_in storage (update' Sql.drift_unlocks_update) (while' Sql.drift_unlocks_while_)
 
-let fill_in_gate_approvals (config, storage) =
+let fill_in_gate_approvals (_config, storage) =
   fill_in storage (update' Sql.gate_approvals_update) (while' Sql.gate_approvals_while_)
 
-let fill_in_gates (config, storage) =
+let fill_in_gates (_config, storage) =
   fill_in storage (update' Sql.gates_update) (while' Sql.gates_while_)
 
-let fill_in_pull_request_unlocks (config, storage) =
+let fill_in_pull_request_unlocks (_config, storage) =
   fill_in storage (update' Sql.pull_request_unlocks_update) (while' Sql.pull_request_unlocks_while_)
 
-let fill_in_repo_configs (config, storage) =
+let fill_in_repo_configs (_config, storage) =
   fill_in storage (update' Sql.repo_configs_update) (while' Sql.repo_configs_while_)
 
-let fill_in_repo_trees (config, storage) =
+let fill_in_repo_trees (_config, storage) =
   fill_in storage (update' Sql.repo_trees_update) (while' Sql.repo_trees_while_)
 
-let fill_in_work_manifests_repos (config, storage) =
+let fill_in_work_manifests_repos (_config, storage) =
   fill_in storage (update' Sql.work_manifests_repos_update) (while' Sql.work_manifests_repos_while_)
 
-let fill_in_work_manifests_pull_requests (config, storage) =
+let fill_in_work_manifests_pull_requests (_config, storage) =
   fill_in
     storage
     (update' Sql.work_manifests_pull_requests_update)

--- a/code/src/terrat_migrations_ex/terrat_migrations_ex_568.ml
+++ b/code/src/terrat_migrations_ex/terrat_migrations_ex_568.ml
@@ -65,8 +65,8 @@ let while' sql db =
   | [] -> Abb.Future.return (Ok `Done)
   | _ :: _ -> Abb.Future.return (Ok `Cont)
 
-let run_github (config, storage) =
+let run_github (_config, storage) =
   run_batch storage (update' Sql.github_perform) (while' Sql.github_more_rows)
 
-let run_gitlab (config, storage) =
+let run_gitlab (_config, storage) =
   run_batch storage (update' Sql.gitlab_perform) (while' Sql.gitlab_more_rows)

--- a/code/src/terrat_repo_config/dune
+++ b/code/src/terrat_repo_config/dune
@@ -1,5 +1,6 @@
 (library
  (name terrat_repo_config)
  (wrapped false)
+ (flags (:standard -w -27-67))
  (libraries json_schema yojson)
  (preprocess (pps ppx_deriving.eq ppx_deriving.make ppx_deriving.show ppx_deriving_yojson)))

--- a/code/src/terrat_session/terrat_session.ml
+++ b/code/src/terrat_session/terrat_session.ml
@@ -140,7 +140,7 @@ module Bearer = struct
         Logs.err (fun m -> m "%a" Terrat_user.Token.pp_of_token_err err);
         Abb.Future.return None
 
-  let store storage keys _ = raise (Failure "nyi")
+  let store _storage _keys _ = raise (Failure "nyi")
 end
 
 module Sql = struct

--- a/code/src/terrat_vcs_access_token/terrat_vcs_access_token.ml
+++ b/code/src/terrat_vcs_access_token/terrat_vcs_access_token.ml
@@ -46,7 +46,7 @@ module Make (P : Terrat_vcs_provider2.S) (S : S) = struct
 
   module List = struct
     (* Not implementing pagination now, but the API is designed for it. *)
-    let run config storage _page _limit =
+    let run _config storage _page _limit =
       Brtl_ep.run_result_json ~f:(fun ctx ->
           let open Abbs_future_combinators.Infix_result_monad in
           Terrat_session.with_session ~caps:[ Terrat_user.Capability.Access_token_create ] ctx
@@ -85,7 +85,7 @@ module Make (P : Terrat_vcs_provider2.S) (S : S) = struct
   end
 
   module Create = struct
-    let run config storage body =
+    let run _config storage body =
       Brtl_ep.run_result_json ~f:(fun ctx ->
           let module C = Terrat_api_components.Access_token_create in
           let open Abbs_future_combinators.Infix_result_monad in
@@ -161,7 +161,7 @@ module Make (P : Terrat_vcs_provider2.S) (S : S) = struct
   end
 
   module Delete = struct
-    let run config storage access_token_id =
+    let run _config storage access_token_id =
       Brtl_ep.run_result_json ~f:(fun ctx ->
           let open Abbs_future_combinators.Infix_result_monad in
           Terrat_session.with_session ~caps:[ Terrat_user.Capability.Access_token_create ] ctx

--- a/code/src/terrat_vcs_access_token/terrat_vcs_access_token.mli
+++ b/code/src/terrat_vcs_access_token/terrat_vcs_access_token.mli
@@ -2,7 +2,7 @@ module type S = sig
   val vcs : string
 end
 
-module Make (P : Terrat_vcs_provider2.S) (S : S) : sig
+module Make (P : Terrat_vcs_provider2.S) (_ : S) : sig
   val routes :
     P.Api.Config.t ->
     Terrat_storage.t ->

--- a/code/src/terrat_vcs_api_github/terrat_vcs_api_github.ml
+++ b/code/src/terrat_vcs_api_github/terrat_vcs_api_github.ml
@@ -381,7 +381,7 @@ let create_client' config { Account.installation_id } =
   let github_client = Terrat_github.create config.Config.github (`Token access_token) in
   Abb.Future.return (Ok github_client)
 
-let create_client ~request_id config account db =
+let create_client ~request_id config account _db =
   let open Abb.Future.Infix_monad in
   let fetch () =
     create_client' config account
@@ -524,7 +524,7 @@ let fetch_diff ~client ~owner ~repo pull_number =
   let diff = diff_of_github_diff github_diff in
   Abb.Future.return (Ok diff)
 
-let fetch_pull_request' request_id account client repo pull_request_id =
+let fetch_pull_request' request_id _account client repo pull_request_id =
   let owner = repo.Repo.owner in
   let repo_name = repo.Repo.name in
   let open Abbs_future_combinators.Infix_result_monad in

--- a/code/src/terrat_vcs_api_gitlab/terrat_vcs_api_gitlab.ml
+++ b/code/src/terrat_vcs_api_gitlab/terrat_vcs_api_gitlab.ml
@@ -232,10 +232,11 @@ module Client = struct
     account : Account.t;
     client : Openapic_abb.t;
   }
+  [@@warning "-69"]
 
   type native = Openapic_abb.t
 
-  let make ~account ~client ~config () = { account; client }
+  let make ~account ~client ~config:_ () = { account; client }
   let to_native t = t.client
 end
 
@@ -285,7 +286,7 @@ let fetch_file ~request_id client repo ref_ path =
       Logs.err (fun m -> m "%s : FETCH_FILE : %a" request_id Openapic_abb.pp_call_err err);
       Abb.Future.return (Error `Error)
 
-let fetch_remote_repo' ~request_id client repo =
+let fetch_remote_repo' ~request_id:_ client repo =
   let module Gl = Gitlabc_projects.GetApiV4ProjectsId in
   let open Abbs_future_combinators.Infix_result_monad in
   let id = CCInt.to_string @@ Repo.id repo in
@@ -456,7 +457,7 @@ let comment_on_pull_request ~request_id client pull_request body =
   let open Abb.Future.Infix_monad in
   run
   >>= function
-  | Ok id as r -> Abb.Future.return r
+  | Ok _id as r -> Abb.Future.return r
   | Error (#Gl.Responses.t as err) ->
       Logs.err (fun m -> m "%s : COMMENT_ON_PULL_REQUEST : %a" request_id Gl.Responses.pp err);
       Abb.Future.return (Error `Error)
@@ -465,8 +466,11 @@ let comment_on_pull_request ~request_id client pull_request body =
           m "%s : COMMENT_ON_PULL_REQUEST : %a" request_id Openapic_abb.pp_call_err err);
       Abb.Future.return (Error `Error)
 
-let delete_pull_request_comment ~request_id client pull_request comment_id = raise (Failure "nyi")
-let minimize_pull_request_comment ~request_id client pull_request comment_id = raise (Failure "nyi")
+let delete_pull_request_comment ~request_id:_ _client _pull_request _comment_id =
+  raise (Failure "nyi")
+
+let minimize_pull_request_comment ~request_id:_ _client _pull_request _comment_id =
+  raise (Failure "nyi")
 
 let fetch_diff ~request_id ~client ~repo merge_request_iid =
   let module Gl =
@@ -504,7 +508,7 @@ let fetch_diff ~request_id ~client ~repo merge_request_iid =
       Logs.err (fun m -> m "%s : FETCH_DIFF : %a" request_id Openapic_abb.pp_call_err err);
       Abb.Future.return (Error `Error)
 
-let fetch_pull_request' ~request_id ~client ~repo merge_request_iid =
+let fetch_pull_request' ~request_id:_ ~client ~repo merge_request_iid =
   let module Gl = Gitlabc_projects_merge_requests.GetApiV4ProjectsIdMergeRequestsMergeRequestIid in
   let module Mr = Gitlabc_components_api_entities_mergerequest in
   let open Abbs_future_combinators.Infix_result_monad in
@@ -530,7 +534,7 @@ let fetch_pull_request' ~request_id ~client ~repo merge_request_iid =
   | `OK { Mr.diff_refs = None; _ } -> assert false
   | `Not_found -> Abb.Future.return (Error `Not_found)
 
-let fetch_pull_request ~request_id account client repo merge_request_iid =
+let fetch_pull_request ~request_id _account client repo merge_request_iid =
   let run =
     let open Abbs_future_combinators.Infix_result_monad in
     Abbs_future_combinators.Infix_result_app.(
@@ -898,7 +902,7 @@ let fetch_pull_request_requested_reviews ~request_id repo pull_number client =
   let open Abb.Future.Infix_monad in
   run
   >>= function
-  | Ok id as r -> Abb.Future.return r
+  | Ok _id as r -> Abb.Future.return r
   | Error (#Gl.Responses.t as err) ->
       Logs.err (fun m ->
           m "%s : FETCH_PULL_REQUEST_REQUESTED_REVIEWS : %a" request_id Gl.Responses.pp err);
@@ -990,7 +994,7 @@ let delete_branch ~request_id client repo branch =
       Logs.err (fun m -> m "%s : DELETE_BRANCH : %a" request_id Openapic_abb.pp_call_err err);
       Abb.Future.return (Error `Error)
 
-let fetch_member_of_team ~request_id ~team ~user client =
+let fetch_member_of_team ~request_id:_ ~team ~user client =
   let module Glu = Gitlabc_users.GetApiV4Users in
   let module Glg = Gitlabc_groups_members.GetApiV4GroupsIdMembersUserId in
   let run =
@@ -1014,7 +1018,7 @@ let fetch_member_of_team ~request_id ~team ~user client =
   | Ok _ as r -> Abb.Future.return r
   | Error (#Openapic_abb.call_err as err) -> Abb.Future.return (Error err)
 
-let is_member_of_team ~request_id ~team ~user repo client =
+let is_member_of_team ~request_id ~team ~user _repo client =
   let run =
     let open Abbs_future_combinators.Infix_result_monad in
     fetch_member_of_team ~request_id ~team ~user client
@@ -1110,4 +1114,4 @@ let get_org_role ~request_id ~org user client =
       Logs.err (fun m -> m "%s : GET_ORG_ROLE : %a" request_id Openapic_abb.pp_call_err err);
       Abb.Future.return (Error `Error)
 
-let find_workflow_file ~request_id _repo _client = Abb.Future.return (Ok (Some ".gitlab-ci.yml"))
+let find_workflow_file ~request_id:_ _repo _client = Abb.Future.return (Ok (Some ".gitlab-ci.yml"))

--- a/code/src/terrat_vcs_event_evaluator/terrat_vcs_event_evaluator.ml
+++ b/code/src/terrat_vcs_event_evaluator/terrat_vcs_event_evaluator.ml
@@ -644,7 +644,7 @@ module Make (S : Terrat_vcs_provider2.S) = struct
   module Repo_config = struct
     type fetch_err = Terrat_vcs_provider2.fetch_repo_config_with_provenance_err [@@deriving show]
 
-    let fetch_with_provenance ?built_config ~system_defaults request_id config client repo ref_ =
+    let fetch_with_provenance ?built_config ~system_defaults request_id _config client repo ref_ =
       fetch_repo_config_with_provenance ?built_config ~system_defaults request_id client repo ref_
 
     let fetch ?built_config ~system_defaults request_id config client repo ref_ =
@@ -1204,6 +1204,7 @@ module Make (S : Terrat_vcs_provider2.S) = struct
       request_id : string;
       user : string;
     }
+    [@@warning "-69"]
 
     let make ~request_id ~ctx ~repo_config ~user ~policy_branch () =
       let config = V1.access_control repo_config in
@@ -1275,7 +1276,7 @@ module Make (S : Terrat_vcs_provider2.S) = struct
          approvals. *)
       eval' t change_matches (fun { P.apply_with_superapproval; _ } -> apply_with_superapproval)
       >>= function
-      | { Terrat_access_control2.R.pass = _ :: _ as pass; deny } ->
+      | { Terrat_access_control2.R.pass = _ :: _ as pass; deny = _ } ->
           (* Now, of those that passed, let's see if any have been approved by a
              super approver.  To do this we'll iterate over the approvers. *)
           let pass_with_superapproval =
@@ -1547,7 +1548,7 @@ module Make (S : Terrat_vcs_provider2.S) = struct
           }
     end
 
-    let is_interactive ctx state =
+    let is_interactive _ctx state =
       match state.State.event with
       | Event.Pull_request_open _
       | Event.Pull_request_close _
@@ -1556,7 +1557,7 @@ module Make (S : Terrat_vcs_provider2.S) = struct
       | Event.Pull_request_comment _ -> true
       | Event.Push _ | Event.Run_scheduled_drift | Event.Run_drift _ -> false
 
-    let repo_config_system_defaults ctx state =
+    let repo_config_system_defaults ctx _state =
       let module V1 = Terrat_base_repo_config_v1 in
       match Terrat_config.infracost @@ S.Api.Config.config @@ Ctx.config ctx with
       | Some _ -> Abb.Future.return (Ok V1.default)
@@ -1861,7 +1862,7 @@ module Make (S : Terrat_vcs_provider2.S) = struct
 
     let matches ctx state op =
       let compute_matches
-          ~ctx
+          ~ctx:_
           ~repo_config
           ~tag_query
           ~out_of_change_applies
@@ -2572,7 +2573,7 @@ module Make (S : Terrat_vcs_provider2.S) = struct
             (CCOption.map_or ~default:"" string_of_input input)
             (CCOption.map_or ~default:"" Uuidm.to_string work_manifest_id))
 
-    let log_state_err_iter ctx state =
+    let log_state_err_iter _ctx state =
       log_state_err
         state.State.request_id
         state.State.st
@@ -3085,7 +3086,7 @@ module Make (S : Terrat_vcs_provider2.S) = struct
         <*> Dv.repo_tree_branch ctx state
         <*> Dv.base_branch_name ctx state
         <*> Dv.branch_name ctx state)
-      >>= fun (client, repo_config, repo_tree, base_branch_name', branch_name') ->
+      >>= fun (_client, repo_config, repo_tree, base_branch_name', branch_name') ->
       Dv.query_repo_tree ctx state
       >>= fun built_repo_tree ->
       let repo_tree =
@@ -3151,13 +3152,13 @@ module Make (S : Terrat_vcs_provider2.S) = struct
         db
       >>= fun user -> Terrat_user.Token.to_token db user
 
-    let generate_index_work_manifest_initiate ctx state encryption_key run_id sha work_manifest =
+    let generate_index_work_manifest_initiate ctx state _encryption_key run_id sha work_manifest =
       let module Wm = Terrat_work_manifest3 in
       let open Abbs_future_combinators.Infix_result_monad in
       initiate_work_manifest state state.State.request_id (Ctx.storage ctx) run_id sha work_manifest
       >>= function
       | Some
-          ({ Wm.account; id; branch_ref; base_ref; state = Wm.State.(Queued | Running); _ } as wm)
+          ({ Wm.account; id; branch_ref = _; base_ref = _; state = Wm.State.(Queued | Running); _ } as wm)
         ->
           generate_index_run_dirs ctx state wm
           >>= fun wm ->
@@ -4206,14 +4207,14 @@ module Make (S : Terrat_vcs_provider2.S) = struct
             })
         changes
 
-    let run_op_work_manifest_iter_initiate ctx state encryption_key run_id sha work_manifest =
+    let run_op_work_manifest_iter_initiate ctx state _encryption_key run_id sha work_manifest =
       let module Wm = Terrat_work_manifest3 in
       let open Abbs_future_combinators.Infix_result_monad in
       initiate_work_manifest state state.State.request_id (Ctx.storage ctx) run_id sha work_manifest
       >>= function
-      | Some { Wm.account; steps; base_ref; branch_ref; changes; target; _ } -> (
+      | Some { Wm.account; steps; base_ref = _; branch_ref = _; changes; target; _ } -> (
           Dv.base_branch_name ctx state
-          >>= fun base_branch_name ->
+          >>= fun _base_branch_name ->
           let step =
             match CCList.rev steps with
             | [] -> assert false
@@ -4458,7 +4459,7 @@ module Make (S : Terrat_vcs_provider2.S) = struct
                      <*> Dv.pull_request ctx state
                      <*> Dv.repo_config_with_provenance ctx state
                      <*> Dv.repo_tree_branch ctx state)
-                   >>= fun (client, pull_request, (provenance, repo_config), repo_tree) ->
+                   >>= fun (_client, pull_request, (_provenance, repo_config), repo_tree) ->
                    Dv.query_repo_tree ctx state
                    >>= fun built_repo_tree ->
                    let repo_tree =
@@ -4612,9 +4613,9 @@ module Make (S : Terrat_vcs_provider2.S) = struct
 
        If the goal is to reset context (for example caches), look at returning a
        [`Reset_ctx], which resets the context and resets caches. *)
-    let checkpoint ctx state = Abb.Future.return (Error (`Checkpoint state))
+    let checkpoint _ctx state = Abb.Future.return (Error (`Checkpoint state))
 
-    let wait_for_initiate ctx state =
+    let wait_for_initiate _ctx state =
       match state.State.input with
       | Some (State.Io.I.Work_manifest_initiate _) -> Abb.Future.return (Ok state)
       | _ ->
@@ -4654,7 +4655,7 @@ module Make (S : Terrat_vcs_provider2.S) = struct
       Logs.info (fun m -> m "%s : ACCOUNT_DISABLED" state.State.request_id);
       Abb.Future.return (Error (`Noop state))
 
-    let test_event_kind ctx state =
+    let test_event_kind _ctx state =
       match state.State.event with
       | Event.Pull_request_open _
       | Event.Pull_request_close _
@@ -4968,7 +4969,7 @@ module Make (S : Terrat_vcs_provider2.S) = struct
                      repo_config))
         >>= fun repo_config ->
         match Terrat_change_match3.synthesize_config ~index repo_config with
-        | Ok config ->
+        | Ok _config ->
             publish_msg
               state.State.request_id
               client
@@ -5064,13 +5065,13 @@ module Make (S : Terrat_vcs_provider2.S) = struct
     let store_pull_request ctx state =
       let open Abbs_future_combinators.Infix_result_monad in
       Dv.client ctx state
-      >>= fun client ->
+      >>= fun _client ->
       Dv.pull_request ctx state
       >>= fun pull_request ->
       store_pull_request state.State.request_id (Ctx.storage ctx) pull_request
       >>= fun () -> Abb.Future.return (Ok state)
 
-    let record_feedback ctx state =
+    let record_feedback _ctx state =
       match state.State.event with
       | Event.Pull_request_comment
           { account; repo; user; comment = Terrat_comment.Feedback feedback; pull_request_id; _ } ->
@@ -5166,9 +5167,9 @@ module Make (S : Terrat_vcs_provider2.S) = struct
       let run state client pull_request unlock_ids =
         let open Abbs_future_combinators.Infix_result_monad in
         Dv.repo_config ctx state
-        >>= fun repo_config ->
+        >>= fun _repo_config ->
         fetch_remote_repo state.State.request_id client repo
-        >>= fun remote_repo ->
+        >>= fun _remote_repo ->
         Dv.access_control ctx state
         >>= fun access_control ->
         let open Abb.Future.Infix_monad in
@@ -5234,7 +5235,7 @@ module Make (S : Terrat_vcs_provider2.S) = struct
             (Msg.Invalid_unlock_id s)
           >>= fun _ -> Abb.Future.return (Error `Error)
 
-    let test_op_kind ctx state =
+    let test_op_kind _ctx state =
       match state.State.event with
       | Event.Pull_request_open _
       | Event.Pull_request_sync _
@@ -5685,7 +5686,7 @@ module Make (S : Terrat_vcs_provider2.S) = struct
             (Msg.Access_control_denied
                (Access_control_engine.policy_branch access_control, `All_dirspaces deny))
           >>= fun () -> Abb.Future.return (Error (`Noop state))
-      | Ok { Terrat_access_control2.R.pass; deny }
+      | Ok { Terrat_access_control2.R.pass = _; deny }
         when CCList.is_empty deny
              || not (Access_control_engine.plan_require_all_dirspace_access access_control) ->
           Abb.Future.return (Ok state)
@@ -5868,7 +5869,7 @@ module Make (S : Terrat_vcs_provider2.S) = struct
         <*> Dv.client ctx state
         <*> Dv.pull_request ctx state
         <*> Dv.tf_operation_access_control_evaluation ctx state access_control_run_type)
-      >>= fun (access_control, matches, client, pull_request, access_control_result) ->
+      >>= fun (access_control, _matches, client, pull_request, access_control_result) ->
       let passed_apply_requirements = S.Apply_requirements.Result.passed apply_requirements in
       match access_control_result with
       | _ when (not passed_apply_requirements) && not (op = `Apply_force) ->
@@ -5894,7 +5895,7 @@ module Make (S : Terrat_vcs_provider2.S) = struct
             (Msg.Access_control_denied
                (Access_control_engine.policy_branch access_control, `All_dirspaces deny))
           >>= fun () -> Abb.Future.return (Error (`Noop state))
-      | { Terrat_access_control2.R.pass; deny }
+      | { Terrat_access_control2.R.pass = _; deny }
         when CCList.is_empty deny
              || not (Access_control_engine.apply_require_all_dirspace_access access_control) ->
           Abb.Future.return (Ok state)
@@ -6201,7 +6202,7 @@ module Make (S : Terrat_vcs_provider2.S) = struct
     let run_drift_work_manifest_iter = run_drift_plan_work_manifest_iter
     let run_drift_reconcile_work_manifest_iter = run_apply_work_manifest_iter `Apply
 
-    let check_reconcile ctx state =
+    let check_reconcile _ctx state =
       let module V1 = Terrat_base_repo_config_v1 in
       let module D = V1.Drift in
       match state.State.event with
@@ -6404,7 +6405,7 @@ module Make (S : Terrat_vcs_provider2.S) = struct
                 err
               >>= fun () -> Abb.Future.return (Ok state))
           >>= fun _ -> Abb.Future.return (Ok ()))
-        ~initiate:(fun ctx state encryption_key run_id sha work_manifest ->
+        ~initiate:(fun ctx state _encryption_key run_id sha work_manifest ->
           let module Wm = Terrat_work_manifest3 in
           let open Abbs_future_combinators.Infix_result_monad in
           H.initiate_work_manifest
@@ -6415,7 +6416,7 @@ module Make (S : Terrat_vcs_provider2.S) = struct
             sha
             work_manifest
           >>= function
-          | Some { Wm.account; id; branch_ref; base_ref; state = Wm.State.(Queued | Running); _ } ->
+          | Some { Wm.account; id; branch_ref = _; base_ref = _; state = Wm.State.(Queued | Running); _ } ->
               Dv.base_branch_name ctx state
               >>= fun base_branch_name' ->
               Dv.repo_config ctx state
@@ -6696,7 +6697,7 @@ module Make (S : Terrat_vcs_provider2.S) = struct
                 err
               >>= fun () -> Abb.Future.return (Ok state))
           >>= fun _ -> Abb.Future.return (Ok ()))
-        ~initiate:(fun ctx state encryption_key run_id sha work_manifest ->
+        ~initiate:(fun ctx state _encryption_key run_id sha work_manifest ->
           let module Wm = Terrat_work_manifest3 in
           let open Abbs_future_combinators.Infix_result_monad in
           H.initiate_work_manifest
@@ -6707,7 +6708,7 @@ module Make (S : Terrat_vcs_provider2.S) = struct
             sha
             work_manifest
           >>= function
-          | Some { Wm.account; id; branch_ref; base_ref; state = Wm.State.(Queued | Running); _ } ->
+          | Some { Wm.account; id; branch_ref = _; base_ref = _; state = Wm.State.(Queued | Running); _ } ->
               Dv.repo_config ctx state
               >>= fun repo_config ->
               Dv.repo_tree_branch ctx state
@@ -6935,7 +6936,7 @@ module Make (S : Terrat_vcs_provider2.S) = struct
               | None -> assert false)
           | None -> Abb.Future.return (Ok (Id.More_layers_to_run, state)))
 
-    let synthesize_pull_request_sync ctx state =
+    let synthesize_pull_request_sync _ctx state =
       let account = Event.account state.State.event in
       let user = Event.user state.State.event in
       let repo = Event.repo state.State.event in
@@ -7475,7 +7476,7 @@ module Make (S : Terrat_vcs_provider2.S) = struct
                              gen (op_kind_apply_flow `Apply_autoapprove) );
                            (Id.Op_kind_apply_force, gen (op_kind_apply_flow `Apply_force));
                          ])))))
-          ~f:(fun _ state -> function
+          ~f:(fun _ _state -> function
             | `Step_err (_, `Noop state) -> Abb.Future.return (Ok (Id.Recover_noop, state))
             | _ -> Abb.Future.return (Error `Error))
           ~recover:[ (Id.Recover_noop, recover_noop_flow) ])
@@ -7521,7 +7522,7 @@ module Make (S : Terrat_vcs_provider2.S) = struct
                    ~f:(eval_step F.complete_work_manifest)
                    ();
                ])
-          ~f:(fun _ state -> function
+          ~f:(fun _ _state -> function
             | `Step_err (_, `Noop state) -> Abb.Future.return (Ok (Id.Recover_noop, state))
             | _ -> Abb.Future.return (Error `Error))
           ~recover:[ (Id.Recover_noop, recover_noop_flow) ])
@@ -7815,13 +7816,13 @@ module Make (S : Terrat_vcs_provider2.S) = struct
         ~finally:(fun () ->
           Abbs_future_combinators.ignore (run_work_manifests (Ctx.request_id ctx) ctx))
 
-    and notify_work_manifest_run_success request_id ctx work_manifest =
+    and notify_work_manifest_run_success _request_id ctx work_manifest =
       let module Wm = Terrat_work_manifest3 in
       Abbs_future_combinators.ignore
         (resume_raw ctx (`Work_manifest work_manifest.Wm.id) (fun state ->
              { state with State.input = Some State.Io.I.Work_manifest_run_success }))
 
-    and notify_work_manifest_run_failure request_id ctx work_manifest err =
+    and notify_work_manifest_run_failure _request_id ctx work_manifest err =
       let module Wm = Terrat_work_manifest3 in
       Abbs_future_combinators.ignore
         (resume_raw ctx (`Work_manifest work_manifest.Wm.id) (fun state ->

--- a/code/src/terrat_vcs_event_evaluator2/terrat_vcs_event_evaluator2.ml
+++ b/code/src/terrat_vcs_event_evaluator2/terrat_vcs_event_evaluator2.ml
@@ -651,7 +651,7 @@ module Make (S : Terrat_vcs_provider2.S) = struct
     in
     let add_work_manifest_keys work_manifest store =
       let module Wm = Terrat_work_manifest3 in
-      let { Wm.id; account; target; _ } = work_manifest in
+      let { Wm.id = _; account; target; _ } = work_manifest in
       match target with
       | Terrat_vcs_provider2.Target.Pr pr ->
           store

--- a/code/src/terrat_vcs_event_evaluator2/terrat_vcs_event_evaluator2_access_control.ml
+++ b/code/src/terrat_vcs_event_evaluator2/terrat_vcs_event_evaluator2_access_control.ml
@@ -90,7 +90,7 @@ struct
     eval' access_control change_matches (fun { P.apply_with_superapproval; _ } ->
         apply_with_superapproval)
     >>= function
-    | { Terrat_access_control2.R.pass = _ :: _ as pass; deny } ->
+    | { Terrat_access_control2.R.pass = _ :: _ as pass; deny = _ } ->
         (* Now, of those that passed, let's see if any have been approved by a
              super approver.  To do this we'll iterate over the approvers. *)
         let pass_with_superapproval =

--- a/code/src/terrat_vcs_event_evaluator2/terrat_vcs_event_evaluator2_builder.ml
+++ b/code/src/terrat_vcs_event_evaluator2/terrat_vcs_event_evaluator2_builder.ml
@@ -185,7 +185,7 @@ module Make (S : Terrat_vcs_provider2.S) = struct
     | `Closed -> Abb.Future.return (Error `Closed)
 
   let make_tasks tasks_map =
-    { Bs.Tasks.get = (fun s k -> Abb.Future.return (Hmap.find (coerce_to_task k) tasks_map)) }
+    { Bs.Tasks.get = (fun _s k -> Abb.Future.return (Hmap.find (coerce_to_task k) tasks_map)) }
 
   let eval s k =
     let path =

--- a/code/src/terrat_vcs_event_evaluator2/terrat_vcs_event_evaluator2_tasks.ml
+++ b/code/src/terrat_vcs_event_evaluator2/terrat_vcs_event_evaluator2_tasks.ml
@@ -54,7 +54,7 @@ struct
 
   let add_work_manifest_keys work_manifest store =
     let module Wm = Terrat_work_manifest3 in
-    let { Wm.id; account; target; _ } = work_manifest in
+    let { Wm.id = _; account; target; _ } = work_manifest in
     match target with
     | Terrat_vcs_provider2.Target.Pr pr ->
         store
@@ -177,7 +177,7 @@ struct
         ~repo_tree
         ~repo_config_raw
         s
-        { Bs.Fetcher.fetch } =
+        { Bs.Fetcher.fetch = _ } =
       let open Irm in
       Builder.run_db s ~f:(load ~cache_key)
       >>= function
@@ -255,7 +255,7 @@ struct
       | Error #Builder.err as err -> Abb.Future.return err
 
     let target =
-      run ~name:"target" (fun s { Bs.Fetcher.fetch } ->
+      run ~name:"target" (fun _s { Bs.Fetcher.fetch } ->
           let module C = Terrat_job_context.Context in
           let open Irm in
           fetch Keys.context
@@ -277,7 +277,7 @@ struct
                    (Terrat_vcs_provider2.Target.Drift { repo; branch = S.Api.Ref.to_string branch })))
 
     let initiator =
-      run ~name:"initiator" (fun s { Bs.Fetcher.fetch } ->
+      run ~name:"initiator" (fun _s { Bs.Fetcher.fetch } ->
           let open Irm in
           fetch Keys.job
           >>= function
@@ -288,7 +288,7 @@ struct
               Abb.Future.return (Ok Terrat_work_manifest3.Initiator.System))
 
     let user =
-      run ~name:"user" (fun s { Bs.Fetcher.fetch } ->
+      run ~name:"user" (fun _s { Bs.Fetcher.fetch } ->
           let open Irm in
           fetch Keys.job >>= fun { Tjc.Job.initiator; _ } -> Abb.Future.return (Ok initiator))
 
@@ -303,7 +303,7 @@ struct
     let commit_checks = run ~name:"commit_checks" (fun _s _ -> Abb.Future.return (Ok []))
 
     let context_id =
-      run ~name:"context_id" (fun s { Bs.Fetcher.fetch } ->
+      run ~name:"context_id" (fun _s { Bs.Fetcher.fetch } ->
           let open Irm in
           fetch Keys.job >>= fun job -> Abb.Future.return (Ok job.Tjc.Job.context.Tjc.Context.id))
 
@@ -323,7 +323,7 @@ struct
           | None -> assert false)
 
     let work_manifest_event =
-      run ~name:"work_manifest_event" (fun _s { Bs.Fetcher.fetch } ->
+      run ~name:"work_manifest_event" (fun _s { Bs.Fetcher.fetch = _ } ->
           (* This is a default value in case no work manifest event is set in the store
              by the runner. *)
           Abb.Future.return (Ok None))
@@ -386,13 +386,13 @@ struct
     let matches =
       run ~name:"matches" (fun s { Bs.Fetcher.fetch } ->
           let compute_matches
-              ~repo_config
+              ~repo_config:_
               ~tag_query
               ~out_of_change_applies
               ~applied_dirspaces
               ~diff
               ~repo_tree
-              ~index
+              ~index:_
               () =
             let module Dc = Terrat_change_match3.Dirspace_config in
             let module Dir_set = CCSet.Make (CCString) in
@@ -550,15 +550,15 @@ struct
               (fetch Keys.repo_config)
               (fetch Keys.repo_tree_branch)
               (fetch Keys.repo_index_branch)
-            >>= fun (repo_config, repo_tree, repo_index) ->
+            >>= fun (_repo_config, repo_tree, _repo_index) ->
             fetch Keys.out_of_change_applies
             >>= fun out_of_change_applies ->
             fetch Keys.applied_dirspaces
             >>= fun applied_dirspaces ->
             fetch Keys.dest_branch_name
-            >>= fun dest_branch_name ->
+            >>= fun _dest_branch_name ->
             fetch Keys.branch_name
-            >>= fun branch_name ->
+            >>= fun _branch_name ->
             fetch Keys.job
             >>= fun job ->
             let tag_query =
@@ -707,34 +707,34 @@ struct
           Abb.Future.return (Ok matches))
 
     let working_set_matches =
-      run ~name:"working_set_matches" (fun s { Bs.Fetcher.fetch } ->
+      run ~name:"working_set_matches" (fun _s { Bs.Fetcher.fetch } ->
           let open Irm in
           fetch Keys.matches
           >>= fun { Keys.Matches.working_set_matches; _ } ->
           Abb.Future.return (Ok working_set_matches))
 
     let all_matches =
-      run ~name:"all_matches" (fun s { Bs.Fetcher.fetch } ->
+      run ~name:"all_matches" (fun _s { Bs.Fetcher.fetch } ->
           let open Irm in
           fetch Keys.matches
           >>= fun { Keys.Matches.all_matches; _ } -> Abb.Future.return (Ok all_matches))
 
     let all_unapplied_matches =
-      run ~name:"all_unapplied_matches" (fun s { Bs.Fetcher.fetch } ->
+      run ~name:"all_unapplied_matches" (fun _s { Bs.Fetcher.fetch } ->
           let open Irm in
           fetch Keys.matches
           >>= fun { Keys.Matches.all_unapplied_matches; _ } ->
           Abb.Future.return (Ok all_unapplied_matches))
 
     let all_tag_query_matches =
-      run ~name:"all_tag_query_matches" (fun s { Bs.Fetcher.fetch } ->
+      run ~name:"all_tag_query_matches" (fun _s { Bs.Fetcher.fetch } ->
           let open Irm in
           fetch Keys.matches
           >>= fun { Keys.Matches.all_tag_query_matches; _ } ->
           Abb.Future.return (Ok all_tag_query_matches))
 
     let working_layer =
-      run ~name:"working_layer" (fun s { Bs.Fetcher.fetch } ->
+      run ~name:"working_layer" (fun _s { Bs.Fetcher.fetch } ->
           let open Irm in
           fetch Keys.matches
           >>= fun { Keys.Matches.working_layer; _ } -> Abb.Future.return (Ok working_layer))
@@ -1304,17 +1304,17 @@ struct
           >>= fun repo_config -> Abb.Future.return (Ok (provenance, repo_config)))
 
     let repo_config_with_provenance =
-      run ~name:"repo_config_with_provenance" (fun s { Bs.Fetcher.fetch } ->
+      run ~name:"repo_config_with_provenance" (fun _s { Bs.Fetcher.fetch } ->
           let open Irm in
           fetch Keys.derived_repo_config
           >>= fun repo_config ->
           fetch Keys.synthesized_config >>= fun _ -> Abb.Future.return (Ok repo_config))
 
     let synthesized_config_empty_index =
-      run ~name:"synthesized_config_empty_index" (fun s { Bs.Fetcher.fetch } ->
+      run ~name:"synthesized_config_empty_index" (fun _s { Bs.Fetcher.fetch } ->
           let open Irm in
           fetch Keys.repo_tree_branch
-          >>= fun repo_tree ->
+          >>= fun _repo_tree ->
           fetch Keys.derived_repo_config_empty_index
           >>= fun (_provenance, repo_config) ->
           match
@@ -1327,10 +1327,10 @@ struct
               Abb.Future.return (Error err))
 
     let synthesized_config =
-      run ~name:"synthesized_config" (fun s { Bs.Fetcher.fetch } ->
+      run ~name:"synthesized_config" (fun _s { Bs.Fetcher.fetch } ->
           let open Irm in
           fetch Keys.repo_tree_branch
-          >>= fun repo_tree ->
+          >>= fun _repo_tree ->
           fetch Keys.repo_index_branch
           >>= fun index ->
           fetch Keys.derived_repo_config
@@ -1341,7 +1341,7 @@ struct
               Abb.Future.return (Error err))
 
     let repo_config =
-      run ~name:"repo_config" (fun s { Bs.Fetcher.fetch } ->
+      run ~name:"repo_config" (fun _s { Bs.Fetcher.fetch } ->
           let open Irm in
           fetch Keys.repo_config_with_provenance
           >>= fun (_, repo_config) -> Abb.Future.return (Ok repo_config))
@@ -1476,17 +1476,17 @@ struct
           >>= fun repo_config -> Abb.Future.return (Ok (provenance, repo_config)))
 
     let repo_config_dest_branch_with_provenance =
-      run ~name:"repo_config_dest_branch_with_provenance" (fun s { Bs.Fetcher.fetch } ->
+      run ~name:"repo_config_dest_branch_with_provenance" (fun _s { Bs.Fetcher.fetch } ->
           let open Irm in
           fetch Keys.derived_repo_config_dest_branch
           >>= fun repo_config ->
           fetch Keys.synthesized_config_dest_branch >>= fun _ -> Abb.Future.return (Ok repo_config))
 
     let synthesized_config_dest_branch_empty_index =
-      run ~name:"synthesized_config_dest_branch_empty_index" (fun s { Bs.Fetcher.fetch } ->
+      run ~name:"synthesized_config_dest_branch_empty_index" (fun _s { Bs.Fetcher.fetch } ->
           let open Irm in
           fetch Keys.repo_tree_dest_branch
-          >>= fun repo_tree ->
+          >>= fun _repo_tree ->
           fetch Keys.derived_repo_config_dest_branch_empty_index
           >>= fun (_provenance, repo_config) ->
           match
@@ -1499,10 +1499,10 @@ struct
               Abb.Future.return (Error err))
 
     let synthesized_config_dest_branch =
-      run ~name:"synthesized_config_dest_branch" (fun s { Bs.Fetcher.fetch } ->
+      run ~name:"synthesized_config_dest_branch" (fun _s { Bs.Fetcher.fetch } ->
           let open Irm in
           fetch Keys.repo_tree_dest_branch
-          >>= fun repo_tree ->
+          >>= fun _repo_tree ->
           fetch Keys.repo_index_dest_branch
           >>= fun index ->
           fetch Keys.derived_repo_config_dest_branch
@@ -1513,7 +1513,7 @@ struct
               Abb.Future.return (Error err))
 
     let repo_config_dest_branch =
-      run ~name:"repo_config_dest_branch" (fun s { Bs.Fetcher.fetch } ->
+      run ~name:"repo_config_dest_branch" (fun _s { Bs.Fetcher.fetch } ->
           let open Irm in
           fetch Keys.repo_config_dest_branch_with_provenance
           >>= fun (_, repo_config) -> Abb.Future.return (Ok repo_config))
@@ -1539,14 +1539,14 @@ struct
           fetch Keys.working_branch_ref
           >>= fun working_branch_ref ->
           fetch Keys.dest_branch_ref
-          >>= fun dest_branch_ref ->
+          >>= fun _dest_branch_ref ->
           fetch Keys.branch_ref
-          >>= fun branch_ref ->
+          >>= fun _branch_ref ->
           Fc.Result.all3
             (fetch Keys.repo_config_raw)
             (fetch Keys.repo_tree_branch)
             (fetch Keys.synthesized_config_empty_index)
-          >>= fun ((_, repo_config_raw), repo_tree, config) ->
+          >>= fun ((_, _repo_config_raw), repo_tree, config) ->
           Abbs_time_it.run
             (fun t -> Logs.info (fun m -> m "%s : MATCH_DIFF_LIST : time=%f" (Builder.log_id s) t))
             (fun () ->
@@ -1584,7 +1584,7 @@ struct
                     (Error (`Msg_err "MISSING_REPO_CONFIG_INDEX_DESPITE_WM_COMPLETED"))))
 
     let repo_index_branch =
-      run ~name:"repo_index_branch" (fun s { Bs.Fetcher.fetch } ->
+      run ~name:"repo_index_branch" (fun _s { Bs.Fetcher.fetch } ->
           let module V1 = Terrat_base_repo_config_v1 in
           let open Irm in
           fetch Keys.dest_branch_name
@@ -1631,7 +1631,7 @@ struct
             (fetch Keys.repo_config_dest_branch_raw)
             (fetch Keys.repo_tree_dest_branch)
             (fetch Keys.synthesized_config_empty_index)
-          >>= fun ((_, repo_config_raw), repo_tree, config) ->
+          >>= fun ((_, _repo_config_raw), repo_tree, config) ->
           Abbs_time_it.run
             (fun t -> Logs.info (fun m -> m "%s : MATCH_DIFF_LIST : time=%f" (Builder.log_id s) t))
             (fun () ->
@@ -1669,7 +1669,7 @@ struct
                   Abb.Future.return (Error `Error)))
 
     let repo_index_dest_branch =
-      run ~name:"repo_index_dest_branch" (fun s { Bs.Fetcher.fetch } ->
+      run ~name:"repo_index_dest_branch" (fun _s { Bs.Fetcher.fetch } ->
           let open Irm in
           let module V1 = Terrat_base_repo_config_v1 in
           fetch Keys.repo_config_dest_branch_raw
@@ -1975,7 +1975,7 @@ struct
               >>= fun () -> Abb.Future.return (Error `Noop))
 
     let publish_dest_branch_no_match =
-      run ~name:"publish_dest_branch_no_match" (fun s { Bs.Fetcher.fetch } ->
+      run ~name:"publish_dest_branch_no_match" (fun _s { Bs.Fetcher.fetch } ->
           let open Irm in
           fetch Keys.pull_request
           >>= fun pull_request ->
@@ -2194,7 +2194,7 @@ struct
           let open Abb.Future.Infix_monad in
           Tf_op_wm.Plan.run ~dest_branch_ref ~branch_ref ~branch ~name:"plan_wm" s fetcher
           >>= function
-          | Ok wms -> maybe_finalize_when_all_applied s fetcher
+          | Ok _wms -> maybe_finalize_when_all_applied s fetcher
           | Error (#Str_template.err as err) ->
               let open Irm in
               fetch Keys.publish_comment
@@ -2211,7 +2211,7 @@ struct
           fetch Keys.working_branch_name
           >>= fun branch ->
           Tf_op_wm.Apply.run ~dest_branch_ref ~branch_ref ~branch ~name:"apply_wm" s fetcher
-          >>= fun wms -> maybe_finalize_when_all_applied s fetcher)
+          >>= fun _wms -> maybe_finalize_when_all_applied s fetcher)
 
     let maybe_complete_job =
       run ~name:"maybe_complete_job" (fun s { Bs.Fetcher.fetch } ->
@@ -2374,7 +2374,7 @@ struct
         let open Irm in
         time_it
           s
-          (fun m log_id time ->
+          (fun m log_id _time ->
             m
               "%s : WM : UPDATE_STATE : work_manifest_id = %a : run_id = %s : state = aborted"
               log_id
@@ -2846,7 +2846,7 @@ struct
           fetch Keys.job >>= fun job -> H.complete_job s job @@ run)
 
     let run_missing_drift_schedules =
-      run ~name:"run_missing_drift_schedules" (fun s { Bs.Fetcher.fetch } ->
+      run ~name:"run_missing_drift_schedules" (fun s { Bs.Fetcher.fetch = _ } ->
           let open Irm in
           Builder.run_db s ~f:(fun db ->
               time_it
@@ -3042,7 +3042,7 @@ struct
           | _ -> Abb.Future.return (Ok ()))
 
     let finalize_unfinished_terrateam_checks =
-      run ~name:"finalize_unfinished_terrateam_checks" (fun s { Bs.Fetcher.fetch } ->
+      run ~name:"finalize_unfinished_terrateam_checks" (fun _s { Bs.Fetcher.fetch } ->
           let module Ch = Terrat_commit_check in
           let module Status = Ch.Status in
           let open Irm in

--- a/code/src/terrat_vcs_event_evaluator2/terrat_vcs_event_evaluator2_tasks.mli
+++ b/code/src/terrat_vcs_event_evaluator2/terrat_vcs_event_evaluator2_tasks.mli
@@ -1,5 +1,5 @@
 module Make
     (S : Terrat_vcs_provider2.S)
-    (Keys : module type of Terrat_vcs_event_evaluator2_targets.Make (S)) : sig
+    (_ : module type of Terrat_vcs_event_evaluator2_targets.Make (S)) : sig
   val default_tasks : unit -> Terrat_vcs_event_evaluator2_targets.Make(S).Hmap.t
 end

--- a/code/src/terrat_vcs_event_evaluator2/terrat_vcs_event_evaluator2_tasks_base.mli
+++ b/code/src/terrat_vcs_event_evaluator2/terrat_vcs_event_evaluator2_tasks_base.mli
@@ -1,6 +1,6 @@
 module Make
     (S : Terrat_vcs_provider2.S)
-    (Keys : module type of Terrat_vcs_event_evaluator2_targets.Make (S)) : sig
+    (_ : module type of Terrat_vcs_event_evaluator2_targets.Make (S)) : sig
   module Builder : module type of Terrat_vcs_event_evaluator2_builder.Make (S)
 
   val run :

--- a/code/src/terrat_vcs_event_evaluator2/terrat_vcs_event_evaluator2_tasks_branch.ml
+++ b/code/src/terrat_vcs_event_evaluator2/terrat_vcs_event_evaluator2_tasks_branch.ml
@@ -30,7 +30,7 @@ struct
     let run = Tasks_base.run
 
     let branch_name =
-      run ~name:"branch_name" (fun s { Bs.Fetcher.fetch } ->
+      run ~name:"branch_name" (fun _s { Bs.Fetcher.fetch } ->
           let open Irm in
           fetch Keys.context
           >>= function
@@ -69,7 +69,7 @@ struct
        care if the dest branch adn the branch name are the same, it just checks
        there and does the right thing. *)
     let dest_branch_name =
-      run ~name:"dest_branch_name" (fun s { Bs.Fetcher.fetch } ->
+      run ~name:"dest_branch_name" (fun _s { Bs.Fetcher.fetch } ->
           let open Irm in
           fetch Keys.context
           >>= function
@@ -159,7 +159,7 @@ struct
           Abb.Future.return (Ok (fun matches -> Abb.Future.return (Ok matches))))
 
     let is_draft_pr =
-      run ~name:"is_draft_pr" (fun s { Bs.Fetcher.fetch } -> Abb.Future.return (Ok false))
+      run ~name:"is_draft_pr" (fun _s { Bs.Fetcher.fetch = _ } -> Abb.Future.return (Ok false))
 
     let check_conflicting_apply_work_manifests =
       run ~name:"check_conflicting_apply_work_manifests" (fun s { Bs.Fetcher.fetch } ->
@@ -196,13 +196,13 @@ struct
           | Some (P2.Conflicting_work_manifests.Maybe_stale _) -> Abb.Future.return (Error `Noop))
 
     let can_run_plan =
-      run ~name:"can_run_plan" (fun s { Bs.Fetcher.fetch } ->
+      run ~name:"can_run_plan" (fun _s { Bs.Fetcher.fetch } ->
           let open Irm in
           Fc.Result.all2 (fetch Keys.branch_dirspaces) (fetch Keys.dest_branch_dirspaces)
           >>= fun (_, _) -> Abb.Future.return (Ok ()))
 
     let can_run_apply =
-      run ~name:"can_run_apply" (fun s { Bs.Fetcher.fetch } ->
+      run ~name:"can_run_apply" (fun _s { Bs.Fetcher.fetch } ->
           let open Irm in
           Fc.Result.ignore
           @@ Fc.Result.all3

--- a/code/src/terrat_vcs_event_evaluator2/terrat_vcs_event_evaluator2_tasks_branch.mli
+++ b/code/src/terrat_vcs_event_evaluator2/terrat_vcs_event_evaluator2_tasks_branch.mli
@@ -1,6 +1,6 @@
 module Make
     (S : Terrat_vcs_provider2.S)
-    (Keys : module type of Terrat_vcs_event_evaluator2_targets.Make (S)) : sig
+    (_ : module type of Terrat_vcs_event_evaluator2_targets.Make (S)) : sig
   val tasks :
     Terrat_vcs_event_evaluator2_targets.Make(S).Hmap.t ->
     Terrat_vcs_event_evaluator2_targets.Make(S).Hmap.t

--- a/code/src/terrat_vcs_event_evaluator2/terrat_vcs_event_evaluator2_tasks_pr.ml
+++ b/code/src/terrat_vcs_event_evaluator2/terrat_vcs_event_evaluator2_tasks_pr.ml
@@ -336,7 +336,7 @@ struct
           fetch Keys.client
           >>= fun client ->
           fetch Keys.pull_request
-          >>= fun pull_request ->
+          >>= fun _pull_request ->
           fetch Keys.repo
           >>= fun repo ->
           Abb.Future.return
@@ -369,28 +369,28 @@ struct
           S.Api.fetch_commit_checks ~request_id:(Builder.log_id s) client repo branch_ref)
 
     let branch_name =
-      run ~name:"branch_name" (fun s { Bs.Fetcher.fetch } ->
+      run ~name:"branch_name" (fun _s { Bs.Fetcher.fetch } ->
           let open Irm in
           fetch Keys.pull_request
           >>= fun pull_request ->
           Abb.Future.return (Ok (S.Api.Pull_request.branch_name pull_request)))
 
     let branch_ref =
-      run ~name:"branch_ref" (fun s { Bs.Fetcher.fetch } ->
+      run ~name:"branch_ref" (fun _s { Bs.Fetcher.fetch } ->
           let open Irm in
           fetch Keys.pull_request
           >>= fun pull_request ->
           Abb.Future.return (Ok (S.Api.Pull_request.branch_ref pull_request)))
 
     let dest_branch_name =
-      run ~name:"dest_branch_name" (fun s { Bs.Fetcher.fetch } ->
+      run ~name:"dest_branch_name" (fun _s { Bs.Fetcher.fetch } ->
           let open Irm in
           fetch Keys.pull_request
           >>= fun pull_request ->
           Abb.Future.return (Ok (S.Api.Pull_request.base_branch_name pull_request)))
 
     let dest_branch_ref =
-      run ~name:"dest_branch_ref" (fun s { Bs.Fetcher.fetch } ->
+      run ~name:"dest_branch_ref" (fun _s { Bs.Fetcher.fetch } ->
           let open Irm in
           fetch Keys.pull_request
           >>= fun pull_request -> Abb.Future.return (Ok (S.Api.Pull_request.base_ref pull_request)))
@@ -425,7 +425,7 @@ struct
           | None -> Abb.Future.return (Error `Error))
 
     let working_branch_ref =
-      run ~name:"working_branch_ref" (fun s { Bs.Fetcher.fetch } ->
+      run ~name:"working_branch_ref" (fun _s { Bs.Fetcher.fetch } ->
           let open Irm in
           fetch Keys.pull_request
           >>= fun pull_request ->
@@ -435,7 +435,7 @@ struct
           | Terrat_pull_request.State.Merged _ -> fetch Keys.working_dest_branch_ref)
 
     let working_branch_name =
-      run ~name:"working_branch_name" (fun s { Bs.Fetcher.fetch } ->
+      run ~name:"working_branch_name" (fun _s { Bs.Fetcher.fetch } ->
           let open Irm in
           fetch Keys.pull_request
           >>= fun pull_request ->
@@ -558,7 +558,7 @@ struct
                         | None -> Error (`Invalid_unlock_id s)))
                   unlock_ids
           in
-          let run client pull_request unlock_ids =
+          let run _client _pull_request unlock_ids =
             let open Irm in
             fetch Keys.repo
             >>= fun repo ->
@@ -600,7 +600,7 @@ struct
           | _ -> assert false)
 
     let publish_repo_config =
-      run ~name:"publish_repo_config" (fun s { Bs.Fetcher.fetch } ->
+      run ~name:"publish_repo_config" (fun _s { Bs.Fetcher.fetch } ->
           let open Irm in
           Fc.Result.all2 (fetch Keys.repo_config_with_provenance) (fetch Keys.store_stacks)
           >>= fun (repo_config_with_provenance, ()) ->
@@ -609,13 +609,13 @@ struct
           publish_comment' publish_comment (Msg.Repo_config repo_config_with_provenance))
 
     let publish_help =
-      run ~name:"publish_help" (fun s { Bs.Fetcher.fetch } ->
+      run ~name:"publish_help" (fun _s { Bs.Fetcher.fetch } ->
           let open Irm in
           fetch Keys.publish_comment
           >>= fun publish_comment -> publish_comment' publish_comment Msg.Help)
 
     let comment_id =
-      run ~name:"comment_id" (fun s { Bs.Fetcher.fetch } ->
+      run ~name:"comment_id" (fun _s { Bs.Fetcher.fetch = _ } ->
           (* This is a default value in case no comment id is set in the store
              by the runner. *)
           Abb.Future.return (Ok None))
@@ -798,7 +798,7 @@ struct
           >>= fun pull_request -> fetch_pull_request_reviews s client repo pull_request)
 
     let access_control_eval_plan =
-      run ~name:"access_control_eval_plan" (fun s { Bs.Fetcher.fetch } ->
+      run ~name:"access_control_eval_plan" (fun _s { Bs.Fetcher.fetch } ->
           let open Irm in
           fetch Keys.access_control
           >>= fun access_control ->
@@ -809,7 +809,7 @@ struct
           >>= fun ret -> Abb.Future.return (Ok ret))
 
     let access_control_eval_apply =
-      run ~name:"access_control_eval_apply" (fun s { Bs.Fetcher.fetch } ->
+      run ~name:"access_control_eval_apply" (fun _s { Bs.Fetcher.fetch } ->
           let module Rr = Terrat_pull_request_review in
           let open Irm in
           fetch Keys.access_control
@@ -817,9 +817,9 @@ struct
           fetch Keys.working_set_matches
           >>= fun working_set_matches ->
           fetch Keys.client
-          >>= fun client ->
+          >>= fun _client ->
           fetch Keys.repo
-          >>= fun repo ->
+          >>= fun _repo ->
           fetch Keys.pull_request_reviews
           >>= fun reviews ->
           let reviews =
@@ -847,7 +847,7 @@ struct
           >>= fun ret -> Abb.Future.return (Ok ret))
 
     let check_access_control_plan =
-      run ~name:"check_access_control_plan" (fun s { Bs.Fetcher.fetch } ->
+      run ~name:"check_access_control_plan" (fun _s { Bs.Fetcher.fetch } ->
           let module R = Terrat_access_control2.R in
           let open Irm in
           fetch Keys.access_control
@@ -863,7 +863,7 @@ struct
                 (Msg.Access_control_denied
                    ( S.Api.Ref.to_string access_control.Keys.Access_control_engine.policy_branch,
                      `All_dirspaces deny ))
-          | Ok { R.pass; deny }
+          | Ok { R.pass = _; deny }
             when CCList.is_empty deny
                  || not (Access_control.plan_require_all_dirspace_access access_control) ->
               Abb.Future.return (Ok ())
@@ -931,13 +931,13 @@ struct
           | None -> assert false)
 
     let check_access_control_apply =
-      run ~name:"check_access_control_apply" (fun s { Bs.Fetcher.fetch } ->
+      run ~name:"check_access_control_apply" (fun _s { Bs.Fetcher.fetch } ->
           let module R = Terrat_access_control2.R in
           let open Irm in
           fetch Keys.job
-          >>= fun job ->
+          >>= fun _job ->
           fetch Keys.check_apply_requirements
-          >>= fun apply_requirements ->
+          >>= fun _apply_requirements ->
           Fc.Result.all6
             (fetch Keys.access_control)
             (fetch Keys.matches)
@@ -945,7 +945,7 @@ struct
             (fetch Keys.pull_request)
             (fetch Keys.access_control_eval_apply)
             (fetch Keys.user)
-          >>= fun (access_control, matches, client, pull_request, access_control_result, user) ->
+          >>= fun (access_control, _matches, _client, _pull_request, access_control_result, _user) ->
           Abb.Future.return
             (access_control_result
               : (R.t, Terrat_access_control2.err) result
@@ -962,7 +962,7 @@ struct
                    ( S.Api.Ref.to_string access_control.Keys.Access_control_engine.policy_branch,
                      `All_dirspaces deny ))
               >>= fun () -> Abb.Future.return (Error `Noop)
-          | { Terrat_access_control2.R.pass; deny }
+          | { Terrat_access_control2.R.pass = _; deny }
             when CCList.is_empty deny
                  || not (Access_control.apply_require_all_dirspace_access access_control) ->
               (* This is the success path *)
@@ -982,7 +982,7 @@ struct
           let module R = Terrat_access_control2.R in
           let open Irm in
           fetch Keys.pull_request
-          >>= fun pull_request ->
+          >>= fun _pull_request ->
           fetch Keys.access_control_eval_apply
           >>= fun access_control_eval ->
           Abb.Future.return
@@ -1079,7 +1079,7 @@ struct
                   fetch Keys.account
                   >>= fun account ->
                   fetch Keys.client
-                  >>= fun client ->
+                  >>= fun _client ->
                   fetch Keys.working_branch_ref
                   >>= fun working_branch_ref ->
                   let checks =
@@ -1099,7 +1099,7 @@ struct
           | _ -> Abb.Future.return (Ok ()))
 
     let check_dirspaces_to_apply =
-      run ~name:"check_dirspaces_to_apply" (fun s { Bs.Fetcher.fetch } ->
+      run ~name:"check_dirspaces_to_apply" (fun _s { Bs.Fetcher.fetch } ->
           let open Irm in
           fetch Keys.job
           >>= function
@@ -1162,7 +1162,7 @@ struct
               >>= fun () -> Abb.Future.return (Error `Noop))
 
     let check_access_control_repo_config =
-      run ~name:"check_access_control_repo_config" (fun s { Bs.Fetcher.fetch } ->
+      run ~name:"check_access_control_repo_config" (fun _s { Bs.Fetcher.fetch } ->
           let open Irm in
           Fc.Result.all2 (fetch Keys.access_control) (fetch Keys.changes)
           >>= fun (access_control, diff) ->
@@ -1192,7 +1192,7 @@ struct
               >>= fun () -> Abb.Future.return (Error `Noop))
 
     let check_access_control_files =
-      run ~name:"check_access_control_files" (fun s { Bs.Fetcher.fetch } ->
+      run ~name:"check_access_control_files" (fun _s { Bs.Fetcher.fetch } ->
           let open Irm in
           Fc.Result.all2 (fetch Keys.access_control) (fetch Keys.changes)
           >>= fun (access_control, diff) ->
@@ -1222,7 +1222,7 @@ struct
               >>= fun () -> Abb.Future.return (Error `Noop))
 
     let check_access_control_ci_change =
-      run ~name:"check_access_control_ci_change" (fun s { Bs.Fetcher.fetch } ->
+      run ~name:"check_access_control_ci_change" (fun _s { Bs.Fetcher.fetch } ->
           let open Irm in
           Fc.Result.all2 (fetch Keys.access_control) (fetch Keys.changes)
           >>= fun (access_control, diff) ->
@@ -1265,7 +1265,7 @@ struct
           Builder.run_db s ~f:(fun db -> store_stacks s db account repo pull_request config))
 
     let can_run_plan =
-      run ~name:"can_run_plan" (fun s { Bs.Fetcher.fetch } ->
+      run ~name:"can_run_plan" (fun _s { Bs.Fetcher.fetch } ->
           let maybe_publish_msg msg =
             let open Irm in
             fetch Keys.publish_comment
@@ -1552,7 +1552,7 @@ struct
                 fetch Keys.client
                 >>= fun client ->
                 fetch Keys.user
-                >>= fun user ->
+                >>= fun _user ->
                 fetch Keys.pull_request
                 >>= fun pull_request ->
                 let open Abb.Future.Infix_monad in

--- a/code/src/terrat_vcs_event_evaluator2/terrat_vcs_event_evaluator2_tasks_pr.mli
+++ b/code/src/terrat_vcs_event_evaluator2/terrat_vcs_event_evaluator2_tasks_pr.mli
@@ -1,6 +1,6 @@
 module Make
     (S : Terrat_vcs_provider2.S)
-    (Keys : module type of Terrat_vcs_event_evaluator2_targets.Make (S)) : sig
+    (_ : module type of Terrat_vcs_event_evaluator2_targets.Make (S)) : sig
   val tasks :
     Terrat_vcs_event_evaluator2_targets.Make(S).Hmap.t ->
     Terrat_vcs_event_evaluator2_targets.Make(S).Hmap.t

--- a/code/src/terrat_vcs_event_evaluator2/terrat_vcs_event_evaluator2_wm_sm.ml
+++ b/code/src/terrat_vcs_event_evaluator2/terrat_vcs_event_evaluator2_wm_sm.ml
@@ -216,7 +216,7 @@ struct
       | { Wm.state = Wm.State.Aborted; _ } -> false
       | _ -> true)
 
-  let publish_fail s { Builder.Bs.Fetcher.fetch } = function
+  let publish_fail _s { Builder.Bs.Fetcher.fetch } = function
     | (`Failed_to_start_with_msg_err _ | `Failed_to_start | `Missing_workflow) as err ->
         let open Irm in
         fetch Keys.publish_comment

--- a/code/src/terrat_vcs_event_evaluator2/terrat_vcs_event_evaluator2_wm_sm.mli
+++ b/code/src/terrat_vcs_event_evaluator2/terrat_vcs_event_evaluator2_wm_sm.mli
@@ -1,6 +1,6 @@
 module Make
     (S : Terrat_vcs_provider2.S)
-    (Keys : module type of Terrat_vcs_event_evaluator2_targets.Make (S)) : sig
+    (_ : module type of Terrat_vcs_event_evaluator2_targets.Make (S)) : sig
   module Builder : module type of Terrat_vcs_event_evaluator2_builder.Make (S)
 
   type existing_wm =

--- a/code/src/terrat_vcs_event_evaluator2/terrat_vcs_event_evaluator2_wm_sm_repo_tree.ml
+++ b/code/src/terrat_vcs_event_evaluator2/terrat_vcs_event_evaluator2_wm_sm_repo_tree.ml
@@ -210,7 +210,7 @@ struct
     fetch Keys.repo
     >>= fun repo ->
     fetch Keys.client
-    >>= fun client ->
+    >>= fun _client ->
     fetch Keys.branch_ref
     >>= fun branch_ref ->
     fetch Keys.branch_name

--- a/code/src/terrat_vcs_event_evaluator2/terrat_vcs_event_evaluator2_wm_sm_tf_op.ml
+++ b/code/src/terrat_vcs_event_evaluator2/terrat_vcs_event_evaluator2_wm_sm_tf_op.ml
@@ -393,9 +393,9 @@ struct
     fetch Keys.repo
     >>= fun repo ->
     fetch Keys.initiator
-    >>= fun initiator ->
+    >>= fun _initiator ->
     fetch Keys.target
-    >>= fun target ->
+    >>= fun _target ->
     fetch Keys.repo_config
     >>= fun repo_config ->
     fetch Keys.matches
@@ -552,7 +552,7 @@ struct
       fetch Keys.repo
       >>= fun repo ->
       fetch Keys.client
-      >>= fun client ->
+      >>= fun _client ->
       fetch Keys.branch_ref
       >>= fun branch_ref ->
       fetch Keys.create_commit_checks
@@ -570,7 +570,7 @@ struct
       >>= fun () ->
       Abb.Future.return (Ok ())
       >>= fun () ->
-      let { Wm.base_ref; branch_ref; changes; target; _ } = work_manifest in
+      let { Wm.base_ref = _; branch_ref = _; changes; target; _ } = work_manifest in
       let run_kind =
         match target with
         | P2.Target.Pr pr -> `Pull_request pr
@@ -641,7 +641,7 @@ struct
       fetch Keys.repo
       >>= fun repo ->
       fetch Keys.client
-      >>= fun client ->
+      >>= fun _client ->
       fetch Keys.branch_ref
       >>= fun branch_ref ->
       fetch Keys.create_commit_checks
@@ -662,7 +662,7 @@ struct
       match result with
       | Wmr.Work_manifest_tf_operation_result2 result ->
           fetch Keys.client
-          >>= fun client ->
+          >>= fun _client ->
           fetch Keys.matches
           >>= fun matches ->
           let work_manifest_result = S.Work_manifest.result2 result in
@@ -710,7 +710,7 @@ struct
                 (fetch Keys.client)
                 (fetch Keys.repo_config_with_provenance)
                 (fetch Keys.repo_tree_branch)
-              >>= fun (client, (provenance, repo_config), repo_tree) ->
+              >>= fun (_client, (_provenance, repo_config), repo_tree) ->
               fetch Keys.dest_branch_name
               >>= fun dest_branch_name ->
               fetch Keys.branch_name
@@ -839,7 +839,7 @@ struct
       && branch_ref = S.Api.Ref.to_string branch_ref'
       && steps = [ Wm.Step.Apply ]
 
-    let maybe_comment_autoapply_running s { Bs.Fetcher.fetch } =
+    let maybe_comment_autoapply_running _s { Bs.Fetcher.fetch } =
       let module Tjc = Terrat_job_context in
       let open Irm in
       fetch Keys.context
@@ -872,7 +872,7 @@ struct
       fetch Keys.repo
       >>= fun repo ->
       fetch Keys.client
-      >>= fun client ->
+      >>= fun _client ->
       fetch Keys.branch_ref
       >>= fun branch_ref ->
       fetch Keys.create_commit_checks
@@ -888,7 +888,7 @@ struct
         "Running"
         Status.Running
       >>= fun () ->
-      let { Wm.base_ref; branch_ref; changes; target; _ } = work_manifest in
+      let { Wm.base_ref = _; branch_ref = _; changes; target; _ } = work_manifest in
       let run_kind =
         match target with
         | P2.Target.Pr pr -> `Pull_request pr

--- a/code/src/terrat_vcs_github_comment/terrat_vcs_github_comment_publishers.ml
+++ b/code/src/terrat_vcs_github_comment/terrat_vcs_github_comment_publishers.ml
@@ -23,7 +23,7 @@ module Output = struct
     let name = CCOption.map_or ~default:name snd (CCString.Split.right ~by:"/" name) in
     { cmd; name; success; text; text_decorator; visible_on }
 
-  let to_kv { cmd; name; success; text; text_decorator; visible_on } =
+  let to_kv { cmd; name; success; text; text_decorator; visible_on = _ } =
     `Assoc
       (CCList.flatten
          [
@@ -51,7 +51,7 @@ let steps_has_changes steps =
   match
     CCList.find_map
       (function
-        | { O.step = "tf/plan" | "pulumi/plan" | "custom/plan" | "fly/plan"; payload; success; _ }
+        | { O.step = "tf/plan" | "pulumi/plan" | "custom/plan" | "fly/plan"; payload; success = _; _ }
           -> (
             match P.of_yojson (O.Payload.to_yojson payload) with
             | Ok { P.has_changes } -> Some has_changes
@@ -191,7 +191,7 @@ let output_of_plan output =
   let module O = Terrat_api_components.Workflow_step_output in
   let open CCResult.Infix in
   P.of_yojson (O.Payload.to_yojson output.O.payload)
-  >>= fun { P.cmd; text; has_changes; plan } ->
+  >>= fun { P.cmd; text; has_changes = _; plan } ->
   if output.O.success then
     Ok
       (Output.make
@@ -221,7 +221,7 @@ let output_of_workflow_output output =
   | "tf/apply" | "pulumi/apply" | "custom/apply" | "fly/apply" ->
       output_of_run ~default_visible_on:Visible_on.Always output
   | "tf/plan" | "pulumi/plan" | "custom/plan" | "fly/plan" -> output_of_plan output
-  | step -> output_of_run output
+  | _step -> output_of_run output
 
 let output_of_raw output =
   let module O = Terrat_api_components.Workflow_step_output in
@@ -260,7 +260,7 @@ let dirspace_compare (dirspace1, steps1) (dirspace2, steps2) =
   Cmp.compare (not has_changes1, success1, dirspace1) (not has_changes2, success2, dirspace2)
 
 module Comment_api = struct
-  let comment_on_pull_request ~request_id client pull_request msg_type body =
+  let comment_on_pull_request ~request_id client pull_request _msg_type body =
     let open Abbs_future_combinators.Infix_result_monad in
     Api.comment_on_pull_request ~request_id client pull_request body
     >>= fun comment_id -> Abb.Future.return (Ok comment_id)

--- a/code/src/terrat_vcs_gitlab_comment/terrat_vcs_gitlab_comment.ml
+++ b/code/src/terrat_vcs_gitlab_comment/terrat_vcs_gitlab_comment.ml
@@ -41,19 +41,19 @@ module S = struct
     type t = bool * bool * Terrat_dirspace.t [@@deriving ord]
   end
 
-  let create_el t dirspace steps =
-    (* TODO: Once proper tables for GitLab exist, replace this function 
+  let create_el _t dirspace steps =
+    (* TODO: Once proper tables for GitLab exist, replace this function
        with a similar implementation that is used in GITLAB *)
     let module St = Terrat_vcs_comment.Strategy in
     let compact = false in
     let strategy = St.Append in
     Some { dirspace; steps; strategy; compact }
 
-  let query_comment_id t el = raise (Failure "nyi")
-  let query_els_for_comment_id t cid = raise (Failure "nyi")
-  let upsert_comment_id t els cid = Abb.Future.return (Ok ())
-  let delete_comment t comment_id = raise (Failure "nyi")
-  let minimize_comment t comment_id = raise (Failure "nyi")
+  let query_comment_id _t _el = raise (Failure "nyi")
+  let query_els_for_comment_id _t _cid = raise (Failure "nyi")
+  let upsert_comment_id _t _els _cid = Abb.Future.return (Ok ())
+  let delete_comment _t _comment_id = raise (Failure "nyi")
+  let minimize_comment _t _comment_id = raise (Failure "nyi")
 
   let post_comment t els =
     let open Abb.Future.Infix_monad in
@@ -154,7 +154,7 @@ module S = struct
 
   let dirspace el = el.dirspace
   (* TODO: Remove this once proper GitLab migrations are also merged *)
-  let strategy el = Terrat_vcs_comment.Strategy.Append
+  let strategy _el = Terrat_vcs_comment.Strategy.Append
   let compact el = { el with compact = true }
 
   let compare_el el1 el2 =

--- a/code/src/terrat_vcs_gitlab_comment/terrat_vcs_gitlab_comment_publishers.ml
+++ b/code/src/terrat_vcs_gitlab_comment/terrat_vcs_gitlab_comment_publishers.ml
@@ -23,7 +23,7 @@ module Output = struct
     let name = CCOption.map_or ~default:name snd (CCString.Split.right ~by:"/" name) in
     { cmd; name; success; text; text_decorator; visible_on }
 
-  let to_kv { cmd; name; success; text; text_decorator; visible_on } =
+  let to_kv { cmd; name; success; text; text_decorator; visible_on = _ } =
     `Assoc
       (CCList.flatten
          [
@@ -51,7 +51,7 @@ let steps_has_changes steps =
   match
     CCList.find_map
       (function
-        | { O.step = "tf/plan" | "pulumi/plan" | "custom/plan" | "fly/plan"; payload; success; _ }
+        | { O.step = "tf/plan" | "pulumi/plan" | "custom/plan" | "fly/plan"; payload; success = _; _ }
           -> (
             match P.of_yojson (O.Payload.to_yojson payload) with
             | Ok { P.has_changes } -> Some has_changes
@@ -191,7 +191,7 @@ let output_of_plan output =
   let module O = Terrat_api_components.Workflow_step_output in
   let open CCResult.Infix in
   P.of_yojson (O.Payload.to_yojson output.O.payload)
-  >>= fun { P.cmd; text; has_changes; plan } ->
+  >>= fun { P.cmd; text; has_changes = _; plan } ->
   if output.O.success then
     Ok
       (Output.make
@@ -221,7 +221,7 @@ let output_of_workflow_output output =
   | "tf/apply" | "pulumi/apply" | "custom/apply" | "fly/apply" ->
       output_of_run ~default_visible_on:Visible_on.Always output
   | "tf/plan" | "pulumi/plan" | "custom/plan" | "fly/plan" -> output_of_plan output
-  | step -> output_of_run output
+  | _step -> output_of_run output
 
 let output_of_raw output =
   let module O = Terrat_api_components.Workflow_step_output in
@@ -260,7 +260,7 @@ let dirspace_compare (dirspace1, steps1) (dirspace2, steps2) =
   Cmp.compare (not has_changes1, success1, dirspace1) (not has_changes2, success2, dirspace2)
 
 module Comment_api = struct
-  let comment_on_pull_request ~request_id client pull_request msg_type body =
+  let comment_on_pull_request ~request_id client pull_request _msg_type body =
     let open Abbs_future_combinators.Infix_result_monad in
     Api.comment_on_pull_request ~request_id client pull_request body
     >>= fun comment_id -> Abb.Future.return (Ok comment_id)

--- a/code/src/terrat_vcs_gitlab_comment/terrat_vcs_gitlab_comment_ui.ml
+++ b/code/src/terrat_vcs_gitlab_comment/terrat_vcs_gitlab_comment_ui.ml
@@ -1,3 +1,3 @@
 module Ui = struct
-  let work_manifest_url config account work_manifest = None
+  let work_manifest_url _config _account _work_manifest = None
 end

--- a/code/src/terrat_vcs_gitlab_comment_templates/terrat_vcs_gitlab_comment_templates.ml
+++ b/code/src/terrat_vcs_gitlab_comment_templates/terrat_vcs_gitlab_comment_templates.ml
@@ -207,5 +207,5 @@ module Tmpl = struct
 end
 
 module Ui = struct
-  let work_manifest_url config account = raise (Failure "nyi")
+  let work_manifest_url _config _account = raise (Failure "nyi")
 end

--- a/code/src/terrat_vcs_kv_store/terrat_vcs_kv_store.ml
+++ b/code/src/terrat_vcs_kv_store/terrat_vcs_kv_store.ml
@@ -70,7 +70,7 @@ struct
         Abb.Future.return (Error (Brtl_ctx.set_response `Internal_server_error ctx))
 
   module Get = struct
-    let run config storage installation_id key committed idx select =
+    let run _config storage installation_id key committed idx select =
       Brtl_ep.run_result_json ~f:(fun ctx ->
           let open Abbs_future_combinators.Infix_result_monad in
           Terrat_session.with_session ~caps:[ Cap.Kv_store_read ] ctx
@@ -94,7 +94,7 @@ struct
   end
 
   module Set = struct
-    let run config storage installation_id key body =
+    let run _config storage installation_id key body =
       Brtl_ep.run_result_json ~f:(fun ctx ->
           let open Abbs_future_combinators.Infix_result_monad in
           Terrat_session.with_session ~caps:[ Cap.Kv_store_write ] ctx
@@ -135,7 +135,7 @@ struct
   end
 
   module Cas = struct
-    let run config storage installation_id key body =
+    let run _config storage installation_id key body =
       Brtl_ep.run_result_json ~f:(fun ctx ->
           let open Abbs_future_combinators.Infix_result_monad in
           Terrat_session.with_session ~caps:[ Cap.Kv_store_read; Cap.Kv_store_write ] ctx
@@ -181,7 +181,7 @@ struct
   end
 
   module Delete = struct
-    let run config storage installation_id key idx version =
+    let run _config storage installation_id key idx version =
       Brtl_ep.run_result_json ~f:(fun ctx ->
           let open Abbs_future_combinators.Infix_result_monad in
           Terrat_session.with_session ~caps:[ Cap.Kv_store_read; Cap.Kv_store_write ] ctx
@@ -204,7 +204,7 @@ struct
   end
 
   module Count = struct
-    let run config storage installation_id key committed =
+    let run _config storage installation_id key committed =
       Brtl_ep.run_result_json ~f:(fun ctx ->
           let open Abbs_future_combinators.Infix_result_monad in
           Terrat_session.with_session ~caps:[ Cap.Kv_store_read ] ctx
@@ -229,7 +229,7 @@ struct
   end
 
   module Size = struct
-    let run config storage installation_id key idx committed =
+    let run _config storage installation_id key idx committed =
       Brtl_ep.run_result_json ~f:(fun ctx ->
           let open Abbs_future_combinators.Infix_result_monad in
           Terrat_session.with_session ~caps:[ Cap.Kv_store_read ] ctx
@@ -253,7 +253,7 @@ struct
   end
 
   module Iter = struct
-    let run config storage installation_id key select idx inclusive committed prefix limit =
+    let run _config storage installation_id key select idx inclusive committed prefix limit =
       Brtl_ep.run_result_json ~f:(fun ctx ->
           let open Abbs_future_combinators.Infix_result_monad in
           Terrat_session.with_session ~caps:[ Cap.Kv_store_read ] ctx
@@ -276,7 +276,7 @@ struct
   end
 
   module Commit = struct
-    let run config storage installation_id commit =
+    let run _config storage installation_id commit =
       Brtl_ep.run_result_json ~f:(fun ctx ->
           let open Abbs_future_combinators.Infix_result_monad in
           Terrat_session.with_session ~caps:[ Cap.Kv_store_write ] ctx

--- a/code/src/terrat_vcs_kv_store/terrat_vcs_kv_store.mli
+++ b/code/src/terrat_vcs_kv_store/terrat_vcs_kv_store.mli
@@ -14,7 +14,7 @@ end
 
 module Make
     (P : Terrat_vcs_provider2.S)
-    (S : S with type Installation_id.t = P.Api.Account.Id.t) : sig
+    (_ : S with type Installation_id.t = P.Api.Account.Id.t) : sig
   val routes :
     P.Api.Config.t ->
     Terrat_storage.t ->

--- a/code/src/terrat_vcs_service_github/terrat_vcs_service_github.mli
+++ b/code/src/terrat_vcs_service_github/terrat_vcs_service_github.mli
@@ -11,5 +11,5 @@ module Make
     (Provider :
       Terrat_vcs_provider2_github.S
         with type Api.Config.t = Terrat_vcs_service_github_provider.Api.Config.t)
-    (Routes : ROUTES with type config = Provider.Api.Config.t) :
+    (_ : ROUTES with type config = Provider.Api.Config.t) :
   Terrat_vcs_service.S with type Service.vcs_config = Provider.Api.Config.vcs_config

--- a/code/src/terrat_vcs_service_github/terrat_vcs_service_github_ep_client_id.ml
+++ b/code/src/terrat_vcs_service_github/terrat_vcs_service_github_ep_client_id.ml
@@ -1,4 +1,4 @@
-let get config storage =
+let get config _storage =
   Brtl_ep.run_json ~f:(fun ctx ->
       let body =
         Terrat_api_api_v1.Client_id.Responses.OK.(

--- a/code/src/terrat_vcs_service_github/terrat_vcs_service_github_ep_events3.ml
+++ b/code/src/terrat_vcs_service_github/terrat_vcs_service_github_ep_events3.ml
@@ -159,7 +159,7 @@ module Make (P : Terrat_vcs_provider2_github.S) = struct
         | Ok () -> f ()
         | Error _ as err -> Abb.Future.return err)
 
-  let process_installation request_id config storage = function
+  let process_installation _request_id config storage = function
     | Gw.Installation_event.Installation_created created ->
         let open Abbs_future_combinators.Infix_result_monad in
         Prmths.Counter.inc_one (Metrics.installation_events_total "created");
@@ -783,7 +783,7 @@ module Make (P : Terrat_vcs_provider2_github.S) = struct
         Abb.Future.return
           (Brtl_ctx.set_response (Brtl_rspnc.create ~status:`Internal_server_error "") ctx)
 
-  let process_event_handler config storage ctx f =
+  let process_event_handler _config _storage ctx f =
     let open Abb.Future.Infix_monad in
     f ()
     >>= function

--- a/code/src/terrat_vcs_service_github/terrat_vcs_service_github_ep_installations.ml
+++ b/code/src/terrat_vcs_service_github/terrat_vcs_service_github_ep_installations.ml
@@ -1157,7 +1157,7 @@ module Make (S : S with type Account_id.t = int) = struct
 
     module Paginate = Brtl_ep_paginate.Make (Page)
 
-    let get config storage installation_id pr_opt page limit =
+    let get _config storage installation_id pr_opt page limit =
       Brtl_ep.run_result_json ~f:(fun ctx ->
           let open Abbs_future_combinators.Infix_result_monad in
           Terrat_session.with_session ctx
@@ -1274,7 +1274,7 @@ module Make (S : S with type Account_id.t = int) = struct
 
     module Paginate = Brtl_ep_paginate.Make (Page)
 
-    let get config storage installation_id page limit =
+    let get _config storage installation_id page limit =
       Brtl_ep.run_result_json ~f:(fun ctx ->
           let open Abbs_future_combinators.Infix_result_monad in
           Terrat_session.with_session ctx

--- a/code/src/terrat_vcs_service_github/terrat_vcs_service_github_ep_installations.mli
+++ b/code/src/terrat_vcs_service_github/terrat_vcs_service_github_ep_installations.mli
@@ -9,7 +9,7 @@ module type S = sig
     (unit, [> `Forbidden ]) result Abb.Future.t
 end
 
-module Make (S : S with type Account_id.t = int) : sig
+module Make (_ : S with type Account_id.t = int) : sig
   module Work_manifests : sig
     module Outputs : sig
       val get :

--- a/code/src/terrat_vcs_service_github/terrat_vcs_service_github_ep_repo_delete.ml
+++ b/code/src/terrat_vcs_service_github/terrat_vcs_service_github_ep_repo_delete.ml
@@ -51,7 +51,7 @@ module Make (P : Terrat_vcs_provider2_github.S) (S : S) = struct
     if P.Api.Remote_repo.is_archived remote_repo then Abb.Future.return (Ok ())
     else Abb.Future.return (Error `Not_archived)
 
-  let perform_delete ~request_id config storage installation_id repo_id user db =
+  let perform_delete ~request_id config _storage installation_id repo_id user db =
     let open Abbs_future_combinators.Infix_result_monad in
     P.Db.query_repo_by_id ~request_id db installation_id repo_id
     >>= function

--- a/code/src/terrat_vcs_service_github/terrat_vcs_service_github_ep_user.ml
+++ b/code/src/terrat_vcs_service_github/terrat_vcs_service_github_ep_user.ml
@@ -25,7 +25,7 @@ module Whoami = struct
         /% Var.uuid "user_id")
   end
 
-  let get config storage =
+  let get _config storage =
     Brtl_ep.run_result_json ~f:(fun ctx ->
         let open Abbs_future_combinators.Infix_result_monad in
         Terrat_session.with_session ctx

--- a/code/src/terrat_vcs_service_github/terrat_vcs_service_github_ep_work_manifest.ml
+++ b/code/src/terrat_vcs_service_github/terrat_vcs_service_github_ep_work_manifest.ml
@@ -83,7 +83,7 @@ module Make (P : Terrat_vcs_provider2_github.S) = struct
   end
 
   module Plans = struct
-    let post config storage work_manifest_id plan =
+    let post _config storage work_manifest_id plan =
       Brtl_ep.run_result_json ~f:(fun ctx ->
           let open Abbs_future_combinators.Infix_result_monad in
           (* TODO: Uncomment once all runs are on new work manifest access tokens *)
@@ -118,7 +118,7 @@ module Make (P : Terrat_vcs_provider2_github.S) = struct
           | Error `Error ->
               Abb.Future.return (Error (Brtl_ctx.set_response `Internal_server_error ctx)))
 
-    let get config storage work_manifest_id dir workspace =
+    let get _config storage work_manifest_id dir workspace =
       Brtl_ep.run_result_json ~f:(fun ctx ->
           let open Abbs_future_combinators.Infix_result_monad in
           (* TODO: Uncomment once all runs are on new work manifest access tokens *)
@@ -323,7 +323,7 @@ module Make (P : Terrat_vcs_provider2_github.S) = struct
           /% Var.uuid "id")
     end
 
-    let get config storage work_manifest_id =
+    let get _config storage work_manifest_id =
       Brtl_ep.run_result_json ~f:(fun ctx ->
           let open Abbs_future_combinators.Infix_result_monad in
           (* TODO: Uncomment once all runs are on new work manifest access tokens *)

--- a/code/src/terrat_vcs_service_github/terrat_vcs_service_github_provider.ml
+++ b/code/src/terrat_vcs_service_github/terrat_vcs_service_github_provider.ml
@@ -834,7 +834,7 @@ module Db = struct
                     state
                     tag_query
                     user
-                    run_kind
+                    _run_kind
                     installation_id
                     owner
                     name
@@ -1064,7 +1064,7 @@ module Db = struct
         Logs.err (fun m -> m "%s : ERROR : %a" request_id Pgsql_io.pp_err err);
         Abb.Future.return (Error `Error)
 
-  let lock_repository ~request_id db account repo =
+  let lock_repository ~request_id db _account repo =
     let open Abb.Future.Infix_monad in
     Metrics.Psql_query_time.time (Metrics.psql_query_time "select_repository_for_update") (fun () ->
         Pgsql_io.Prepared_stmt.fetch
@@ -2241,7 +2241,7 @@ module Apply_requirements = struct
     let open Abbs_future_combinators.Infix_result_monad in
     let module Tprr = Terrat_pull_request_review in
     let module Ac = Terrat_base_repo_config_v1.Apply_requirements.Approved in
-    let { Ac.all_of; any_of; any_of_count; enabled; require_completed_reviews } = approved in
+    let { Ac.all_of; any_of; any_of_count; enabled = _; require_completed_reviews } = approved in
     let combined_queries = Match_set.(to_list (of_list (all_of @ any_of))) in
     Abbs_future_combinators.List_result.fold_left
       ~init:Match_map.empty
@@ -2305,7 +2305,7 @@ module Apply_requirements = struct
            missing_any_of,
            any_of_count ))
 
-  let eval ~request_id config user client repo_config pull_request dirspace_configs =
+  let eval ~request_id _config _user client repo_config pull_request dirspace_configs =
     let max_parallel = 20 in
     let module R = Terrat_base_repo_config_v1 in
     let module Ar = R.Apply_requirements in
@@ -2631,10 +2631,10 @@ module Tier = struct
 end
 
 module Gate = struct
-  let add_approval ~request_id ~token ~approver pull_request db =
+  let add_approval ~request_id:_ ~token:_ ~approver:_ _pull_request _db =
     Abb.Future.return (Error (`Premium_feature_err `Gatekeeping))
 
-  let eval ~request_id _ _ _ _ = Abb.Future.return (Ok [])
+  let eval ~request_id:_ _ _ _ _ = Abb.Future.return (Ok [])
 end
 
 module Comment = struct
@@ -3310,7 +3310,7 @@ module Comment = struct
          Tmpl.repo_config_generic_failure
          kv
 
-  let repo_config_err ~request_id ~client ~pull_request ~title err =
+  let repo_config_err ~request_id ~client ~pull_request ~title:_ err =
     let module Gcm_api = Terrat_vcs_github_comment_publishers.Comment_api in
     match err with
     | `Access_control_ci_config_update_match_parse_err m ->
@@ -3541,7 +3541,7 @@ module Comment = struct
              "NOTIFICATION_POLICY_TAG_QUERY_ERR"
              Tmpl.notification_policy_tag_query_err
              kv
-    | `Stack_config_tag_query_err err -> raise (Failure "nyi")
+    | `Stack_config_tag_query_err _err -> raise (Failure "nyi")
 
   let publish_comment ~request_id client user pull_request =
     let module Gcm_api = Terrat_vcs_github_comment_publishers.Comment_api in
@@ -3845,7 +3845,7 @@ module Comment = struct
              "AUTO_APPLY_RUNNING"
              Tmpl.auto_apply_running
              kv
-    | Msg.Automerge_failure (pr, msg) ->
+    | Msg.Automerge_failure (_pr, msg) ->
         let kv = Snabela.Kv.(Map.of_list [ ("msg", string msg) ]) in
         Abbs_future_combinators.Result.ignore
         @@ Gcm_api.apply_template_and_publish
@@ -4793,8 +4793,8 @@ module Access_control = struct
   (* Access control is an enterprise feature, so always return success on
        any requests. *)
 
-  let query ~request_id _ _ _ _ = Abb.Future.return (Ok true)
-  let is_ci_changed ~request_id _ _ _ = Abb.Future.return (Ok false)
+  let query ~request_id:_ _ _ _ _ = Abb.Future.return (Ok true)
+  let is_ci_changed ~request_id:_ _ _ _ = Abb.Future.return (Ok false)
 end
 
 module Commit_check = struct
@@ -4815,7 +4815,7 @@ module Commit_check = struct
       Printf.sprintf "terrateam %s: ...%s %s... %s" run_type short_dir short_workspace short_hash
     else title
 
-  let make ?work_manifest ~config ~description ~title ~status ~repo account =
+  let make ?work_manifest ~config ~description ~title ~status ~repo:_ account =
     let module Wm = Terrat_work_manifest3 in
     let details_url =
       match work_manifest with
@@ -5307,7 +5307,7 @@ module Work_manifest = struct
                        Terrat_vcs_provider2.Target.Pr
                          (Terrat_pull_request.set_diff () @@ Terrat_pull_request.set_checks () pr);
                    })
-          | Terrat_vcs_provider2.Target.Drift { repo; branch } ->
+          | Terrat_vcs_provider2.Target.Drift { repo = _; branch } ->
               Pgsql_io.Prepared_stmt.execute db (Sql.insert_drift_work_manifest ()) id branch
               >>= fun () -> Abb.Future.return (Ok work_manifest))
     in
@@ -6095,7 +6095,7 @@ module Job_context = struct
           initiator
         >>= function
         | [] -> assert false
-        | (id, created_at, updated_at) :: _ ->
+        | (id, created_at, _updated_at) :: _ ->
             Abb.Future.return
               (Ok
                  {
@@ -6157,8 +6157,8 @@ module Job_context = struct
           Logs.err (fun m -> m "%s : JOB : QUERY : %a" request_id Pgsql_io.pp_err err);
           Abb.Future.return (Error `Error)
 
-    let query_all_by_context_id ~request_id db ~context_id () = raise (Failure "nyi")
-    let query_pending_by_context_id ~request_id db ~context_id () = raise (Failure "nyi")
+    let query_all_by_context_id ~request_id:_ _db ~context_id:_ () = raise (Failure "nyi")
+    let query_pending_by_context_id ~request_id:_ _db ~context_id:_ () = raise (Failure "nyi")
 
     let query_by_work_manifest_id ~request_id db ~work_manifest_id () =
       let run =

--- a/code/src/terrat_vcs_service_github_ee/terrat_vcs_service_github_ee.ml
+++ b/code/src/terrat_vcs_service_github_ee/terrat_vcs_service_github_ee.ml
@@ -303,7 +303,7 @@ module Provider :
                         CCList.filter_map
                           (function
                             | q, [] -> Some q
-                            | q, _ -> None)
+                            | _q, _ -> None)
                           all_of
                       in
                       let result =

--- a/code/src/terrat_vcs_service_gitlab/terrat_vcs_service_gitlab.ml
+++ b/code/src/terrat_vcs_service_gitlab/terrat_vcs_service_gitlab.ml
@@ -45,6 +45,7 @@ struct
     storage : Terrat_storage.t;
     exec : Terrat_vcs_event_evaluator2.Exec.t;
   }
+  [@@warning "-69"]
 
   module Kv_store =
     Terrat_vcs_kv_store.Make
@@ -286,7 +287,7 @@ struct
       Abb.Future.return
         (Ok { config; drift; flow_state_cleanup; plan_cleanup; repo_config_cleanup; storage; exec })
 
-    let stop t = raise (Failure "nyi")
+    let stop _t = raise (Failure "nyi")
     let routes t = Routes.routes t
 
     let get_user t user_id =

--- a/code/src/terrat_vcs_service_gitlab/terrat_vcs_service_gitlab.mli
+++ b/code/src/terrat_vcs_service_gitlab/terrat_vcs_service_gitlab.mli
@@ -11,5 +11,5 @@ module Make
     (Provider :
       Terrat_vcs_provider2_gitlab.S
         with type Api.Config.t = Terrat_vcs_service_gitlab_provider.Api.Config.t)
-    (Routes : ROUTES with type config = Provider.Api.Config.t) :
+    (_ : ROUTES with type config = Provider.Api.Config.t) :
   Terrat_vcs_service.S with type Service.vcs_config = Provider.Api.Config.vcs_config

--- a/code/src/terrat_vcs_service_gitlab/terrat_vcs_service_gitlab_ep_callback.ml
+++ b/code/src/terrat_vcs_service_gitlab/terrat_vcs_service_gitlab_ep_callback.ml
@@ -123,7 +123,7 @@ let perform_auth config storage code =
                 (CCInt64.of_int gitlab_user_id)
               >>= fun () -> Abb.Future.return (Ok (Terrat_user.make ~id:user_id ()))))
 
-let get config storage code state =
+let get config storage code _state =
   let open Abb.Future.Infix_monad in
   Brtl_ep.run ~content_type:"text/plain" ~f:(fun ctx ->
       perform_auth config storage code

--- a/code/src/terrat_vcs_service_gitlab/terrat_vcs_service_gitlab_ep_events.ml
+++ b/code/src/terrat_vcs_service_gitlab/terrat_vcs_service_gitlab_ep_events.ml
@@ -59,7 +59,7 @@ module Make (P : Terrat_vcs_provider2_gitlab.S) = struct
     | Some (owner, name) -> (owner, name)
     | None -> raise (Failure "nyi")
 
-  let upsert_installation_repo config storage installation_id =
+  let upsert_installation_repo _config storage installation_id =
     let module E = Gitlab_webhooks.Event in
     let module Pe = Gitlab_webhooks_push_event in
     let module Mre = Gitlab_webhooks_merge_request_event in

--- a/code/src/terrat_vcs_service_gitlab/terrat_vcs_service_gitlab_ep_installations.ml
+++ b/code/src/terrat_vcs_service_gitlab/terrat_vcs_service_gitlab_ep_installations.ml
@@ -396,7 +396,7 @@ module Make (S : S with type Account_id.t = int) = struct
 
     module Paginate = Brtl_ep_paginate.Make (Page)
 
-    let get' config storage user installation_id page limit ctx =
+    let get' _config storage user installation_id page limit ctx =
       let open Abbs_future_combinators.Infix_result_monad in
       Pgsql_pool.with_conn storage ~f:(fun db ->
           enforce_installation_access user installation_id db ctx)

--- a/code/src/terrat_vcs_service_gitlab/terrat_vcs_service_gitlab_ep_installations.mli
+++ b/code/src/terrat_vcs_service_gitlab/terrat_vcs_service_gitlab_ep_installations.mli
@@ -9,7 +9,7 @@ module type S = sig
     (unit, [> `Forbidden ]) result Abb.Future.t
 end
 
-module Make (S : S with type Account_id.t = int) : sig
+module Make (_ : S with type Account_id.t = int) : sig
   module List : sig
     val get :
       Terrat_vcs_service_gitlab_provider.Api.Config.t -> Terrat_storage.t -> Brtl_rtng.Handler.t

--- a/code/src/terrat_vcs_service_gitlab/terrat_vcs_service_gitlab_ep_repo_delete.ml
+++ b/code/src/terrat_vcs_service_gitlab/terrat_vcs_service_gitlab_ep_repo_delete.ml
@@ -51,7 +51,7 @@ module Make (P : Terrat_vcs_provider2_gitlab.S) (S : S) = struct
     if P.Api.Remote_repo.is_archived remote_repo then Abb.Future.return (Ok ())
     else Abb.Future.return (Error `Not_archived)
 
-  let perform_delete ~request_id config storage installation_id repo_id user db =
+  let perform_delete ~request_id config _storage installation_id repo_id user db =
     let open Abbs_future_combinators.Infix_result_monad in
     P.Db.query_repo_by_id ~request_id db installation_id repo_id
     >>= function

--- a/code/src/terrat_vcs_service_gitlab/terrat_vcs_service_gitlab_ep_user.ml
+++ b/code/src/terrat_vcs_service_gitlab/terrat_vcs_service_gitlab_ep_user.ml
@@ -28,7 +28,7 @@ module Whoami = struct
         /% Var.uuid "user_id")
   end
 
-  let get config storage =
+  let get _config storage =
     Brtl_ep.run_result_json ~f:(fun ctx ->
         let open Abbs_future_combinators.Infix_result_monad in
         Terrat_session.with_session ctx

--- a/code/src/terrat_vcs_service_gitlab/terrat_vcs_service_gitlab_ep_work_manifest.ml
+++ b/code/src/terrat_vcs_service_gitlab/terrat_vcs_service_gitlab_ep_work_manifest.ml
@@ -89,7 +89,7 @@ module Make (P : Terrat_vcs_provider2_gitlab.S) = struct
   end
 
   module Plans = struct
-    let post config storage work_manifest_id plan =
+    let post _config storage work_manifest_id plan =
       Brtl_ep.run_result_json ~f:(fun ctx ->
           let open Abbs_future_combinators.Infix_result_monad in
           (* TODO: Uncomment once all runs are on new work manifest access tokens *)
@@ -124,7 +124,7 @@ module Make (P : Terrat_vcs_provider2_gitlab.S) = struct
           | Error `Error ->
               Abb.Future.return (Error (Brtl_ctx.set_response `Internal_server_error ctx)))
 
-    let get config storage work_manifest_id dir workspace =
+    let get _config storage work_manifest_id dir workspace =
       Brtl_ep.run_result_json ~f:(fun ctx ->
           let open Abbs_future_combinators.Infix_result_monad in
           (* TODO: Uncomment once all runs are on new work manifest access tokens *)
@@ -220,7 +220,7 @@ module Make (P : Terrat_vcs_provider2_gitlab.S) = struct
           /% Var.uuid "id")
     end
 
-    let get config storage work_manifest_id =
+    let get _config storage work_manifest_id =
       Brtl_ep.run_result_json ~f:(fun ctx ->
           let open Abbs_future_combinators.Infix_result_monad in
           (* TODO: Uncomment once all runs are on new work manifest access tokens *)

--- a/code/src/terrat_vcs_service_gitlab/terrat_vcs_service_gitlab_provider.ml
+++ b/code/src/terrat_vcs_service_gitlab/terrat_vcs_service_gitlab_provider.ml
@@ -833,7 +833,7 @@ module Db = struct
                     state
                     tag_query
                     user
-                    run_kind
+                    _run_kind
                     installation_id
                     owner
                     name
@@ -1063,7 +1063,7 @@ module Db = struct
         Logs.err (fun m -> m "%s : ERROR : %a" request_id Pgsql_io.pp_err err);
         Abb.Future.return (Error `Error)
 
-  let lock_repository ~request_id db account repo =
+  let lock_repository ~request_id db _account repo =
     let open Abb.Future.Infix_monad in
     Metrics.Psql_query_time.time (Metrics.psql_query_time "select_repository_for_update") (fun () ->
         Pgsql_io.Prepared_stmt.fetch
@@ -1340,7 +1340,7 @@ module Db = struct
               gates
         | Some _ | None -> Abb.Future.return (Ok ()))
 
-  let store_tf_operation_result ~request_id db work_manifest_id result =
+  let store_tf_operation_result ~request_id:_ _db _work_manifest_id _result =
     raise (Failure "NOT SUPPORTED")
 
   let store_tf_operation_result2 ~request_id db work_manifest_id result =
@@ -1587,7 +1587,7 @@ module Db = struct
         Logs.err (fun m -> m "%s : ERROR : %a" request_id Pgsql_io.pp_err err);
         Abb.Future.return (Error `Error)
 
-  let query_next_pending_work_manifest ?(new_age = false) ~request_id db =
+  let query_next_pending_work_manifest ?new_age:(_ = false) ~request_id db =
     let run =
       let open Abbs_future_combinators.Infix_result_monad in
       Metrics.Psql_query_time.time (Metrics.psql_query_time "select_next_work_manifest") (fun () ->
@@ -2197,7 +2197,7 @@ module Apply_requirements = struct
     let open Abbs_future_combinators.Infix_result_monad in
     let module Tprr = Terrat_pull_request_review in
     let module Ac = Terrat_base_repo_config_v1.Apply_requirements.Approved in
-    let { Ac.all_of; any_of; any_of_count; enabled; require_completed_reviews } = approved in
+    let { Ac.all_of; any_of; any_of_count; enabled = _; require_completed_reviews } = approved in
     let combined_queries = Match_set.(to_list (of_list (all_of @ any_of))) in
     Abbs_future_combinators.List_result.fold_left
       ~init:Match_map.empty
@@ -2261,7 +2261,7 @@ module Apply_requirements = struct
            missing_any_of,
            any_of_count ))
 
-  let eval ~request_id config user client repo_config pull_request dirspace_configs =
+  let eval ~request_id _config _user client repo_config pull_request dirspace_configs =
     let max_parallel = 20 in
     let module R = Terrat_base_repo_config_v1 in
     let module Ar = R.Apply_requirements in
@@ -2577,10 +2577,10 @@ module Tier = struct
 end
 
 module Gate = struct
-  let add_approval ~request_id ~token ~approver pull_request db =
+  let add_approval ~request_id:_ ~token:_ ~approver:_ _pull_request _db =
     Abb.Future.return (Error (`Premium_feature_err `Gatekeeping))
 
-  let eval ~request_id _ _ _ _ = Abb.Future.return (Ok [])
+  let eval ~request_id:_ _ _ _ _ = Abb.Future.return (Ok [])
 end
 
 module Comment = struct
@@ -2657,7 +2657,7 @@ module Comment = struct
       Tmpl.repo_config_generic_failure
       kv
 
-  let repo_config_err ~request_id ~client ~pull_request ~title err =
+  let repo_config_err ~request_id ~client ~pull_request ~title:_ err =
     let module Gcm_api = Terrat_vcs_gitlab_comment_publishers.Comment_api in
     match err with
     | `Access_control_ci_config_update_match_parse_err m ->
@@ -2867,7 +2867,7 @@ module Comment = struct
              "NOTIFICATION_POLICY_TAG_QUERY_ERR"
              Tmpl.notification_policy_tag_query_err
              kv
-    | `Stack_config_tag_query_err err -> raise (Failure "nyi")
+    | `Stack_config_tag_query_err _err -> raise (Failure "nyi")
 
   let publish_comment ~request_id client user pull_request =
     let module Gcm_api = Terrat_vcs_gitlab_comment_publishers.Comment_api in
@@ -3158,7 +3158,7 @@ module Comment = struct
           "AUTO_APPLY_RUNNING"
           Tmpl.auto_apply_running
           kv
-    | Msg.Automerge_failure (pr, msg) ->
+    | Msg.Automerge_failure (_pr, msg) ->
         let kv = Snabela.Kv.(Map.of_list [ ("msg", string msg) ]) in
         Gcm_api.apply_template_and_publish
           ~request_id
@@ -4072,15 +4072,15 @@ module Access_control = struct
   (* Access control is an enterprise feature, so always return success on
        any requests. *)
 
-  let query ~request_id _ _ _ _ = Abb.Future.return (Ok true)
-  let is_ci_changed ~request_id _ _ _ = Abb.Future.return (Ok false)
+  let query ~request_id:_ _ _ _ _ = Abb.Future.return (Ok true)
+  let is_ci_changed ~request_id:_ _ _ _ = Abb.Future.return (Ok false)
 end
 
 module Commit_check = struct
   let make_dirspace_title ~run_type { Terrat_dirspace.dir; workspace } =
     Printf.sprintf "terrateam %s: %s %s" run_type dir workspace
 
-  let make ?work_manifest ~config ~description ~title ~status ~repo ~account () =
+  let make ?work_manifest:_ ~config:_ ~description ~title ~status ~repo:_ ~account:_ () =
     Terrat_commit_check.make ~details_url:"" ~description ~title ~status
 
   let make_str ?work_manifest ~config ~description ~status ~repo ~account s =
@@ -4435,7 +4435,7 @@ module Work_manifest = struct
                        Terrat_vcs_provider2.Target.Pr
                          (Terrat_pull_request.set_diff () @@ Terrat_pull_request.set_checks () pr);
                    })
-          | Terrat_vcs_provider2.Target.Drift { repo; branch } ->
+          | Terrat_vcs_provider2.Target.Drift { repo = _; branch } ->
               Pgsql_io.Prepared_stmt.execute db (Sql.insert_drift_work_manifest ()) id branch
               >>= fun () -> Abb.Future.return (Ok work_manifest))
     in
@@ -4586,7 +4586,7 @@ module Work_manifest = struct
         Logs.err (fun m -> m "%s : ERROR : %a" request_id Pgsql_io.pp_err err);
         Abb.Future.return (Error `Error)
 
-  let result rest = raise (Failure "NOT SUPPORTED")
+  let result _rest = raise (Failure "NOT SUPPORTED")
 
   let result2 result =
     let module O = Terrat_api_components.Workflow_step_output in
@@ -5177,7 +5177,7 @@ module Job_context = struct
           initiator
         >>= function
         | [] -> assert false
-        | (id, created_at, updated_at) :: _ ->
+        | (id, created_at, _updated_at) :: _ ->
             Abb.Future.return
               (Ok
                  {
@@ -5239,8 +5239,8 @@ module Job_context = struct
           Logs.err (fun m -> m "%s : JOB : QUERY : %a" request_id Pgsql_io.pp_err err);
           Abb.Future.return (Error `Error)
 
-    let query_all_by_context_id ~request_id db ~context_id () = raise (Failure "nyi")
-    let query_pending_by_context_id ~request_id db ~context_id () = raise (Failure "nyi")
+    let query_all_by_context_id ~request_id:_ _db ~context_id:_ () = raise (Failure "nyi")
+    let query_pending_by_context_id ~request_id:_ _db ~context_id:_ () = raise (Failure "nyi")
 
     let query_by_work_manifest_id ~request_id db ~work_manifest_id () =
       let run =

--- a/code/src/terrat_vcs_service_gitlab/terrat_vcs_service_gitlab_user.ml
+++ b/code/src/terrat_vcs_service_gitlab/terrat_vcs_service_gitlab_user.ml
@@ -88,7 +88,7 @@ module Oauth = struct
         match Response.of_yojson (Yojson.Safe.from_string body) with
         | Ok value -> Ok value
         | Error _ -> Error (`Authorize_err body))
-    | Ok (resp, body) -> Error (`Authorize_err body)
+    | Ok (_resp, body) -> Error (`Authorize_err body)
     | Error err -> Error err
 
   let refresh ~config refresh_token =
@@ -121,7 +121,7 @@ module Oauth = struct
         match Response.of_yojson (Yojson.Safe.from_string body) with
         | Ok value -> Ok value
         | Error err -> Error (`Refresh_err err))
-    | Ok (resp, body) -> Error (`Refresh_err body)
+    | Ok (_resp, body) -> Error (`Refresh_err body)
     | Error err -> Error err
 
   let access_token ~config db user =

--- a/code/src/terrat_vcs_stacks/terrat_vcs_stacks.ml
+++ b/code/src/terrat_vcs_stacks/terrat_vcs_stacks.ml
@@ -108,7 +108,7 @@ module Make (M : M with type db = Pgsql_io.t) = struct
     | { Tcm.Stack_config.paths; _ } :: _ -> CCList.hd @@ CCList.hd paths
 
   let inner_stacks dirspace_configs =
-    CCList.map (fun { Tcm.Stack_config.name; paths; config } ->
+    CCList.map (fun { Tcm.Stack_config.name; paths; config = _ } ->
         let module Tac = Terrat_api_components in
         {
           Tac.Stack_inner.name;
@@ -197,7 +197,7 @@ module Make (M : M with type db = Pgsql_io.t) = struct
         (fun {
                Tac.Stack_inner.Dirspaces.Items.dirspace =
                  { Tac.Dirspace.dir; workspace } as dirspace;
-               state;
+               state = _;
              }
            ->
           {
@@ -248,7 +248,7 @@ module Make (M : M with type db = Pgsql_io.t) = struct
   let enforce_installation_access user installation_id db ctx =
     M.enforce_installation_access ~request_id:(Brtl_ctx.token ctx) user installation_id db
 
-  let get config storage installation_id repo_id pull_request_id =
+  let get _config storage installation_id repo_id pull_request_id =
     Brtl_ep.run_result_json ~f:(fun ctx ->
         let open Abbs_future_combinators.Infix_result_monad in
         Terrat_session.with_session ctx

--- a/code/src/ttm/ttm.ml
+++ b/code/src/ttm/ttm.ml
@@ -7,7 +7,7 @@ module Cmdline = struct
         over ();
         k ()
       in
-      let with_stamp h tags k ppf fmt =
+      let with_stamp h _tags k ppf fmt =
         (* TODO: Make this use the proper Abb time *)
         let time = Unix.gettimeofday () in
         let time_str = ISO8601.Permissive.string_of_datetime time in

--- a/code/src/ttm_kv/ttm_kv.ml
+++ b/code/src/ttm_kv/ttm_kv.ml
@@ -385,7 +385,7 @@ module Commit = struct
 end
 
 module Delete = struct
-  let run api_base vcs installation version idx output key () =
+  let run api_base vcs installation version idx _output key () =
     let f () =
       let open Abbs_future_combinators.Infix_result_monad in
       Ttm_client.create ~base_url:(Uri.of_string api_base) ()

--- a/code/src/ttm_kv/ttm_kv_store.ml
+++ b/code/src/ttm_kv/ttm_kv_store.ml
@@ -192,8 +192,8 @@ let delete ?idx ?version ~key t =
   | `OK { Terrat_api_components_kv_delete.result } -> Abb.Future.return (Ok result)
   | `Forbidden -> Abb.Future.return (Error `Refresh_token_err)
 
-let count ?committed ~key t = raise (Failure "nyi")
-let size ?idx ?committed ~key t = raise (Failure "nyi")
+let count ?committed:_ ~key:_ _t = raise (Failure "nyi")
+let size ?idx:_ ?committed:_ ~key:_ _t = raise (Failure "nyi")
 
 let iter ?select ?idx ?inclusive ?prefix ?committed ?limit ~key t =
   let open Abbs_future_combinators.Infix_result_monad in


### PR DESCRIPTION
…rams, unused fields)

- W27 (unused-var-strict): prefix unused variables with _, or use field = _ in record patterns, or ~label:_ for labeled args.
- W67 (unused-functor-parameter): change (Name : Sig) to (_ : Sig) in .mli files.
- W69 (unused-field): add [@@warning "-69"] to record types where the field is set but never read.
- Generated directories (gitlabc, githubc2, terrat_api, terrat_repo_config, terrat_github_webhooks, gitlab_webhooks, terrat_access_token_caps, terrat_job_context_param, terrat_job_type) get (flags (:standard -w -27-67)) so future regenerations don't reintroduce the same noise.

## Description

<!-- Briefly describe the changes and the issue it fixes. -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Other (explain):

Clean up warnings

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/terrateamio/terrateam/blob/main/CONTRIBUTING.md)
- [x] The pull request title follows this format:
      `ISSUE_NUMBER ACTION_TYPE Short description` (e.g., `123 ADD Feature description`)
- [x] I have added tests and documentation (if applicable)
- [x] My changes generate no new warnings/errors and do not break existing functionality

## Additional context (optional)

<!-- Add any additional context here, e.g., screenshots, dependencies, etc. -->
