### PR TITLE
#1455 FIX Misc GitLab service fixes: nyi crashes, telemetry, merge SHA, MR states

### DIFF
--- a/code/src/terrat_vcs_api_gitlab/terrat_vcs_api_gitlab.ml
+++ b/code/src/terrat_vcs_api_gitlab/terrat_vcs_api_gitlab.ml
@@ -581,8 +581,27 @@ let fetch_pull_request ~request_id _account client repo merge_request_iid =
       | "opened", _, _, _ -> Terrat_pull_request.State.(Open Open_status.Mergeable)
       | "merged", _, Some merge_commit_sha, Some merged_at ->
           Terrat_pull_request.State.(Merged { Merged.merged_hash = merge_commit_sha; merged_at })
+      (* A merged merge request without a merge commit sha is not a broken
+         response.  GitLab leaves it null for some merge methods, squash in
+         particular, where the resulting commit is reported elsewhere.  Fall
+         back to the head of the source branch rather than crashing, since the
+         merged hash is only used to identify what was merged. *)
+      | "merged", _, merge_commit_sha, merged_at ->
+          Terrat_pull_request.State.(
+            Merged
+              {
+                Merged.merged_hash =
+                  CCOption.get_or ~default:(Ref.to_string branch_ref) merge_commit_sha;
+                merged_at = CCOption.get_or ~default:"" merged_at;
+              })
       | "closed", _, _, _ -> Terrat_pull_request.State.Closed
-      | _, _, _, _ -> assert false
+      (* "locked" is the remaining state GitLab documents, and it is transient
+         while a merge is in progress.  Treat anything unrecognised as closed:
+         it stops Terrateam acting on the merge request, which is the safe
+         outcome, and it used to raise. *)
+      | state, _, _, _ ->
+          Logs.info (fun m -> m "%s : UNEXPECTED_MERGE_REQUEST_STATE : %s" request_id state);
+          Terrat_pull_request.State.Closed
     in
     let draft = CCOption.get_or ~default:false draft in
     let provisional_merge_ref = None in
@@ -974,7 +993,12 @@ let merge_pull_request ~request_id ?(retain_pr_title = false) client pull_reques
   let is_squash = merge_strategy = Ms.Squash in
   let merge_commit_message = None in
   let merge_when_pipeline_succeeds = None in
-  let sha = None in
+  (* GitLab rejects a merge with "SHA must be provided when merging" unless the
+     head of the source branch is passed, so automerge failed outright without
+     it.  Sending it is also the safer behaviour: GitLab refuses the merge if
+     the branch has moved on since, rather than merging something newer than
+     what was planned and approved. *)
+  let sha = Some (Ref.to_string (Terrat_pull_request.branch_ref pull_request)) in
   let should_remove_source_branch = None in
   let skip_merge_train = None in
   let squash = Some is_squash in
@@ -1172,4 +1196,20 @@ let get_org_role ~request_id ~org user client =
       Logs.err (fun m -> m "%s : GET_ORG_ROLE : %a" request_id Openapic_abb.pp_call_err err);
       Abb.Future.return (Error `Error)
 
+(* Deliberately a constant rather than a lookup.  The only caller is
+   [Access_control.is_ci_changed], which asks whether a merge request touches
+   the CI configuration so the ci_config_update policy can be applied, and it
+   treats [None] as "the CI config did not change".
+
+   Checking the repository for the file would therefore be a bypass: a merge
+   request that *adds* .gitlab-ci.yml is exactly the case the policy exists to
+   catch, and the file does not yet exist on the branch being compared against,
+   so the lookup would return [None] and the policy would not fire.  Returning
+   the conventional path unconditionally means the diff is always checked
+   against it, which is the safe direction to be wrong in.
+
+   GitLab reads the pipeline definition from .gitlab-ci.yml unless a project
+   overrides ci_config_path.  Honouring that override would be a genuine
+   improvement, but it must be read from the project settings rather than by
+   probing the repository, for the reason above. *)
 let find_workflow_file ~request_id:_ _repo _client = Abb.Future.return (Ok (Some ".gitlab-ci.yml"))

--- a/code/src/terrat_vcs_service_github/terrat_vcs_service_github_provider.ml
+++ b/code/src/terrat_vcs_service_github/terrat_vcs_service_github_provider.ml
@@ -2306,8 +2306,21 @@ module Apply_requirements = struct
                 | None -> Abb.Future.return (Ok false))
             | Ok None -> Abb.Future.return (Ok false)
             | Error _ -> Abb.Future.return (Error `Error))
-        | None -> raise (Failure "nyi")
-        (* Abb.Future.return (Error (`Invalid_query query)) *))
+        (* The role named in the access control query is not one this VCS
+           defines, which is a mistake in the repo config.  It used to raise,
+           turning a config typo into a 500 with a backtrace.  Report it as an
+           error instead, and name the offending role so it is diagnosable.
+
+           This should really surface as `Invalid_query so the user is told
+           which role is wrong, and the renderers already handle that message.
+           Doing so means widening Terrat_access_control2.query_err and
+           Terrat_vcs_provider2.access_control_query_err past [`Error], which
+           ripples into the evaluator and every provider; each of those sites
+           needs a deliberate decision about how an unevaluatable policy should
+           behave, so it is left as follow-up rather than done here. *)
+        | None ->
+            Logs.err (fun m -> m "%s : ACCESS_CONTROL : UNKNOWN_ROLE : role=%s" request_id value);
+            Abb.Future.return (Error `Error))
     | M.Any -> Abb.Future.return (Ok true)
 
   let compute_approved

--- a/code/src/terrat_vcs_service_github_ee/terrat_vcs_service_github_ee.ml
+++ b/code/src/terrat_vcs_service_github_ee/terrat_vcs_service_github_ee.ml
@@ -50,8 +50,21 @@ module Provider :
                 | None -> Abb.Future.return (Ok false))
             | Ok None -> Abb.Future.return (Ok false)
             | Error _ -> Abb.Future.return (Error `Error))
-        | None -> raise (Failure "nyi")
-        (* Abb.Future.return (Error (`Invalid_query query)) *))
+        (* The role named in the access control query is not one this VCS
+           defines, which is a mistake in the repo config.  It used to raise,
+           turning a config typo into a 500 with a backtrace.  Report it as an
+           error instead, and name the offending role so it is diagnosable.
+
+           This should really surface as `Invalid_query so the user is told
+           which role is wrong, and the renderers already handle that message.
+           Doing so means widening Terrat_access_control2.query_err and
+           Terrat_vcs_provider2.access_control_query_err past [`Error], which
+           ripples into the evaluator and every provider; each of those sites
+           needs a deliberate decision about how an unevaluatable policy should
+           behave, so it is left as follow-up rather than done here. *)
+        | None ->
+            Logs.err (fun m -> m "%s : ACCESS_CONTROL : UNKNOWN_ROLE : role=%s" request_id value);
+            Abb.Future.return (Error `Error))
     | M.Any -> Abb.Future.return (Ok true)
 
   module Gate = struct

--- a/code/src/terrat_vcs_service_gitlab/terrat_vcs_service_gitlab.ml
+++ b/code/src/terrat_vcs_service_gitlab/terrat_vcs_service_gitlab.ml
@@ -287,7 +287,15 @@ struct
       Abb.Future.return
         (Ok { config; drift; flow_state_cleanup; plan_cleanup; repo_config_cleanup; storage; exec })
 
-    let stop _t = raise (Failure "nyi")
+    let stop t =
+      let open Abb.Future.Infix_monad in
+      Abb.Future.abort t.drift
+      >>= fun () ->
+      Abb.Future.abort t.flow_state_cleanup
+      >>= fun () ->
+      Abb.Future.abort t.plan_cleanup
+      >>= fun () -> Abb.Future.abort t.repo_config_cleanup >>= fun () -> Abb.Future.return ()
+
     let routes t = Routes.routes t
 
     let get_user t user_id =

--- a/code/src/terrat_vcs_service_gitlab/terrat_vcs_service_gitlab_provider.ml
+++ b/code/src/terrat_vcs_service_gitlab/terrat_vcs_service_gitlab_provider.ml
@@ -2262,8 +2262,21 @@ module Apply_requirements = struct
                 | None -> Abb.Future.return (Ok false))
             | Ok None -> Abb.Future.return (Ok false)
             | Error _ -> Abb.Future.return (Error `Error))
-        | None -> raise (Failure "nyi")
-        (* Abb.Future.return (Error (`Invalid_query query)) *))
+        (* The role named in the access control query is not one this VCS
+           defines, which is a mistake in the repo config.  It used to raise,
+           turning a config typo into a 500 with a backtrace.  Report it as an
+           error instead, and name the offending role so it is diagnosable.
+
+           This should really surface as `Invalid_query so the user is told
+           which role is wrong, and the renderers already handle that message.
+           Doing so means widening Terrat_access_control2.query_err and
+           Terrat_vcs_provider2.access_control_query_err past [`Error], which
+           ripples into the evaluator and every provider; each of those sites
+           needs a deliberate decision about how an unevaluatable policy should
+           behave, so it is left as follow-up rather than done here. *)
+        | None ->
+            Logs.err (fun m -> m "%s : ACCESS_CONTROL : UNKNOWN_ROLE : role=%s" request_id value);
+            Abb.Future.return (Error `Error))
     | M.Any -> Abb.Future.return (Ok true)
 
   let compute_approved ~request_id client repo approved approved_reviews requested_reviews =
@@ -4386,6 +4399,16 @@ module Work_manifest = struct
         /% Var.bigint "installation_id")
   end
 
+  let make_run_telemetry config step repo =
+    Terrat_telemetry.Event.Run
+      {
+        app_type = "gitlab";
+        app_id = Terrat_config.Gitlab.app_id @@ Api.Config.vcs_config config;
+        step;
+        owner = Api.Repo.owner repo;
+        repo = Api.Repo.name repo;
+      }
+
   let run ~request_id config client work_manifest =
     let module Pipeline_api = Gitlabc_projects_pipeline.PostApiV4ProjectsIdPipeline in
     let module Wm = Terrat_work_manifest3 in
@@ -4439,7 +4462,19 @@ module Work_manifest = struct
         Pipeline_api.(make ~body (Parameters.make ~id:(CCInt.to_string @@ Api.Repo.id repo)))
       >>= fun resp ->
       match Openapi.Response.value resp with
-      | `Created _ -> Abb.Future.return (Ok ())
+      | `Created _ -> (
+          (* GitLab usage was invisible in telemetry because only the GitHub
+             provider reported runs. *)
+          match CCList.last_opt work_manifest.Wm.steps with
+          | Some step ->
+              (* [send] is not in the result monad the rest of this function
+                 uses. *)
+              let open Abb.Future.Infix_monad in
+              Terrat_telemetry.send
+                (Terrat_config.telemetry @@ Api.Config.config config)
+                (make_run_telemetry config step repo)
+              >>= fun () -> Abb.Future.return (Ok ())
+          | None -> Abb.Future.return (Ok ()))
       | `Bad_request json
         when CCString.find ~sub:"Identity verification is required in order to run CI jobs"
              @@ Yojson.Safe.to_string json

--- a/code/src/terrat_vcs_service_gitlab_ee/terrat_vcs_service_gitlab_ee.ml
+++ b/code/src/terrat_vcs_service_gitlab_ee/terrat_vcs_service_gitlab_ee.ml
@@ -44,8 +44,21 @@ module Provider : module type of Terrat_vcs_service_gitlab_provider = struct
                 | None -> Abb.Future.return (Ok false))
             | Ok None -> Abb.Future.return (Ok false)
             | Error _ -> Abb.Future.return (Error `Error))
-        | None -> raise (Failure "nyi")
-        (* Abb.Future.return (Error (`Invalid_query query)) *))
+        (* The role named in the access control query is not one this VCS
+           defines, which is a mistake in the repo config.  It used to raise,
+           turning a config typo into a 500 with a backtrace.  Report it as an
+           error instead, and name the offending role so it is diagnosable.
+
+           This should really surface as `Invalid_query so the user is told
+           which role is wrong, and the renderers already handle that message.
+           Doing so means widening Terrat_access_control2.query_err and
+           Terrat_vcs_provider2.access_control_query_err past [`Error], which
+           ripples into the evaluator and every provider; each of those sites
+           needs a deliberate decision about how an unevaluatable policy should
+           behave, so it is left as follow-up rather than done here. *)
+        | None ->
+            Logs.err (fun m -> m "%s : ACCESS_CONTROL : UNKNOWN_ROLE : role=%s" request_id value);
+            Abb.Future.return (Error `Error))
     | M.Any -> Abb.Future.return (Ok true)
 
   module Gate = Terrat_vcs_service_gitlab_provider.Gate


### PR DESCRIPTION
Closes #1455. Part of the #1445 stack (5/12, bottom to top). Base: `1452-gitlab-wm-token-enforcement`. `1446-gitlab-comment-tables` stacks on top.