### PR TITLE
Update docker-compose.yml to use postgres 18

### DIFF
--- a/docker/terrat/docker-compose.yml
+++ b/docker/terrat/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - terrateam
 
   db:
-    image: postgres:14.5-alpine
+    image: postgres:18.4-alpine
     user: postgres
     environment:
       POSTGRES_PASSWORD: "terrateam"
@@ -24,7 +24,7 @@ services:
       timeout: 3s
       retries: 5
     volumes:
-      - db:/var/lib/postgresql/data/
+      - db:/var/lib/postgresql
     networks:
       - terrateam
 


### PR DESCRIPTION
I have been running `terrat-oss` locally now for a few weeks, with the latest version of PostgreSQL 18.4

I thought I'd submit a PR to get the compose file updated. I skimmed the repo, and didn't observe any other areas where changes are needed.

[link](https://hub.docker.com/_/postgres#pgdata) to documentation for volume path change with newer versions of postgres