### PR TITLE
#1448 ADD Link GitLab commit statuses to the Terrateam run page

### DIFF
--- a/code/src/terrat_vcs_service_gitlab/terrat_vcs_service_gitlab_provider.ml
+++ b/code/src/terrat_vcs_service_gitlab/terrat_vcs_service_gitlab_provider.ml
@@ -4267,8 +4267,19 @@ module Commit_check = struct
   let make_dirspace_title ~run_type { Terrat_dirspace.dir; workspace } =
     Printf.sprintf "terrateam %s: %s %s" run_type dir workspace
 
-  let make ?work_manifest:_ ~config:_ ~description ~title ~status ~repo:_ ~account:_ () =
-    Terrat_commit_check.make ~details_url:"" ~description ~title ~status
+  let make ?work_manifest ~config ~description ~title ~status ~repo:_ ~account () =
+    let module Wm = Terrat_work_manifest3 in
+    let details_url =
+      match work_manifest with
+      | Some work_manifest ->
+          Printf.sprintf
+            "%s/i/%d/runs/%s"
+            (Uri.to_string @@ Terrat_config.terrateam_web_base_url @@ Api.Config.config config)
+            (Api.Account.id account)
+            (Uuidm.to_string work_manifest.Wm.id)
+      | None -> Uri.to_string @@ Terrat_config.terrateam_web_base_url @@ Api.Config.config config
+    in
+    Terrat_commit_check.make ~details_url ~description ~title ~status
 
   let make_str ?work_manifest ~config ~description ~status ~repo ~account s =
     make ?work_manifest ~config ~description ~title:s ~status ~repo ~account ()


### PR DESCRIPTION
Closes #1448. Part of the #1445 stack (8/12, bottom to top). Base: `1447-gitlab-ui-links`. `1450-gitlab-ee-gates` stacks on top.