### PR TITLE
1438 ADD Queue applies behind in-flight plans

### DIFF
--- a/code/src/terrat_vcs_github_comment_templates/tmpl/conflicting_work_manifests.tmpl
+++ b/code/src/terrat_vcs_github_comment_templates/tmpl/conflicting_work_manifests.tmpl
@@ -1,8 +1,12 @@
-## Conflicting operations :heavy_multiplication_x:
-There are conflicting operations that are preventing this operation from being performed.  If there are other operations running, wait for them to complete and try again.  If you believe any operations are stuck for some reason, see the **Conflicting operations** section below for how to resolve them.
+## Apply already in progress :heavy_multiplication_x:
+An apply is already queued or running against directories and workspaces this operation touches, so it was not started.  Only one apply runs against a directory and workspace at a time, and a second apply is not queued behind the first.
+
+Wait for the apply below to finish, then comment `terrateam apply` again.  If that apply belongs to another pull request, plan again first, because an apply supersedes any plan made against those directories and workspaces before it ran.
+
+Plans do not have to wait like this.  A plan against those directories and workspaces is queued automatically and runs once the apply has completed.
 
 <details>
-   <summary><h3>Conflicting operations</h3></summary>
+   <summary><h3>Apply in progress</h3></summary>
 
 | Pull Request | Operation | State | Created At |
 | --- | --- | --- | --- |
@@ -10,7 +14,7 @@ There are conflicting operations that are preventing this operation from being p
 | @?is_pr-@ #@id@ @-/is_pr@@!is_pr-@ @id@ @-/is_pr@ | @run_type@ | @state@ | @created_at@ UTC |
 @/work_manifests-@
 
-If these appear to be stuck, unlock them by commenting in any pull request:
+If this appears to be stuck, unlock it by commenting in any pull request:
 
 ```
 terrateam unlock@-#work_manifests@ @id@@/work_manifests@

--- a/code/src/terrat_vcs_gitlab_comment_templates/tmpl/conflicting_work_manifests.tmpl
+++ b/code/src/terrat_vcs_gitlab_comment_templates/tmpl/conflicting_work_manifests.tmpl
@@ -1,8 +1,12 @@
-## Conflicting operations :heavy_multiplication_x:
-There are conflicting operations that are preventing this operation from being performed.  If there are other operations running, wait for them to complete and try again.  If you believe any operations are stuck for some reason, see the **Conflicting operations** section below for how to resolve them.
+## Apply already in progress :heavy_multiplication_x:
+An apply is already queued or running against directories and workspaces this operation touches, so it was not started.  Only one apply runs against a directory and workspace at a time, and a second apply is not queued behind the first.
+
+Wait for the apply below to finish, then comment `terrateam apply` again.  If that apply belongs to another pull request, plan again first, because an apply supersedes any plan made against those directories and workspaces before it ran.
+
+Plans do not have to wait like this.  A plan against those directories and workspaces is queued automatically and runs once the apply has completed.
 
 <details>
-   <summary><h3>Conflicting operations</h3></summary>
+   <summary><h3>Apply in progress</h3></summary>
 
 | Pull Request | Operation | State | Created At |
 | --- | --- | --- | --- |
@@ -10,7 +14,7 @@ There are conflicting operations that are preventing this operation from being p
 | @?is_pr-@ #@id@ @-/is_pr@@!is_pr-@ @id@ @-/is_pr@ | @run_type@ | @state@ | @created_at@ UTC |
 @/work_manifests-@
 
-If these appear to be stuck, unlock them by commenting in any pull request:
+If this appears to be stuck, unlock it by commenting in any pull request:
 
 ```
 terrateam unlock@-#work_manifests@ @id@@/work_manifests@

--- a/code/src/terrat_vcs_service_github/sql/select_conflicting_work_manifests_in_repo2.sql
+++ b/code/src/terrat_vcs_service_github/sql/select_conflicting_work_manifests_in_repo2.sql
@@ -18,17 +18,21 @@ wm as (
 work_manifests_for_dirspace as (
     select
         gwm.id,
--- Consider a work manifest as maybe stale if we have no run id after a minute
--- or it was created over 10 minutes ago
-        ((gwm.run_id is null and (now() - gwm.created_at > interval '1 minutes'))
-         or (gwm.run_id is not null and (now() - gwm.created_at > interval '1 hour'))) as maybe_stale
+-- Consider a work manifest as maybe stale if it was dispatched but has not
+-- started after a minute, or if it has been in flight for over an hour.  A work
+-- manifest that is still queued is not stale, it may legitimately be waiting on
+-- other work against its dirspaces.
+        ((gwm.state = 'running'
+          and gwm.run_id is null
+          and (now() - gwm.created_at > interval '1 minutes'))
+         or (now() - gwm.created_at > interval '1 hour')) as maybe_stale
     from dirspaces
     inner join work_manifest_dirspaceflows as gwmdsfs
         on dirspaces.dir = gwmdsfs.path and dirspaces.workspace = gwmdsfs.workspace
     inner join wm as gwm
         on gwmdsfs.work_manifest = gwm.id
     where gwm.repository = $repository
-    group by gwm.id, gwm.run_id, gwm.created_at
+    group by gwm.id, gwm.state, gwm.run_id, gwm.created_at
 )
 select
     gwm.id,
@@ -50,7 +54,12 @@ where gwm.repository = $repository
             and (latest_unlocks.unlocked_at is null or latest_unlocks.unlocked_at < gwm.created_at))
            or (gdwm.work_manifest is not null
                and (latest_drift_unlocks.unlocked_at is null or latest_drift_unlocks.unlocked_at < gwm.created_at)))
-      and ((gwm.pull_number is not null and gwm.pull_number = $pull_number)
-           or ($run_type in ('autoapply', 'apply', 'unsafe-apply'))
+-- A plan is never in conflict, it is queued behind whatever is already running
+-- or queued against its dirspaces.  An apply is in conflict with another apply
+-- against those dirspaces, because a second apply is not queued behind the
+-- first.  Either is in conflict with work that looks stale, because stale work
+-- blocks the queue until it is unlocked.
+      and (($run_type in ('autoapply', 'apply', 'unsafe-apply')
+            and gwm.run_type in ('autoapply', 'apply', 'unsafe-apply'))
            or work_manifests_for_dirspace.maybe_stale)
 order by gwm.created_at

--- a/code/src/terrat_vcs_service_github/sql/select_conflicting_work_manifests_in_repo_for_context.sql
+++ b/code/src/terrat_vcs_service_github/sql/select_conflicting_work_manifests_in_repo_for_context.sql
@@ -42,10 +42,14 @@ wm as (
 work_manifests_for_dirspace as (
     select
         gwm.id,
--- Consider a work manifest as maybe stale if we have no run id after a minute
--- or it was created over 10 minutes ago
-        ((gwm.run_id is null and (now() - gwm.created_at > interval '1 minutes'))
-         or (gwm.run_id is not null and (now() - gwm.created_at > interval '1 hour'))) as maybe_stale
+-- Consider a work manifest as maybe stale if it was dispatched but has not
+-- started after a minute, or if it has been in flight for over an hour.  A work
+-- manifest that is still queued is not stale, it may legitimately be waiting on
+-- other work against its dirspaces.
+        ((gwm.state = 'running'
+          and gwm.run_id is null
+          and (now() - gwm.created_at > interval '1 minutes'))
+         or (now() - gwm.created_at > interval '1 hour')) as maybe_stale
     from dirspaces
     inner join work_manifest_dirspaceflows as gwmdsfs
         on dirspaces.dir = gwmdsfs.path and dirspaces.workspace = gwmdsfs.workspace
@@ -53,7 +57,7 @@ work_manifests_for_dirspace as (
         on gwmdsfs.work_manifest = gwm.id
     inner join context as c
       on c.repo = gwm.repository
-    group by gwm.id, gwm.run_id, gwm.created_at
+    group by gwm.id, gwm.state, gwm.run_id, gwm.created_at
 )
 select
     gwm.id,
@@ -76,7 +80,12 @@ where gwm.state in ('queued', 'running')
             and (latest_unlocks.unlocked_at is null or latest_unlocks.unlocked_at < gwm.created_at))
            or (gdwm.work_manifest is not null
                and (latest_drift_unlocks.unlocked_at is null or latest_drift_unlocks.unlocked_at < gwm.created_at)))
-      and ((gwm.pull_number is not distinct from c.pull_number)
-           or ($run_type in ('autoapply', 'apply', 'unsafe-apply'))
+-- A plan is never in conflict, it is queued behind whatever is already running
+-- or queued against its dirspaces.  An apply is in conflict with another apply
+-- against those dirspaces, because a second apply is not queued behind the
+-- first.  Either is in conflict with work that looks stale, because stale work
+-- blocks the queue until it is unlocked.
+      and (($run_type in ('autoapply', 'apply', 'unsafe-apply')
+            and gwm.run_type in ('autoapply', 'apply', 'unsafe-apply'))
            or work_manifests_for_dirspace.maybe_stale)
 order by gwm.created_at

--- a/code/src/terrat_vcs_service_github/sql/select_next_work_manifest.sql
+++ b/code/src/terrat_vcs_service_github/sql/select_next_work_manifest.sql
@@ -30,6 +30,7 @@ wms as (
         (case gwm.run_type
          when 'autoapply' then 0
          when 'apply' then 0
+         when 'unsafe-apply' then 0
          when 'autoplan' then 1
          when 'plan' then 1
          end) as priority
@@ -77,31 +78,52 @@ running_dirspaces_per_repo as (
         on gwmds.work_manifest = wms.id
     where wms.state = 'running'
 ),
--- Find all those queued dirspaces that have running instance where the running
--- instance is an apply.  These work manifests cannot be run because the apply
--- is blocking them
-apply_dirspaces_with_overlap as (
+-- The dirspaces a queued work manifest cannot be run against yet, along with
+-- the kind of work manifest that has to wait on it.  A plan and an apply never
+-- run against the same dirspace at the same time, and two applies never run
+-- against the same dirspace at the same time.
+blocked_dirspaces as (
+    -- An apply waits for every operation running against its dirspaces to
+    -- complete.  It does not cancel them.
+    select distinct
+        rds.repository as repository,
+        rds.path as path,
+        rds.workspace as workspace,
+        'apply' as unified_run_type
+    from running_dirspaces_per_repo as rds
+    union
+    -- A plan waits for an apply running against its dirspaces.
+    select distinct
+        rds.repository as repository,
+        rds.path as path,
+        rds.workspace as workspace,
+        'plan' as unified_run_type
+    from running_dirspaces_per_repo as rds
+    where rds.unified_run_type = 'apply'
+    union
+    -- A queued apply skips the line: every plan queued against its dirspaces,
+    -- those queued before it and those queued after it, runs only once the
+    -- apply has completed.  This is what bounds how long an apply waits, the
+    -- set of work it is waiting on can only shrink.
     select distinct
         qds.repository as repository,
         qds.path as path,
-        qds.workspace as workspace
+        qds.workspace as workspace,
+        'plan' as unified_run_type
     from queued_dirspaces_per_repo as qds
-    inner join running_dirspaces_per_repo as rds
-        on qds.repository = rds.repository
-           and qds.path = rds.path
-           and qds.workspace = rds.workspace
-    where rds.unified_run_type = 'apply'
+    where qds.unified_run_type = 'apply'
 ),
--- Reject all those work manifests that have a dirspace in the overlapping apply
--- table
+-- Reject all those work manifests that have a dirspace blocked for their kind
+-- of run
 rejected_work_manifests as (
     select distinct wms.id as id from wms
     inner join dirspaces_for_work_manifests as dswm
         on dswm.work_manifest = wms.id
-    inner join apply_dirspaces_with_overlap as adso
-        on adso.repository = wms.repository
-           and adso.path = dswm.path
-           and adso.workspace = dswm.workspace
+    inner join blocked_dirspaces as bds
+        on bds.repository = wms.repository
+           and bds.path = dswm.path
+           and bds.workspace = dswm.workspace
+           and bds.unified_run_type = wms.unified_run_type
 ),
 next_work_manifests as (
     select

--- a/code/src/terrat_vcs_service_gitlab/sql/select_conflicting_work_manifests_in_repo2.sql
+++ b/code/src/terrat_vcs_service_gitlab/sql/select_conflicting_work_manifests_in_repo2.sql
@@ -18,17 +18,21 @@ wm as (
 work_manifests_for_dirspace as (
     select
         gwm.id,
--- Consider a work manifest as maybe stale if we have no run id after a minute
--- or it was created over 10 minutes ago
-        ((gwm.run_id is null and (now() - gwm.created_at > interval '1 minutes'))
-         or (gwm.run_id is not null and (now() - gwm.created_at > interval '1 hour'))) as maybe_stale
+-- Consider a work manifest as maybe stale if it was dispatched but has not
+-- started after a minute, or if it has been in flight for over an hour.  A work
+-- manifest that is still queued is not stale, it may legitimately be waiting on
+-- other work against its dirspaces.
+        ((gwm.state = 'running'
+          and gwm.run_id is null
+          and (now() - gwm.created_at > interval '1 minutes'))
+         or (now() - gwm.created_at > interval '1 hour')) as maybe_stale
     from dirspaces
     inner join work_manifest_dirspaceflows as gwmdsfs
         on dirspaces.dir = gwmdsfs.path and dirspaces.workspace = gwmdsfs.workspace
     inner join wm as gwm
         on gwmdsfs.work_manifest = gwm.id
     where gwm.repository = $repository
-    group by gwm.id, gwm.run_id, gwm.created_at
+    group by gwm.id, gwm.state, gwm.run_id, gwm.created_at
 )
 select
     gwm.id,
@@ -50,7 +54,12 @@ where gwm.repository = $repository
             and (latest_unlocks.unlocked_at is null or latest_unlocks.unlocked_at < gwm.created_at))
            or (gdwm.work_manifest is not null
                and (latest_drift_unlocks.unlocked_at is null or latest_drift_unlocks.unlocked_at < gwm.created_at)))
-      and ((gwm.pull_number is not null and gwm.pull_number = $pull_number)
-           or ($run_type in ('autoapply', 'apply', 'unsafe-apply'))
+-- A plan is never in conflict, it is queued behind whatever is already running
+-- or queued against its dirspaces.  An apply is in conflict with another apply
+-- against those dirspaces, because a second apply is not queued behind the
+-- first.  Either is in conflict with work that looks stale, because stale work
+-- blocks the queue until it is unlocked.
+      and (($run_type in ('autoapply', 'apply', 'unsafe-apply')
+            and gwm.run_type in ('autoapply', 'apply', 'unsafe-apply'))
            or work_manifests_for_dirspace.maybe_stale)
 order by gwm.created_at

--- a/code/src/terrat_vcs_service_gitlab/sql/select_conflicting_work_manifests_in_repo_for_context.sql
+++ b/code/src/terrat_vcs_service_gitlab/sql/select_conflicting_work_manifests_in_repo_for_context.sql
@@ -42,10 +42,14 @@ wm as (
 work_manifests_for_dirspace as (
     select
         gwm.id,
--- Consider a work manifest as maybe stale if we have no run id after a minute
--- or it was created over 10 minutes ago
-        ((gwm.run_id is null and (now() - gwm.created_at > interval '1 minutes'))
-         or (gwm.run_id is not null and (now() - gwm.created_at > interval '1 hour'))) as maybe_stale
+-- Consider a work manifest as maybe stale if it was dispatched but has not
+-- started after a minute, or if it has been in flight for over an hour.  A work
+-- manifest that is still queued is not stale, it may legitimately be waiting on
+-- other work against its dirspaces.
+        ((gwm.state = 'running'
+          and gwm.run_id is null
+          and (now() - gwm.created_at > interval '1 minutes'))
+         or (now() - gwm.created_at > interval '1 hour')) as maybe_stale
     from dirspaces
     inner join work_manifest_dirspaceflows as gwmdsfs
         on dirspaces.dir = gwmdsfs.path and dirspaces.workspace = gwmdsfs.workspace
@@ -53,7 +57,7 @@ work_manifests_for_dirspace as (
         on gwmdsfs.work_manifest = gwm.id
     inner join context as c
       on c.repo = gwm.repository
-    group by gwm.id, gwm.run_id, gwm.created_at
+    group by gwm.id, gwm.state, gwm.run_id, gwm.created_at
 )
 select
     gwm.id,
@@ -76,7 +80,12 @@ where gwm.state in ('queued', 'running')
             and (latest_unlocks.unlocked_at is null or latest_unlocks.unlocked_at < gwm.created_at))
            or (gdwm.work_manifest is not null
                and (latest_drift_unlocks.unlocked_at is null or latest_drift_unlocks.unlocked_at < gwm.created_at)))
-      and ((gwm.pull_number is not distinct from c.pull_number)
-           or ($run_type in ('autoapply', 'apply', 'unsafe-apply'))
+-- A plan is never in conflict, it is queued behind whatever is already running
+-- or queued against its dirspaces.  An apply is in conflict with another apply
+-- against those dirspaces, because a second apply is not queued behind the
+-- first.  Either is in conflict with work that looks stale, because stale work
+-- blocks the queue until it is unlocked.
+      and (($run_type in ('autoapply', 'apply', 'unsafe-apply')
+            and gwm.run_type in ('autoapply', 'apply', 'unsafe-apply'))
            or work_manifests_for_dirspace.maybe_stale)
 order by gwm.created_at

--- a/code/src/terrat_vcs_service_gitlab/sql/select_next_work_manifest.sql
+++ b/code/src/terrat_vcs_service_gitlab/sql/select_next_work_manifest.sql
@@ -30,6 +30,7 @@ wms as (
         (case gwm.run_type
          when 'autoapply' then 0
          when 'apply' then 0
+         when 'unsafe-apply' then 0
          when 'autoplan' then 1
          when 'plan' then 1
          end) as priority
@@ -77,31 +78,52 @@ running_dirspaces_per_repo as (
         on gwmds.work_manifest = wms.id
     where wms.state = 'running'
 ),
--- Find all those queued dirspaces that have running instance where the running
--- instance is an apply.  These work manifests cannot be run because the apply
--- is blocking them
-apply_dirspaces_with_overlap as (
+-- The dirspaces a queued work manifest cannot be run against yet, along with
+-- the kind of work manifest that has to wait on it.  A plan and an apply never
+-- run against the same dirspace at the same time, and two applies never run
+-- against the same dirspace at the same time.
+blocked_dirspaces as (
+    -- An apply waits for every operation running against its dirspaces to
+    -- complete.  It does not cancel them.
+    select distinct
+        rds.repository as repository,
+        rds.path as path,
+        rds.workspace as workspace,
+        'apply' as unified_run_type
+    from running_dirspaces_per_repo as rds
+    union
+    -- A plan waits for an apply running against its dirspaces.
+    select distinct
+        rds.repository as repository,
+        rds.path as path,
+        rds.workspace as workspace,
+        'plan' as unified_run_type
+    from running_dirspaces_per_repo as rds
+    where rds.unified_run_type = 'apply'
+    union
+    -- A queued apply skips the line: every plan queued against its dirspaces,
+    -- those queued before it and those queued after it, runs only once the
+    -- apply has completed.  This is what bounds how long an apply waits, the
+    -- set of work it is waiting on can only shrink.
     select distinct
         qds.repository as repository,
         qds.path as path,
-        qds.workspace as workspace
+        qds.workspace as workspace,
+        'plan' as unified_run_type
     from queued_dirspaces_per_repo as qds
-    inner join running_dirspaces_per_repo as rds
-        on qds.repository = rds.repository
-           and qds.path = rds.path
-           and qds.workspace = rds.workspace
-    where rds.unified_run_type = 'apply'
+    where qds.unified_run_type = 'apply'
 ),
--- Reject all those work manifests that have a dirspace in the overlapping apply
--- table
+-- Reject all those work manifests that have a dirspace blocked for their kind
+-- of run
 rejected_work_manifests as (
     select distinct wms.id as id from wms
     inner join dirspaces_for_work_manifests as dswm
         on dswm.work_manifest = wms.id
-    inner join apply_dirspaces_with_overlap as adso
-        on adso.repository = wms.repository
-           and adso.path = dswm.path
-           and adso.workspace = dswm.workspace
+    inner join blocked_dirspaces as bds
+        on bds.repository = wms.repository
+           and bds.path = dswm.path
+           and bds.workspace = dswm.workspace
+           and bds.unified_run_type = wms.unified_run_type
 ),
 next_work_manifests as (
     select


### PR DESCRIPTION
## Description

Fixes #1438.

An apply against a dirspace with plans in flight is now queued rather than rejected as a conflicting operation:

- The apply waits for every operation running against its dirspaces to complete, and does not cancel them.
- Once queued, the apply takes precedence over every other operation queued for those dirspaces. Plans queued before it, and plans requested after it, run only once the apply has completed, which bounds how long the apply waits.
- A conflicting operation for an apply now means only that an apply is already in flight for that dirspace.

All of this lives in the two queries that decide it: `select_conflicting_work_manifests_in_repo{2,_for_context}.sql` decides what is rejected up front, `select_next_work_manifest.sql` decides what may be dispatched. Both are mirrored for GitHub and GitLab.

Two smaller changes in the same queries:

- `unsafe-apply` was missing from the dispatch priority case, so it sorted after plans instead of ahead of them.
- A work manifest is no longer considered maybe stale purely for sitting in the queue without a run id. Queued work can now legitimately be waiting on other work against its dirspaces, so staleness is measured from dispatch: running without a run id after a minute, or in flight for over an hour.

## Type of change

- [x] New feature

## Checklist

- [x] I have read the contributing guidelines
- [x] The pull request title follows this format: `ISSUE_NUMBER ACTION_TYPE Short description`
- [ ] I have added tests and documentation (if applicable)
- [x] My changes generate no new warnings/errors and do not break existing functionality

## Additional context

Verified end to end against the `docker/terrat` compose stack running the CI-built image for this branch, on a repo whose plan workflow sleeps for 180s:

| Situation | Result |
| --- | --- |
| Plan running, apply requested | Apply work manifest created in `queued` state, no conflicting comment |
| Apply queued, second apply requested | Second apply rejected, comment lists only the queued apply |
| Plan completes | Queued apply dispatched and completed |

Also exercised each row of the issue's behavior table directly against the work manifest queries in Postgres, including a plan queued before the apply, which correctly runs only after the apply completes.