### PR TITLE
#1446 ADD GitLab comment tracking and the minimize and delete strategies

### DIFF
--- a/code/src/terrat/migrations/2026-07-21-add-gitlab-comment-tracking.sql
+++ b/code/src/terrat/migrations/2026-07-21-add-gitlab-comment-tracking.sql
@@ -1,0 +1,29 @@
+-- Mirrors github_work_manifest_comments (2025-08-20-add-comment-tracking.sql).
+-- Without it the GitLab comment layer cannot map a dirspace back to the note it
+-- previously posted, so the minimize and delete comment strategies have nothing
+-- to act on and every run can only append.
+--
+-- comment_id is a bigint because Terrat_vcs_api_gitlab.Comment.Id.t is an int
+-- holding a GitLab note id.
+--
+-- Backwards compatible: a new table with no changes to existing relations, so
+-- an older server ignores it entirely.
+create table if not exists gitlab_work_manifest_comments(
+    -- the original id gitlab gave us
+    comment_id bigint not null,
+    work_manifest uuid not null,
+    dir text not null,
+    workspace text not null,
+    pull_number bigint not null,
+    repository bigint not null,
+    unified_run_type text not null,
+    created_at timestamptz default current_timestamp,
+    foreign key (work_manifest, dir, workspace)
+        references work_manifest_results (work_manifest, path, workspace),
+    foreign key (repository, pull_number)
+        references gitlab_pull_requests (repository, pull_number),
+    primary key (repository, pull_number, dir, workspace, unified_run_type)
+);
+
+create index if not exists gitlab_work_manifest_comment_idx
+    on gitlab_work_manifest_comments(comment_id);

--- a/code/src/terrat/terrat_migrations.ml
+++ b/code/src/terrat/terrat_migrations.ml
@@ -281,6 +281,8 @@ let migrations =
       run_sql [%blob "migrations/2026-07-05-extend-repo-configs-with-history.sql"] );
     ("add-tasks-user-id", run_sql [%blob "migrations/2026-07-23-add-tasks-user-id.sql"]);
     ("add-repo-tree-builds", run_sql [%blob "migrations/2026-07-21-add-repo-tree-builds.sql"]);
+    ( "add-gitlab-comment-tracking",
+      run_sql [%blob "migrations/2026-07-21-add-gitlab-comment-tracking.sql"] );
   ]
 
 let run config storage = Mig.run { Migrate.config; storage; tx = () } migrations

--- a/code/src/terrat_vcs_api_gitlab/terrat_vcs_api_gitlab.ml
+++ b/code/src/terrat_vcs_api_gitlab/terrat_vcs_api_gitlab.ml
@@ -466,11 +466,93 @@ let comment_on_pull_request ~request_id client pull_request body =
           m "%s : COMMENT_ON_PULL_REQUEST : %a" request_id Openapic_abb.pp_call_err err);
       Abb.Future.return (Error `Error)
 
-let delete_pull_request_comment ~request_id:_ _client _pull_request _comment_id =
-  raise (Failure "nyi")
+let delete_pull_request_comment ~request_id client pull_request comment_id =
+  let module Gl =
+    Gitlabc_projects_merge_requests.DeleteApiV4ProjectsIdMergeRequestsMergeRequestIidNotesNotesId
+  in
+  let run =
+    let open Abbs_future_combinators.Infix_result_monad in
+    call
+      client.Client.client
+      Gl.(
+        make
+          (Parameters.make
+             ~id:(CCInt.to_string @@ Repo.id @@ Terrat_pull_request.repo pull_request)
+             ~merge_request_iid:(Terrat_pull_request.id pull_request)
+             ~note_id:comment_id))
+    >>= fun resp ->
+    match Openapi.Response.value resp with
+    | `OK -> Abb.Future.return (Ok ())
+    | `Not_found -> Abb.Future.return (Error `Not_found)
+  in
+  let open Abb.Future.Infix_monad in
+  run
+  >>= function
+  | Ok () -> Abb.Future.return (Ok ())
+  | Error (#Gl.Responses.t as err) ->
+      Logs.err (fun m ->
+          m "%s : DELETE_COMMENT_ON_PULL_REQUEST : %a" request_id Gl.Responses.pp err);
+      (* Ignore all errors as this can fail for a bunch of reasons and we don't
+         want to block the actual commenting *)
+      Abb.Future.return (Ok ())
+  | Error (#Openapic_abb.call_err as err) ->
+      Logs.err (fun m ->
+          m "%s : DELETE_COMMENT_ON_PULL_REQUEST : %a" request_id Openapic_abb.pp_call_err err);
+      Abb.Future.return (Ok ())
 
-let minimize_pull_request_comment ~request_id:_ _client _pull_request _comment_id =
-  raise (Failure "nyi")
+(* GitLab has no equivalent of GitHub's "minimize comment", so collapse the
+   note instead: replace its body with a closed [<details>] block.
+
+   Unlike GitHub's minimize this does not keep the original output, and the
+   generated client is why.  Reading the note first in order to wrap its body
+   needs [API_Entities_Note], which declares [system], [id] and [project_id] as
+   [string option] where GitLab sends booleans and integers, so decoding a real
+   note fails with a conversion error.  That is what made the first attempt at
+   this silently do nothing while delete worked.
+
+   Collapsing to a marker is therefore what minimize means here, and it is the
+   outcome audit item 05 allows for.  The full output is still in the run page
+   the comment links to and in the GitLab CI log.  Preserving it inline needs
+   the client's note schema fixed first. *)
+let minimize_pull_request_comment ~request_id client pull_request comment_id =
+  let module Gl =
+    Gitlabc_projects_merge_requests.PutApiV4ProjectsIdMergeRequestsMergeRequestIidNotesNotesId
+  in
+  let body =
+    "<details><summary>Outdated output (minimized)</summary>\n\n\
+     This output was superseded by a later run.\n\n\
+     </details>"
+  in
+  let run =
+    let open Abbs_future_combinators.Infix_result_monad in
+    call
+      client.Client.client
+      Gl.(
+        make
+          (Parameters.make
+             ~body
+             ~id:(CCInt.to_string @@ Repo.id @@ Terrat_pull_request.repo pull_request)
+             ~merge_request_iid:(Terrat_pull_request.id pull_request)
+             ~note_id:comment_id))
+    >>= fun resp ->
+    match Openapi.Response.value resp with
+    | `OK -> Abb.Future.return (Ok ())
+    | `Not_found -> Abb.Future.return (Error `Not_found)
+  in
+  let open Abb.Future.Infix_monad in
+  run
+  >>= function
+  | Ok () -> Abb.Future.return (Ok ())
+  | Error (#Gl.Responses.t as err) ->
+      Logs.err (fun m ->
+          m "%s : MINIMIZE_COMMENT_ON_PULL_REQUEST : %a" request_id Gl.Responses.pp err);
+      (* Ignore all errors as this can fail for a bunch of reasons and we don't
+         want to block the actual commenting *)
+      Abb.Future.return (Ok ())
+  | Error (#Openapic_abb.call_err as err) ->
+      Logs.err (fun m ->
+          m "%s : MINIMIZE_COMMENT_ON_PULL_REQUEST : %a" request_id Openapic_abb.pp_call_err err);
+      Abb.Future.return (Ok ())
 
 let fetch_diff ~request_id ~client ~repo merge_request_iid =
   let module Gl =
@@ -685,9 +767,26 @@ let create_commit_checks ~request_id client repo ref_ checks =
     let module Glp = Gitlabc_projects_pipelines.GetApiV4ProjectsIdPipelines in
     let module Glpb = Gitlabc_components_api_entities_ci_pipelinebasic in
     let module Tcc = Terrat_commit_check in
-    (* For GitLab, we only care about the terrateam apply status checks.  Status
-       checks do not show the same as in GitHub, so creating the extras is not
-       valuable. *)
+    (* Only the "terrateam apply" check is published, and unlike GitHub this is
+       load bearing rather than a display preference.
+
+       A GitLab commit status is attached to a pipeline, and the pipeline's own
+       status is the aggregate of the statuses attached to it.  Every check
+       below is posted against the merge request's pipeline (see
+       [lookup_mr_pipeline_id]), so publishing a check per dirspace would fold
+       each one into that pipeline's result: a queued or failed plan for a
+       single directory would drive the whole pipeline to pending or failed.
+       That feeds [detailed_merge_status] as [ci_must_pass], so on a project
+       that requires a green pipeline to merge it would block the merge on
+       Terrateam's own bookkeeping, and it would also make the merge request
+       read as broken while a plan is merely in flight.
+
+       GitHub has no equivalent coupling: its checks are independent of one
+       another, which is why the GitHub service publishes them all.
+
+       If per-dirspace visibility is wanted here, it needs its own status
+       grouping rather than the merge request pipeline -- do not simply widen
+       this filter. *)
     let checks =
       CCList.filter (fun { Tcc.title; _ } -> CCString.equal title "terrateam apply") checks
     in
@@ -758,7 +857,7 @@ let create_commit_checks ~request_id client repo ref_ checks =
     let module C = Terrat_commit_check in
     let module Body = Gitlabc_components_postapiv4projectsidstatusessha in
     Abbs_future_combinators.List_result.iter
-      ~f:(fun { C.status; title; description; _ } ->
+      ~f:(fun { C.status; title; description; details_url } ->
         let body =
           {
             Body.context = "terrateam external";
@@ -774,7 +873,10 @@ let create_commit_checks ~request_id client repo ref_ checks =
               | C.Status.Completed -> `Success
               | C.Status.Failed -> `Failed
               | C.Status.Canceled -> `Canceled);
-            target_url = None;
+            (* GitLab renders this as the link on the status, the same as
+               GitHub's details_url.  It is empty when there is no work manifest
+               to point at, and GitLab rejects an empty string, so send None. *)
+            target_url = (if CCString.is_empty details_url then None else Some details_url);
           }
         in
         Logs.info (fun m ->

--- a/code/src/terrat_vcs_gitlab_comment/dune
+++ b/code/src/terrat_vcs_gitlab_comment/dune
@@ -13,9 +13,12 @@
   terrat_scope
   terrat_tier
   terrat_vcs_api_gitlab
+  terrat_data
   terrat_vcs_comment
   terrat_vcs_gitlab_comment_templates
   terrat_vcs_provider2
   terrat_work_manifest3)
+ (preprocessor_deps
+  (glob_files sql/*.sql))
  (preprocess
-  (pps ppx_deriving.ord ppx_deriving.show ppx_deriving_yojson)))
+  (pps ppx_blob ppx_deriving.ord ppx_deriving.show ppx_deriving_yojson)))

--- a/code/src/terrat_vcs_gitlab_comment/sql/select_comment_elements.sql
+++ b/code/src/terrat_vcs_gitlab_comment/sql/select_comment_elements.sql
@@ -1,0 +1,44 @@
+-- This CTE selects only the dirspaces which 
+-- changed in the current work manifest
+-- provided by Terrateam's server.
+with currently_changed_dirspaces as (
+  select
+    cd.path as dir,
+    cd.workspace
+  from change_dirspaces cd
+  inner join work_manifests wm on (
+        wm.sha = cd.sha
+    and wm.base_sha = cd.base_sha
+    and wm.repo = cd.repo
+  )
+  where wm.id = $work_manifest
+)
+select 
+    wm.id,
+    gwmc.dir,
+    gwmc.workspace,
+    wm.run_type,
+    wso.ignore_errors,
+    wso.payload,
+    wso.scope,
+    wso.success,
+    wso.step
+from gitlab_work_manifest_comments gwmc
+-- Do not confuse this with the work manifests
+-- targeted by the CTE, these ones are from
+-- previous runs that may still be relevant to be
+-- posted in a comment.
+inner join work_manifests wm on gwmc.work_manifest = wm.id
+inner join workflow_step_outputs wso on (
+        wso.work_manifest = wm.id 
+    and wso.scope->>'type' = 'dirspace'
+    and gwmc.dir = wso.scope->>'dir' 
+    and gwmc.workspace = wso.scope->>'workspace'
+)
+inner join currently_changed_dirspaces ccd on (
+        gwmc.dir = ccd.dir
+    and gwmc.workspace = ccd.workspace
+)
+where 
+    gwmc.comment_id = $comment_id
+order by wso.idx

--- a/code/src/terrat_vcs_gitlab_comment/sql/select_comment_id.sql
+++ b/code/src/terrat_vcs_gitlab_comment/sql/select_comment_id.sql
@@ -1,0 +1,35 @@
+with grouped_work_manifest_by_id as (
+  select
+    wm.pull_request,
+    wm.run_type,
+    case 
+      when wm.run_type in ('autoplan', 'plan') then 'plan'
+      when wm.run_type in ('autoapply', 'apply', 'unsafe-apply') then 'apply'
+      else wm.run_type
+    end as run_group
+  from work_manifests wm
+  where id = $work_manifest
+),
+grouped_work_manifest_with_pr as (
+  select
+    wm.id,
+    wm.pull_request,
+    wm.run_type,
+    case 
+      when wm.run_type in ('autoplan', 'plan') then 'plan'
+      when wm.run_type in ('autoapply', 'apply', 'unsafe-apply') then 'apply'
+      else wm.run_type
+    end as run_group
+  from work_manifests wm
+)
+select 
+    gwmc.comment_id
+from gitlab_work_manifest_comments gwmc
+inner join grouped_work_manifest_with_pr wmpr ON gwmc.work_manifest = wmpr.id
+inner join grouped_work_manifest_by_id wmid ON (
+        wmid.pull_request = wmpr.pull_request 
+    and wmid.run_group = wmpr.run_group
+)
+where 
+    gwmc.dir = $dir 
+and gwmc.workspace = $workspace

--- a/code/src/terrat_vcs_gitlab_comment/sql/upsert_gitlab_work_manifest_comment.sql
+++ b/code/src/terrat_vcs_gitlab_comment/sql/upsert_gitlab_work_manifest_comment.sql
@@ -1,0 +1,33 @@
+with wm AS (
+    select
+        gwm.pull_number,
+        gwm.repository,
+        gwm.run_type,
+        case 
+          when gwm.run_type in ('autoplan', 'plan') then 'plan'
+          when gwm.run_type in ('autoapply', 'apply', 'unsafe-apply') then 'apply'
+          else gwm.run_type
+        end as unified_run_type
+    from gitlab_work_manifests gwm
+    where id = $work_manifest
+),
+insert_comment as (
+  insert into gitlab_work_manifest_comments(comment_id, work_manifest, repository, pull_number, dir, workspace, unified_run_type)
+  select
+      $comment_id, 
+      $work_manifest, 
+      wm.repository,
+      wm.pull_number,
+      $dir,
+      $workspace,
+      wm.unified_run_type
+  from wm
+  on conflict (repository, pull_number, dir, workspace, unified_run_type)
+  do update 
+      set comment_id = excluded.comment_id,
+          created_at = current_timestamp,
+          work_manifest = excluded.work_manifest
+  returning comment_id
+)
+select comment_id
+from insert_comment

--- a/code/src/terrat_vcs_gitlab_comment/terrat_vcs_gitlab_comment.ml
+++ b/code/src/terrat_vcs_gitlab_comment/terrat_vcs_gitlab_comment.ml
@@ -6,6 +6,71 @@ let src = Logs.Src.create "vcs_gitlab_comment"
 
 module Logs = (val Logs.src_log src : Logs.LOG)
 
+module Sql = struct
+  let read s = Pgsql_io.clean_string s
+
+  let select_comment_id =
+    Pgsql_io.Typed_sql.(
+      sql
+      //
+      (* comment_id *)
+      Ret.bigint
+      /^ read [%blob "sql/select_comment_id.sql"]
+      /% Var.uuid "work_manifest"
+      /% Var.text "dir"
+      /% Var.text "workspace")
+
+  let select_comment_elements =
+    Pgsql_io.Typed_sql.(
+      sql
+      //
+      (* work_manifest_id *)
+      Ret.uuid
+      //
+      (* comment.dir *)
+      Ret.text
+      //
+      (* comment.workspace *)
+      Ret.text
+      //
+      (* work_manifest.run_type *)
+      Ret.text
+      //
+      (* steps.ignore_errors *)
+      Ret.boolean
+      //
+      (* steps.payload *)
+      Ret.u
+        Ret.json
+        CCFun.(Terrat_api_components_workflow_step_output.Payload.of_yojson %> CCOption.of_result)
+      //
+      (* steps.scope *)
+      Ret.u
+        Ret.json
+        CCFun.(Terrat_api_components_workflow_step_output_scope.of_yojson %> CCOption.of_result)
+      //
+      (* steps.success *)
+      Ret.boolean
+      //
+      (* steps.step *)
+      Ret.text
+      /^ read [%blob "sql/select_comment_elements.sql"]
+      /% Var.bigint "comment_id"
+      /% Var.uuid "work_manifest")
+
+  let upsert_gitlab_work_manifest_comment =
+    Pgsql_io.Typed_sql.(
+      sql
+      //
+      (* comment_id *)
+      Ret.bigint
+      /^ read [%blob "sql/upsert_gitlab_work_manifest_comment.sql"]
+      /% Var.bigint "comment_id"
+      /% Var.uuid "work_manifest"
+      /% Var.text "dir"
+      /% Var.text "workspace")
+end
+
 module S = struct
   type t = {
     account_status : Terrat_vcs_provider2.Account_status.t;
@@ -30,6 +95,7 @@ module S = struct
     dirspace : Terrat_dirspace.t;
     steps : Terrat_api_components_workflow_step_output.t list;
     strategy : Terrat_vcs_comment.Strategy.t;
+    work_manifest_id : Uuidm.t;
   }
   [@@deriving show]
 
@@ -39,19 +105,130 @@ module S = struct
     type t = bool * bool * Terrat_dirspace.t [@@deriving ord]
   end
 
-  let create_el _t dirspace steps =
-    (* TODO: Once proper tables for GitLab exist, replace this function
-       with a similar implementation that is used in GITLAB *)
+  let create_el t ~work_manifest_id dirspace steps =
     let module St = Terrat_vcs_comment.Strategy in
-    let compact = false in
-    let strategy = St.Append in
-    Some { dirspace; steps; strategy; compact }
+    let module Cm3 = Terrat_change_match3 in
+    let module Brc1 = Terrat_base_repo_config_v1 in
+    let module N = Terrat_base_repo_config_v1.Notifications in
+    let from_base_repo_policy_strategy st =
+      match st with
+      | N.Policy.Strategy.Append -> St.Append
+      | N.Policy.Strategy.Minimize -> St.Minimize
+      | N.Policy.Strategy.Delete -> St.Delete
+    in
+    let notification = Terrat_base_repo_config_v1.notifications t.repo_config in
+    let policies = notification.N.policies in
+    match Cm3.of_dirspace t.synthesized_config dirspace with
+    | Some config ->
+        let strategy =
+          match
+            CCList.find_opt
+              (fun p -> Cm3.match_tag_query ~tag_query:p.N.Policy.tag_query config)
+              policies
+          with
+          | Some { N.Policy.comment_strategy; _ } -> from_base_repo_policy_strategy comment_strategy
+          | None -> Terrat_vcs_comment.Strategy.Minimize
+        in
+        let compact = false in
+        Some { work_manifest_id; dirspace; steps; strategy; compact }
+    | _ -> None
 
-  let query_comment_id _t _el = raise (Failure "nyi")
-  let query_els_for_comment_id _t _cid = raise (Failure "nyi")
-  let upsert_comment_id _t _els _cid = Abb.Future.return (Ok ())
-  let delete_comment _t _comment_id = raise (Failure "nyi")
-  let minimize_comment _t _comment_id = raise (Failure "nyi")
+  let query_comment_id t el =
+    let open Abb.Future.Infix_monad in
+    let work_manifest_id = t.work_manifest.Terrat_work_manifest3.id in
+    let { Terrat_dirspace.dir; workspace } = el.dirspace in
+    Pgsql_io.Prepared_stmt.fetch
+      t.db
+      Sql.select_comment_id
+      ~f:CCFun.id
+      work_manifest_id
+      dir
+      workspace
+    >>= function
+    | Ok r ->
+        Abb.Future.return
+          (Ok
+             (CCOption.of_list r
+             |> CCOption.flat_map CCFun.(Int64.to_string %> Api.Comment.Id.of_string)))
+    | Error (#Pgsql_io.err as err) ->
+        Logs.err (fun m -> m "%s : ERROR : %a" t.request_id Pgsql_io.pp_err err);
+        Abb.Future.return (Error `Error)
+
+  let query_els_for_comment_id t comment_id =
+    let open Abb.Future.Infix_monad in
+    let module D = Terrat_api_components_workflow_step_output_scope_dirspace in
+    let module Step = Terrat_api_components_workflow_step_output in
+    let module Scope = Terrat_api_components_workflow_step_output_scope in
+    let cid = Api.Comment.Id.to_string comment_id |> Int64.of_string in
+    let current_work_manifest = t.work_manifest.Terrat_work_manifest3.id in
+    let module By_scope = Terrat_data.Group_by (struct
+      type t = Uuidm.t * string * Step.t
+      type key = Uuidm.t * string * Terrat_dirspace.t [@@deriving ord]
+
+      let key (work_manifest_id, run_type, step) =
+        match step.Step.scope with
+        | Scope.Workflow_step_output_scope_dirspace { D.dir; workspace; _ } ->
+            let dirspace = { Terrat_dirspace.dir; workspace } in
+            (work_manifest_id, run_type, dirspace)
+        | _ -> assert false
+
+      let compare = compare_key
+    end) in
+    Pgsql_io.Prepared_stmt.fetch
+      t.db
+      Sql.select_comment_elements
+      ~f:(fun wmid _ _ run_type ignore_errors payload scope success step ->
+        (wmid, run_type, { Step.ignore_errors; payload; scope; step; success }))
+      cid
+      current_work_manifest
+    >>= function
+    | Ok elements ->
+        let groups = By_scope.group elements in
+        let split =
+          CCList.map
+            (fun ((wid, run_type, d), v) -> (wid, run_type, d, CCList.map (fun (_, _, s) -> s) v))
+            groups
+        in
+        let els =
+          CCList.filter_map
+            (fun (work_manifest_id, _, dirspace, steps) ->
+              create_el t ~work_manifest_id dirspace steps)
+            split
+        in
+        Abb.Future.return (Ok els)
+    | Error (#Pgsql_io.err as err) ->
+        Logs.err (fun m -> m "%s : ERROR : %a" t.request_id Pgsql_io.pp_err err);
+        Abb.Future.return (Error `Error)
+
+  let upsert_comment_id t els comment_id =
+    let open Abb.Future.Infix_monad in
+    let cid = Api.Comment.Id.to_string comment_id |> Int64.of_string in
+    Abbs_future_combinators.List_result.map
+      ~f:(fun el ->
+        let { Terrat_dirspace.dir; workspace } = el.dirspace in
+        Pgsql_io.Prepared_stmt.fetch
+          t.db
+          Sql.upsert_gitlab_work_manifest_comment
+          ~f:(fun _ -> ())
+          cid
+          el.work_manifest_id
+          dir
+          workspace)
+      els
+    >>= function
+    | Ok _ -> Abb.Future.return (Ok ())
+    | Error (#Pgsql_io.err as err) ->
+        Logs.err (fun m -> m "%s : ERROR : %a" t.request_id Pgsql_io.pp_err err);
+        Abb.Future.return (Error `Error)
+
+  let delete_comment t comment_id =
+    let request_id = t.request_id in
+    Api.delete_pull_request_comment ~request_id t.client t.pull_request comment_id
+
+  let minimize_comment t comment_id =
+    let request_id = t.request_id in
+    Api.minimize_pull_request_comment ~request_id t.client t.pull_request comment_id
+
   let pull_number t = Some (Api.Pull_request.id t.pull_request)
 
   (* GitLab has no Console run pages (see [Ui.run_url]) and does not yet track a
@@ -173,9 +350,7 @@ module S = struct
     CCString.length @@ Yojson.Safe.to_string @@ `String body
 
   let dirspace el = el.dirspace
-
-  (* TODO: Remove this once proper GitLab migrations are also merged *)
-  let strategy _el = Terrat_vcs_comment.Strategy.Append
+  let strategy el = el.strategy
   let compact el = { el with compact = true }
 
   let compare_el el1 el2 =

--- a/code/src/terrat_vcs_gitlab_comment/terrat_vcs_gitlab_comment.mli
+++ b/code/src/terrat_vcs_gitlab_comment/terrat_vcs_gitlab_comment.mli
@@ -24,6 +24,7 @@ module S : sig
     dirspace : Terrat_dirspace.t;
     steps : Terrat_api_components_workflow_step_output.t list;
     strategy : Terrat_vcs_comment.Strategy.t;
+    work_manifest_id : Uuidm.t;
   }
   [@@deriving show]
 
@@ -34,7 +35,11 @@ module S : sig
   end
 
   val create_el :
-    t -> Terrat_dirspace.t -> Terrat_api_components_workflow_step_output.t list -> el option
+    t ->
+    work_manifest_id:Uuidm.t ->
+    Terrat_dirspace.t ->
+    Terrat_api_components_workflow_step_output.t list ->
+    el option
 
   val query_comment_id : t -> el -> (comment_id option, [> `Error ]) result Abb.Future.t
   val query_els_for_comment_id : t -> comment_id -> (el list, [> `Error ]) result Abb.Future.t

--- a/code/src/terrat_vcs_service_gitlab/terrat_vcs_service_gitlab_provider.ml
+++ b/code/src/terrat_vcs_service_gitlab/terrat_vcs_service_gitlab_provider.ml
@@ -2785,10 +2785,11 @@ module Comment = struct
             work_manifest;
           }
         in
+        let work_manifest_id = work_manifest.Terrat_work_manifest3.id in
         let els =
           CCList.filter_map
             (function
-              | Scope.Dirspace dirspace, steps -> Tcm.S.create_el t dirspace steps
+              | Scope.Dirspace dirspace, steps -> Tcm.S.create_el t ~work_manifest_id dirspace steps
               | Scope.Run _, _ -> None)
             by_scope
         in


### PR DESCRIPTION
Closes #1446. Part of the #1445 stack (6/12, bottom to top). Base: `1455-gitlab-misc-cleanups`. `1447-gitlab-ui-links` stacks on top.