### PR TITLE
fix(minijinja-rs): strip NUL bytes so render never panics (CString NulError)

### DIFF
--- a/code/src/minijinja-rs/src/lib.rs
+++ b/code/src/minijinja-rs/src/lib.rs
@@ -76,7 +76,14 @@ pub extern "C" fn minijinja_render_template(
     match env.get_template("template") {
         Ok(tmpl) => match tmpl.render(&context) {
             Ok(result) => {
-                let data = CString::new(result.replace('\0', "\0")).unwrap();
+                // Strip interior NUL bytes before building the C string. A rendered
+                // template can legitimately contain a NUL (e.g. an OpenTofu plan diff
+                // that surfaces a base64gzip'd EC2 user_data blob — gzip magic + NULs),
+                // and CString::new rejects any interior NUL. The previous
+                // `.replace('\0', "\0")` was a no-op (NUL -> NUL), so `.unwrap()`
+                // still panicked with NulError and took the whole process down. NUL
+                // bytes cannot be represented in a C string regardless, so drop them.
+                let data = CString::new(result.replace('\0', "")).unwrap();
                 return RenderResult {
                     success: true,
                     data: data.into_raw(),
@@ -104,5 +111,43 @@ pub extern "C" fn minijinja_render_template(
 pub unsafe extern "C" fn minijinja_free_string(ptr: *mut c_char) {
     if !ptr.is_null() {
         let _ = CString::from_raw(ptr);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Drive the FFI entry point exactly as the OCaml caller does, returning
+    /// (success, rendered_output).
+    fn render(template: &str, json: &str) -> (bool, String) {
+        let t = CString::new(template).unwrap();
+        let j = CString::new(json).unwrap();
+        let res = minijinja_render_template(t.as_ptr(), j.as_ptr());
+        let out = unsafe { CStr::from_ptr(res.data) }
+            .to_str()
+            .expect("output is valid UTF-8")
+            .to_owned();
+        unsafe { minijinja_free_string(res.data) };
+        (res.success, out)
+    }
+
+    #[test]
+    fn renders_a_normal_template() {
+        let (ok, out) = render("Hello {{ name }}", r#"{"name": "world"}"#);
+        assert!(ok);
+        assert_eq!(out, "Hello world");
+    }
+
+    /// Regression for the CString NulError panic: a rendered value containing an
+    /// interior NUL byte — as an OpenTofu plan diff does when it surfaces a
+    /// base64gzip'd EC2 user_data blob (gzip magic + NULs) — must not crash the
+    /// FFI. Before the fix, `CString::new(result.replace('\0', "\0"))` (a
+    /// NUL->NUL no-op) hit NulError and `.unwrap()` aborted the whole process.
+    #[test]
+    fn interior_nul_byte_is_stripped_not_panicked() {
+        let (ok, out) = render("{{ x }}", r#"{"x": "a\u0000b"}"#);
+        assert!(ok, "render must succeed instead of panicking on the NUL byte");
+        assert_eq!(out, "ab", "the interior NUL must be dropped from the output");
     }
 }


### PR DESCRIPTION
minijinja_render_template did:

    let data = CString::new(result.replace('\0', "\0")).unwrap();

`result.replace('\0', "\0")` replaces NUL with NUL — a no-op — so any interior NUL byte in the rendered output still reaches CString::new, which returns Err(NulError), and `.unwrap()` panics. Because the panic can't unwind across the `extern "C"` boundary, Rust ABORTS the whole process (SIGABRT), not just the request.

Reachable from normal operation: rendering a PR-comment body that embeds an OpenTofu plan diff which surfaces a base64gzip'd EC2 user_data blob (gzip magic 0x1f 0x8b + interior NUL bytes). The abort kills the server mid-plan-result; the runner's result PUT then 502s against the dead nginx upstream and the job fails. Operators currently work around it by marking user_data `sensitive()` in Terraform so the bytes never reach the diff — but the engine should never crash on rendered content.

Fix: actually strip the NUL bytes (`.replace('\0', "")`). NUL cannot be represented in a C string regardless, so dropping it is the only valid option, and after the replace `.unwrap()` is infallible.

Adds a regression test (`interior_nul_byte_is_stripped_not_panicked`) that drives the FFI entry point with a context value carrying an interior NUL; without the fix it SIGABRTs the test process, with the fix it renders "ab".

## Description

<!-- Briefly describe the changes and the issue it fixes. -->

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (explain):

## Checklist

- [ ] I have read the [contributing guidelines](https://github.com/terrateamio/terrateam/blob/main/CONTRIBUTING.md)
- [ ] The pull request title follows this format:
      `ISSUE_NUMBER ACTION_TYPE Short description` (e.g., `123 ADD Feature description`)
- [ ] I have added tests and documentation (if applicable)
- [ ] My changes generate no new warnings/errors and do not break existing functionality

## Additional context (optional)

<img width="286" height="512" alt="image" src="https://github.com/user-attachments/assets/443810a2-2f47-48fb-a1c8-76013a98191b" />

👋 Hi yah! Actual human here! I'm not sure what y'alls policy is on AI usage for contributions. I'm just trying to make sure no more energy is wasted by this little bug.  If we need to re-cut this PR with human typing or if you want to close this as an inline the change somewhere else in some other commit, cool! This project is rad I come in peace. ✌️