### PR TITLE
#1447 ADD Link GitLab merge request comments to the Terrateam run page

### DIFF
--- a/code/src/terrat_vcs_gitlab_comment/terrat_vcs_gitlab_comment_ui.ml
+++ b/code/src/terrat_vcs_gitlab_comment/terrat_vcs_gitlab_comment_ui.ml
@@ -1,4 +1,32 @@
 module Ui = struct
-  let work_manifest_url _config _account _pull_number _work_manifest = None
-  let run_url _config _account _work_manifest_id = None
+  module Api = Terrat_vcs_api_gitlab
+
+  let base_url config account =
+    Printf.sprintf
+      "%s/i/%d"
+      (Uri.to_string (Terrat_config.terrateam_web_base_url @@ Api.Config.config config))
+      (Api.Account.id account)
+
+  (* For merge request runs, link to the MR-level runs page which lists every run
+     for the merge request.  For non-merge-request targets (e.g. drift), which
+     have no merge request to aggregate, fall back to the single work manifest's
+     run. *)
+  let work_manifest_url config account pull_number work_manifest =
+    let module Wm = Terrat_work_manifest3 in
+    let url =
+      match pull_number with
+      | Some pull_number -> Printf.sprintf "%s/runs/pr/%d" (base_url config account) pull_number
+      | None ->
+          Printf.sprintf
+            "%s/runs/%s"
+            (base_url config account)
+            (Uuidm.to_string work_manifest.Wm.id)
+    in
+    Some (Uri.of_string url)
+
+  (* Link to a specific work manifest's run detail. *)
+  let run_url config account work_manifest_id =
+    Some
+      (Uri.of_string
+         (Printf.sprintf "%s/runs/%s" (base_url config account) (Uuidm.to_string work_manifest_id)))
 end

--- a/code/src/terrat_vcs_gitlab_comment_templates/terrat_vcs_gitlab_comment_templates.ml
+++ b/code/src/terrat_vcs_gitlab_comment_templates/terrat_vcs_gitlab_comment_templates.ml
@@ -207,7 +207,3 @@ module Tmpl = struct
   let notification_policy_tag_query_err =
     jinja [%blob "tmpl/notification_policy_tag_query_err.tmpl"]
 end
-
-module Ui = struct
-  let work_manifest_url _config _account = raise (Failure "nyi")
-end


### PR DESCRIPTION
Closes #1447. Part of the #1445 stack (7/12, bottom to top). Base: `1446-gitlab-comment-tables`. `1448-gitlab-commit-checks` stacks on top.