### PR TITLE
1329 FIX GitHub comment size threshold too conservative

### DIFF
--- a/code/src/terrat_vcs_github_comment/terrat_vcs_github_comment.ml
+++ b/code/src/terrat_vcs_github_comment/terrat_vcs_github_comment.ml
@@ -318,7 +318,7 @@ module S = struct
         gates
         t.work_manifest
     in
-    CCString.length @@ Yojson.Safe.to_string @@ `String body
+    CCString.length body
 
   let dirspace el = el.dirspace
   let strategy el = el.strategy
@@ -328,8 +328,8 @@ module S = struct
     let module P = Terrat_vcs_github_comment_publishers in
     P.dirspace_compare (el1.dirspace, el1.steps) (el2.dirspace, el2.steps)
 
-  (* Github Limits it to 2^16 = 65536
+  (* Github limits comments to 65536 characters.
      https://github.com/mshick/add-pr-comment/issues/93#issuecomment-1531415467
-     I set it to a smaller value *)
-  let max_comment_length = 65536 / 2
+     Leave a small buffer for any GitHub-side overhead. *)
+  let max_comment_length = 65536 - 512
 end


### PR DESCRIPTION
## Description

Fixes #1329. Two related bugs cause plan output to be hidden with a "comment too large" message more often than necessary.

**Bug 1: `rendered_length` over-counts comment size**

`rendered_length` was wrapping the rendered body in a JSON string before measuring it:

```ocaml
CCString.length @@ Yojson.Safe.to_string @@ `String body
```

This JSON-encodes the content before counting, so every newline counts as 2 chars (`\n`), every double-quote as 2 chars (`\"`), etc. GitHub sees the raw string length, not the JSON-encoded length. Fixed to `CCString.length body`.

**Bug 2: `max_comment_length` set to half of GitHub's actual limit**

```ocaml
(* I set it to a smaller value *)
let max_comment_length = 65536 / 2
```

GitHub's limit is 65,536 characters. The threshold was halved with no documented reason, causing plan output to be compacted or stripped at 32,768 chars. Raised to `65536 - 512` to leave a small buffer while using the full limit.

## Type of change

- [x] Bug fix

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/terrateamio/terrateam/blob/main/CONTRIBUTING.md)
- [x] The pull request title follows this format: `ISSUE_NUMBER ACTION_TYPE Short description`
- [x] My changes generate no new warnings/errors and do not break existing functionality