### PR TITLE
#1449 ADD GitLab end-to-end test harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ pnpm-debug.log*
 
 # Python cache
 *__pycache__.*
+__pycache__/
 
 # Dune-generated merlin config
 code/.merlin

--- a/docker/gitlab-e2e/README.md
+++ b/docker/gitlab-e2e/README.md
@@ -1,0 +1,108 @@
+# GitLab end-to-end test harness
+
+Drives real merge requests through a live GitLab against a live Terrateam
+server and asserts the observable outcome: the comment that gets posted, the
+commit status that gets set, whether an apply is blocked or allowed, what
+lands in the database.
+
+Unit tests cannot catch a regression in the webhook → pipeline → comment loop,
+because every interesting part of it is on the other side of GitLab. This is
+that other side.
+
+## What it needs
+
+A GitLab (gitlab.com or self-hosted) and a Terrateam server that GitLab can
+reach. There is no container for either — pointing the harness at whatever you
+already run is the whole idea, and it means the same scenarios validate a
+laptop, CI, and a staging deploy.
+
+Running GitLab CE locally alongside the stack is possible but heavy: Omnibus
+wants ≥4 GB RAM before a runner, postgres and the Terrateam server are added.
+If the host has the memory, set `GITLAB_WEB_BASE_URL`/`GITLAB_API_BASE_URL` at
+it and everything else works unchanged.
+
+One constraint is easy to miss: **fixture projects must be created in the group
+the Terrateam installation was installed against.** The server acts on a repo
+using that installation's access token, so a project in any other group is
+invisible to it.
+
+## Setup
+
+```sh
+cp env.example .env
+$EDITOR .env
+./run-scenario --list
+```
+
+The installation id and webhook secret come from the Terrateam database:
+
+```sql
+select id, webhook_secret from gitlab_installations where name = '<group>';
+```
+
+## Running
+
+```sh
+./run-scenario 1.1          # one scenario
+./run-scenario 3.3 3.4      # several
+./run-scenario --all        # the suite (nightly)
+```
+
+Exit status is non-zero if any scenario fails. Each scenario creates its own
+throwaway project, registers a webhook on it, does its work, and deletes the
+project — so scenarios are idempotent, self-cleaning, and safe to run in
+sequence unattended. `E2E_KEEP=1` leaves the project behind for debugging.
+
+## Layout
+
+```
+harness/
+  config.py     environment contract
+  gitlab.py     stdlib-only GitLab API client
+  fixture.py    the throwaway Terraform project and its lifecycle
+  scenario.py   registry, execution context, assertions
+  runner.py     CLI
+scenarios/
+  markers.py    strings asserted on, traced back to the comment templates
+  phase1.py     TEST-PLAN Phase 1 (1.1-1.8) -- the core loop
+  item03.py     TEST-PLAN 3.3, 3.4
+  item04.py     TEST-PLAN 3.8
+```
+
+The fixture is three Terraform directories (`dev/`, `prod/`, `modules/shared`)
+built entirely from `null_resource`, so no cloud credentials are ever needed,
+plus a `.gitlab-ci.yml` declaring the four pipeline inputs Terrateam sends
+(`TERRATEAM_TRIGGER`, `WORK_TOKEN`, `API_BASE_URL`, `RUNS_ON`). All four need
+defaults or GitLab refuses the trigger and the server reports
+`GITLAB_INPUTS_MISSING_DEFAULTS`.
+
+## Writing a scenario
+
+```python
+from harness.scenario import scenario
+from . import markers
+
+@scenario("5.1", "What this proves", phase=5)
+def my_scenario(ctx):
+    ctx.fixture.create()
+    ctx.fixture.register_webhook()
+    branch = ctx.fixture.branch_with_change("e2e/thing", dirs=("dev",))
+    mr = ctx.fixture.open_mr(branch)
+
+    ctx.wait_for_note_containing(mr["iid"], markers.PLAN_COMPLETE)
+    ctx.comment(mr["iid"], "terrateam apply")
+    ctx.wait_for_note_containing(mr["iid"], markers.APPLY_COMPLETE)
+```
+
+Add the module to `scenarios/__init__.py` so `--all` picks it up.
+
+Two rules worth keeping:
+
+- **Assert on real API state where you can** — notes, commit statuses,
+  `detailed_merge_status`, rows in the database. Log grepping is the fallback
+  for the cases where the expected outcome genuinely is "nothing happened and
+  nothing crashed" (see `item03.py`).
+- **Assert the failure path too.** A scenario that only proves the happy path
+  still passes when a check has been removed entirely; `item04.py` asserts the
+  rejection *and* that a real run completes, because either half alone can pass
+  for the wrong reason.

--- a/docker/gitlab-e2e/env.example
+++ b/docker/gitlab-e2e/env.example
@@ -1,0 +1,64 @@
+# Copy to .env next to this file and fill in.  run-scenario sources it.
+# .env is gitignored -- never commit real credentials.
+#
+# Quote every value.  run-scenario sources this file with `set -o allexport`,
+# so an unquoted value containing spaces is parsed as a command.
+
+# --- GitLab ------------------------------------------------------------------
+
+# Personal or group access token with the `api` scope.  The harness creates and
+# deletes projects with it, so it needs Maintainer on GITLAB_TEST_GROUP.
+GITLAB_ACCESS_TOKEN="glpat-xxxxxxxxxxxxxxxxxxxx"
+
+# Where fixture projects are created.  This MUST be the group the Terrateam
+# installation under test was installed against -- the server acts on the repo
+# with that installation's access token, so a project anywhere else is
+# invisible to it.
+GITLAB_TEST_GROUP="my-group"
+
+# Optional.  A second account's token, needed only where the acting user must
+# not be the merge request author.  Gate approvals are the case: the server
+# excludes an approval whose approver opened the merge request, so a gate can
+# never be satisfied by its author.  Scenarios needing this skip when unset.
+#GITLAB_APPROVER_TOKEN="glpat-yyyyyyyyyyyyyyyyyyyy"
+
+# Only for self-hosted GitLab; both default to gitlab.com.
+#GITLAB_WEB_BASE_URL=https://gitlab.example.com
+#GITLAB_API_BASE_URL=https://gitlab.example.com/api/v4
+
+# --- Terrateam ---------------------------------------------------------------
+
+# Public base URL of the Terrateam server under test.  GitLab must be able to
+# reach it, so it needs to be publicly resolvable (or fronted by a tunnel).
+TERRATEAM_WEB_BASE_URL="https://terrateam.example.com"
+
+# Defaults to $TERRATEAM_WEB_BASE_URL/api/v1/gitlab/events.
+#TERRATEAM_WEBHOOK_URL=
+
+# The installation under test, and its webhook secret.  Get both with:
+#   select id, webhook_secret from gitlab_installations where name = '<group>';
+TERRATEAM_INSTALLATION_ID="42"
+TERRATEAM_WEBHOOK_SECRET="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+
+# Optional.  A command that reaches the Terrateam database, used by scenarios
+# that assert on server-side state.  Read-only queries only.
+#TERRATEAM_PSQL="docker compose -f /path/to/docker-compose.yml exec -T db psql -U terrateam -d terrateam"
+
+# Optional.  A command printing recent server logs, used by the scenarios whose
+# expected outcome is "nothing happened and nothing crashed".  Include the
+# {since} placeholder: the harness substitutes the running scenario's own age,
+# so one scenario never asserts on lines an earlier one produced.
+#TERRATEAM_LOGS_CMD="docker compose -f /path/to/docker-compose.yml logs --since {since} terrateam-server"
+
+# --- Harness behaviour -------------------------------------------------------
+
+# Seconds to wait for the webhook -> pipeline -> comment loop.  Shared runners
+# are slow; the default is deliberately generous.
+#E2E_TIMEOUT=600
+#E2E_POLL_INTERVAL=5
+
+# Keep the fixture project after the run instead of deleting it.
+#E2E_KEEP=1
+
+# Runner tags, if the group needs a specific runner.
+#E2E_RUNS_ON=saas-linux-small-amd64

--- a/docker/gitlab-e2e/harness/__init__.py
+++ b/docker/gitlab-e2e/harness/__init__.py
@@ -1,0 +1,4 @@
+"""GitLab end-to-end test harness for Terrateam.
+
+See ``../README.md``.
+"""

--- a/docker/gitlab-e2e/harness/config.py
+++ b/docker/gitlab-e2e/harness/config.py
@@ -1,0 +1,89 @@
+"""Configuration for the GitLab e2e harness.
+
+Every value comes from the environment so the harness can be pointed at any
+GitLab (gitlab.com or self-hosted) and any Terrateam server without edits.  See
+``env.example`` for the contract and ``README.md`` for how the pieces fit
+together.
+"""
+
+import os
+import sys
+
+
+class ConfigError(Exception):
+    pass
+
+
+def _require(name):
+    value = os.environ.get(name)
+    if not value:
+        raise ConfigError(
+            "%s is not set.  Copy env.example to .env, fill it in, and source it." % name
+        )
+    return value
+
+
+class Config:
+    def __init__(self):
+        # GitLab
+        self.gitlab_url = os.environ.get("GITLAB_WEB_BASE_URL", "https://gitlab.com").rstrip("/")
+        self.gitlab_api_url = os.environ.get(
+            "GITLAB_API_BASE_URL", self.gitlab_url + "/api/v4"
+        ).rstrip("/")
+        self.gitlab_token = _require("GITLAB_ACCESS_TOKEN")
+
+        # Where fixture projects are created.  This group MUST be the one the
+        # Terrateam installation was installed against, because the server acts
+        # on the repo with that installation's access token.
+        self.group = _require("GITLAB_TEST_GROUP")
+
+        # A second GitLab account, used where one user acting alone cannot
+        # produce the situation under test.  Gate approvals are the case that
+        # needs it: select_gate_approvals excludes approvals whose approver is
+        # the merge request author, so a gate can never be satisfied by the
+        # person who opened the merge request.  Scenarios that need this skip
+        # when it is unset rather than failing.
+        self.approver_token = os.environ.get("GITLAB_APPROVER_TOKEN")
+
+        # Terrateam
+        self.terrateam_url = _require("TERRATEAM_WEB_BASE_URL").rstrip("/")
+        self.webhook_url = os.environ.get(
+            "TERRATEAM_WEBHOOK_URL", self.terrateam_url + "/api/v1/gitlab/events"
+        )
+        # The per-installation webhook secret, sent as X-Gitlab-Token.  Read it
+        # from gitlab_installations.webhook_secret for the installation under
+        # test.
+        self.webhook_secret = _require("TERRATEAM_WEBHOOK_SECRET")
+        self.installation_id = _require("TERRATEAM_INSTALLATION_ID")
+
+        # Optional: a psql command that reaches the Terrateam database, used by
+        # scenarios that assert on server-side state rather than GitLab state.
+        # Example: "docker compose -f /root/demo/docker-compose.yml exec -T db
+        #           psql -U stategraph -d terrateam"
+        self.psql = os.environ.get("TERRATEAM_PSQL")
+
+        # Optional: a shell command that prints recent Terrateam server logs,
+        # used by the scenarios whose expected outcome is "nothing happened and
+        # nothing crashed".  Example: "docker compose -f
+        # /root/demo/docker-compose.yml logs --since 10m terrateam-server"
+        self.logs_cmd = os.environ.get("TERRATEAM_LOGS_CMD")
+
+        # Timeouts, in seconds.  GitLab pipelines on shared runners are slow;
+        # these are deliberately generous.
+        self.timeout = int(os.environ.get("E2E_TIMEOUT", "600"))
+        self.poll_interval = int(os.environ.get("E2E_POLL_INTERVAL", "5"))
+
+        # Leave the fixture project behind for debugging.
+        self.keep = os.environ.get("E2E_KEEP", "") not in ("", "0", "false")
+
+        # Terraform runner tags, if the group uses a specific runner.
+        runs_on = os.environ.get("E2E_RUNS_ON", "")
+        self.runs_on = [t for t in runs_on.split(",") if t]
+
+
+def load():
+    try:
+        return Config()
+    except ConfigError as exc:
+        print("config error: %s" % exc, file=sys.stderr)
+        raise SystemExit(2)

--- a/docker/gitlab-e2e/harness/fixture.py
+++ b/docker/gitlab-e2e/harness/fixture.py
@@ -1,0 +1,263 @@
+"""The fixture Terraform project a scenario runs against.
+
+Each run creates its own project so scenarios never contaminate each other and
+can run unattended in sequence.  The project is deleted on teardown unless
+E2E_KEEP is set.
+
+The layout matches the audit's TEST-PLAN: three directories so dirspace
+targeting is exercisable, and null_resource-only Terraform so no cloud
+credentials are ever needed.
+"""
+
+import time
+
+from . import gitlab
+
+# The pipeline spec Terrateam triggers.  The four inputs are exactly what
+# Terrat_vcs_service_gitlab_provider.build_pipeline_inputs sends
+# (TERRATEAM_TRIGGER, WORK_TOKEN, API_BASE_URL and optionally RUNS_ON).  Every
+# one needs a default, or GitLab rejects the trigger and the server reports
+# GITLAB_INPUTS_MISSING_DEFAULTS.
+GITLAB_CI_YML = """\
+spec:
+  inputs:
+    TERRATEAM_TRIGGER:
+      description: "Is this being triggered by terrateam?"
+      type: string
+      default: "$TERRATEAM_TRIGGER"
+    WORK_TOKEN:
+      description: "The work token from terrateam"
+      type: string
+      default: "$WORK_TOKEN"
+    API_BASE_URL:
+      description: "The base url for the terrateam api"
+      type: string
+      default: "$API_BASE_URL"
+    RUNS_ON:
+      description: "The tags to use for the runner"
+      type: array
+      default: []
+---
+include:
+  - project: 'terrateam-io/terrateam-template'
+    file: 'terrateam-template.yml'
+    inputs:
+      TERRATEAM_TRIGGER: $[[ inputs.TERRATEAM_TRIGGER ]]
+      WORK_TOKEN: $[[ inputs.WORK_TOKEN ]]
+      API_BASE_URL: $[[ inputs.API_BASE_URL ]]
+      RUNS_ON: $[[ inputs.RUNS_ON ]]
+
+stages:
+  - terrateam
+
+terrateam_job:
+  extends: .terrateam_template
+"""
+
+# notifications.summary.enabled defaults to false, and the per-dirspace table in
+# the plan and apply comments is only rendered when it is on.  Scenarios that
+# assert on which dirspaces ran need that table, so the fixture turns it on.
+DEFAULT_CONFIG_YML = """\
+notifications:
+  summary:
+    enabled: true
+when_modified:
+  file_patterns:
+    - '${DIR}/*.tf'
+"""
+
+MODULE_TF = """\
+variable "name" {
+  type = string
+}
+
+resource "null_resource" "shared" {
+  triggers = {
+    name = var.name
+  }
+}
+"""
+
+
+def _root_tf(name):
+    return """\
+terraform {
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3.2"
+    }
+  }
+}
+
+module "shared" {
+  source = "../modules/shared"
+  name   = "%s"
+}
+
+resource "null_resource" "%s" {
+  triggers = {
+    # Bumping this value is how a scenario creates a plan diff.
+    revision = "1"
+  }
+}
+""" % (name, name)
+
+
+def base_files(config_yml=DEFAULT_CONFIG_YML):
+    return {
+        ".gitlab-ci.yml": GITLAB_CI_YML,
+        ".terrateam/config.yml": config_yml,
+        "modules/shared/main.tf": MODULE_TF,
+        "dev/main.tf": _root_tf("dev"),
+        "prod/main.tf": _root_tf("prod"),
+        "README.md": "Terrateam GitLab e2e fixture. Created by docker/gitlab-e2e.\n",
+    }
+
+
+class Fixture:
+    """A throwaway GitLab project seeded with the Terraform fixture."""
+
+    def __init__(self, gl, cfg, log, name):
+        self._gl = gl
+        self._cfg = cfg
+        self._log = log
+        self.name = name
+        self.project = None
+        self.hook = None
+        self._created_groups = []
+        self._branches = set()
+
+    @property
+    def id(self):
+        return self.project["id"]
+
+    @property
+    def path(self):
+        return self.project["path_with_namespace"]
+
+    @property
+    def default_branch(self):
+        return self.project.get("default_branch") or "main"
+
+    def create(self, config_yml=DEFAULT_CONFIG_YML, files=None, subgroups=()):
+        """Seed the fixture project.
+
+        ``subgroups`` nests the project that many levels below the configured
+        group, which is how the deep ``path_with_namespace`` shapes in audit
+        item 03 get exercised.  The subgroups are deleted with the project.
+        """
+        parent = self._gl.group(self._cfg.group)
+        parent_path = self._cfg.group
+        for name in subgroups:
+            parent = self._gl.post(
+                "/groups",
+                body={
+                    "name": name,
+                    "path": name,
+                    "parent_id": parent["id"],
+                    "visibility": "private",
+                },
+            )
+            parent_path = parent["full_path"]
+            self._created_groups.append(parent["id"])
+        self._log("creating project %s/%s" % (parent_path, self.name))
+        self.project = self._gl.create_project(
+            self.name,
+            parent["id"],
+            default_branch="main",
+            description="Terrateam GitLab e2e fixture (throwaway)",
+        )
+
+        content = base_files(config_yml)
+        if files:
+            content.update(files)
+        actions = [
+            {"action": "create", "file_path": path, "content": body}
+            for path, body in sorted(content.items())
+        ]
+        # A freshly created project is not immediately consistent on
+        # gitlab.com: the project exists but its repository can still 404 for a
+        # second or two, so the seeding commit has to be retried.
+        gitlab.retry(
+            lambda: self._gl.commit(self.id, "main", "ADD Terrateam e2e fixture", actions),
+            attempts=6,
+            delay=2,
+        )
+        # A freshly created project reports no default_branch until the first
+        # commit lands.
+        self.project = self._gl.project(self.id)
+        self._log("seeded %s (id %d)" % (self.path, self.id))
+        return self
+
+    def register_webhook(self):
+        """Point the project at the Terrateam server under test.
+
+        The token is the per-installation webhook secret; the server resolves
+        the installation from it, which is the only thing authenticating the
+        event.
+        """
+        self._log("registering webhook -> %s" % self._cfg.webhook_url)
+        self.hook = self._gl.create_project_hook(
+            self.id, self._cfg.webhook_url, self._cfg.webhook_secret
+        )
+        return self.hook
+
+    # -- convenience used by scenarios -------------------------------------
+
+    def branch_with_change(self, branch, dirs=("dev",), revision="2", message=None):
+        """Commit a change to the given dirs, producing a plan diff.
+
+        Creates ``branch`` off the default branch the first time and commits
+        onto it thereafter, which is what a scenario pushing a second commit to
+        an open merge request needs.  GitLab rejects ``start_branch`` for a
+        branch that already exists.
+        """
+        actions = []
+        for d in dirs:
+            body = _root_tf(d).replace('revision = "1"', 'revision = "%s"' % revision)
+            actions.append({"action": "update", "file_path": "%s/main.tf" % d, "content": body})
+        start_branch = None if branch in self._branches else self.default_branch
+        gitlab.retry(
+            lambda: self._gl.commit(
+                self.id,
+                branch,
+                message or ("CHG Touch %s" % ", ".join(dirs)),
+                actions,
+                start_branch=start_branch,
+            ),
+            attempts=6,
+            delay=2,
+        )
+        self._branches.add(branch)
+        return branch
+
+    def open_mr(self, branch, title=None):
+        mr = self._gl.create_merge_request(
+            self.id, branch, self.default_branch, title or ("e2e: %s" % branch)
+        )
+        self._log("opened MR !%d %s" % (mr["iid"], mr["web_url"]))
+        return mr
+
+    def destroy(self):
+        if self.project is None:
+            return
+        if self._cfg.keep:
+            self._log("E2E_KEEP set, leaving %s behind" % self.path)
+            return
+        self._log("deleting %s" % self.path)
+        try:
+            self._gl.delete_project(self.id)
+        except Exception as exc:  # teardown must never mask a test failure
+            self._log("teardown warning: %s" % exc)
+        # Innermost first, so a parent is never deleted while it still has
+        # children.
+        for group_id in reversed(self._created_groups):
+            try:
+                self._gl.delete("/groups/%d" % group_id)
+            except Exception as exc:  # noqa: BLE001
+                self._log("teardown warning (group %d): %s" % (group_id, exc))
+
+
+def unique_name(prefix):
+    return "tt-e2e-%s-%d" % (prefix, int(time.time()))

--- a/docker/gitlab-e2e/harness/gitlab.py
+++ b/docker/gitlab-e2e/harness/gitlab.py
@@ -1,0 +1,212 @@
+"""A small GitLab API client.
+
+Deliberately stdlib-only: the harness has to run from a clean checkout and in
+CI without a pip install step, and it needs a small enough surface that the
+whole thing can be read in one sitting.  Only the calls the scenarios actually
+make are implemented.
+"""
+
+import json
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+
+class GitlabError(Exception):
+    def __init__(self, status, method, path, body):
+        self.status = status
+        self.body = body
+        super().__init__("%s %s -> %s: %s" % (method, path, status, body))
+
+
+class Gitlab:
+    def __init__(self, api_url, token):
+        self._api_url = api_url.rstrip("/")
+        self._token = token
+
+    # -- plumbing ----------------------------------------------------------
+
+    def request(self, method, path, body=None, params=None, raw=False):
+        url = self._api_url + path
+        if params:
+            url += "?" + urllib.parse.urlencode(params)
+        data = None
+        headers = {"PRIVATE-TOKEN": self._token}
+        if body is not None:
+            data = json.dumps(body).encode()
+            headers["Content-Type"] = "application/json"
+        req = urllib.request.Request(url, data=data, headers=headers, method=method)
+        try:
+            with urllib.request.urlopen(req, timeout=60) as resp:
+                payload = resp.read()
+        except urllib.error.HTTPError as exc:
+            raise GitlabError(exc.code, method, path, exc.read().decode(errors="replace")) from None
+        if raw:
+            return payload.decode(errors="replace")
+        if not payload:
+            return None
+        return json.loads(payload)
+
+    def get(self, path, params=None, raw=False):
+        return self.request("GET", path, params=params, raw=raw)
+
+    def post(self, path, body=None, params=None):
+        return self.request("POST", path, body=body, params=params)
+
+    def put(self, path, body=None, params=None):
+        return self.request("PUT", path, body=body, params=params)
+
+    def delete(self, path):
+        return self.request("DELETE", path)
+
+    # -- identity ----------------------------------------------------------
+
+    def version(self):
+        return self.get("/version")
+
+    def current_user(self):
+        return self.get("/user")
+
+    def group(self, path):
+        return self.get("/groups/" + urllib.parse.quote(path, safe=""))
+
+    # -- projects ----------------------------------------------------------
+
+    def create_project(self, name, namespace_id, **kwargs):
+        body = {
+            "name": name,
+            "path": name,
+            "namespace_id": namespace_id,
+            "visibility": "private",
+            "initialize_with_readme": False,
+        }
+        body.update(kwargs)
+        return self.post("/projects", body=body)
+
+    def delete_project(self, project_id):
+        return self.delete("/projects/%d" % project_id)
+
+    def project(self, project_id):
+        return self.get("/projects/%d" % project_id)
+
+    # -- files and commits -------------------------------------------------
+
+    def commit(self, project_id, branch, message, actions, start_branch=None):
+        """Create a commit from a list of {action, file_path, content} dicts."""
+        body = {"branch": branch, "commit_message": message, "actions": actions}
+        if start_branch:
+            body["start_branch"] = start_branch
+        return self.post("/projects/%d/repository/commits" % project_id, body=body)
+
+    def file_raw(self, project_id, path, ref):
+        return self.get(
+            "/projects/%d/repository/files/%s/raw" % (project_id, urllib.parse.quote(path, safe="")),
+            params={"ref": ref},
+            raw=True,
+        )
+
+    # -- merge requests ----------------------------------------------------
+
+    def create_merge_request(self, project_id, source_branch, target_branch, title):
+        return self.post(
+            "/projects/%d/merge_requests" % project_id,
+            body={
+                "source_branch": source_branch,
+                "target_branch": target_branch,
+                "title": title,
+            },
+        )
+
+    def merge_request(self, project_id, iid):
+        return self.get("/projects/%d/merge_requests/%d" % (project_id, iid))
+
+    def update_merge_request(self, project_id, iid, **kwargs):
+        return self.put("/projects/%d/merge_requests/%d" % (project_id, iid), body=kwargs)
+
+    def merge_merge_request(self, project_id, iid, sha=None):
+        """Merge an MR.
+
+        GitLab requires ``sha`` when the project has "merge only if pipeline
+        succeeds" or an equivalent guard, and returns 400 "SHA must be provided
+        when merging" otherwise, so pass the head sha.
+        """
+        body = {}
+        if sha:
+            body["sha"] = sha
+        return self.put("/projects/%d/merge_requests/%d/merge" % (project_id, iid), body=body)
+
+    def approve_merge_request(self, project_id, iid):
+        return self.post("/projects/%d/merge_requests/%d/approve" % (project_id, iid))
+
+    def unapprove_merge_request(self, project_id, iid):
+        return self.post("/projects/%d/merge_requests/%d/unapprove" % (project_id, iid))
+
+    def notes(self, project_id, iid):
+        return self.get(
+            "/projects/%d/merge_requests/%d/notes" % (project_id, iid),
+            params={"per_page": 100, "sort": "asc", "order_by": "created_at"},
+        )
+
+    def create_note(self, project_id, iid, body):
+        return self.post(
+            "/projects/%d/merge_requests/%d/notes" % (project_id, iid), body={"body": body}
+        )
+
+    # -- statuses and pipelines --------------------------------------------
+
+    def commit_statuses(self, project_id, sha):
+        return self.get(
+            "/projects/%d/repository/commits/%s/statuses" % (project_id, sha),
+            params={"per_page": 100},
+        )
+
+    def pipelines(self, project_id, **params):
+        return self.get("/projects/%d/pipelines" % project_id, params=params or None)
+
+    def pipeline_jobs(self, project_id, pipeline_id):
+        return self.get("/projects/%d/pipelines/%d/jobs" % (project_id, pipeline_id))
+
+    def job_trace(self, project_id, job_id):
+        return self.get("/projects/%d/jobs/%d/trace" % (project_id, job_id), raw=True)
+
+    def add_project_member(self, project_id, user_id, access_level=30):
+        """Invite a user to a project.  30 is Developer."""
+        return self.post(
+            "/projects/%d/members" % project_id,
+            body={"user_id": user_id, "access_level": access_level},
+        )
+
+    # -- webhooks ----------------------------------------------------------
+
+    def create_project_hook(self, project_id, url, token):
+        return self.post(
+            "/projects/%d/hooks" % project_id,
+            body={
+                "url": url,
+                "token": token,
+                "push_events": True,
+                "merge_requests_events": True,
+                "note_events": True,
+                "pipeline_events": True,
+                "job_events": True,
+                "enable_ssl_verification": True,
+            },
+        )
+
+    def test_project_hook(self, project_id, hook_id, trigger="push_events"):
+        return self.post("/projects/%d/hooks/%d/test/%s" % (project_id, hook_id, trigger))
+
+
+def retry(fn, attempts=5, delay=2, on=(GitlabError,)):
+    """GitLab occasionally 5xxs or returns a not-yet-consistent read."""
+    last = None
+    for attempt in range(attempts):
+        try:
+            return fn()
+        except on as exc:  # noqa: PERF203 - retry loop
+            last = exc
+            if getattr(exc, "status", 500) < 500 and getattr(exc, "status", 500) != 404:
+                raise
+            time.sleep(delay * (attempt + 1))
+    raise last

--- a/docker/gitlab-e2e/harness/runner.py
+++ b/docker/gitlab-e2e/harness/runner.py
@@ -1,0 +1,109 @@
+"""Entry point: ``run-scenario <id> [<id> ...]`` or ``run-scenario --all``."""
+
+import argparse
+import sys
+import time
+import traceback
+
+from . import config, fixture as fixture_mod, gitlab, scenario as scenario_mod
+
+# Importing the scenarios package populates the registry.
+import scenarios  # noqa: F401,E402  (side-effecting import, must follow the above)
+
+
+PASS = "PASS"
+FAIL = "FAIL"
+SKIP = "SKIP"
+
+
+def _logger(prefix):
+    def log(message):
+        print("[%s] %s" % (prefix, message), flush=True)
+
+    return log
+
+
+def run_one(cfg, gl, id_):
+    fn = scenario_mod.REGISTRY[id_]
+    log = _logger(id_)
+    log("=== %s: %s" % (id_, fn.description))
+    started = time.time()
+
+    fixture = fixture_mod.Fixture(
+        gl, cfg, log, fixture_mod.unique_name(id_.replace(".", "-"))
+    )
+    ctx = scenario_mod.Ctx(gl, cfg, fixture, log)
+    try:
+        fn(ctx)
+    except scenario_mod.Skipped as exc:
+        log("SKIP: %s" % exc)
+        return SKIP, str(exc), time.time() - started
+    except Exception as exc:  # noqa: BLE001 - the runner reports every failure
+        log("FAIL: %s" % exc)
+        traceback.print_exc()
+        return FAIL, str(exc), time.time() - started
+    finally:
+        try:
+            fixture.destroy()
+        except Exception:  # noqa: BLE001
+            traceback.print_exc()
+
+    elapsed = time.time() - started
+    log("PASS (%.0fs)" % elapsed)
+    return PASS, "", elapsed
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(prog="run-scenario")
+    parser.add_argument("ids", nargs="*", help="scenario ids to run, e.g. 1.1 item03")
+    parser.add_argument("--all", action="store_true", help="run every registered scenario")
+    parser.add_argument("--list", action="store_true", help="list registered scenarios")
+    args = parser.parse_args(argv)
+
+    if args.list:
+        for id_ in sorted(scenario_mod.REGISTRY):
+            fn = scenario_mod.REGISTRY[id_]
+            print("%-10s %s" % (id_, fn.description))
+        return 0
+
+    ids = sorted(scenario_mod.REGISTRY) if args.all else args.ids
+    if not ids:
+        parser.error("give one or more scenario ids, or --all (see --list)")
+
+    unknown = [i for i in ids if i not in scenario_mod.REGISTRY]
+    if unknown:
+        parser.error("unknown scenario(s): %s" % ", ".join(unknown))
+
+    cfg = config.load()
+    gl = gitlab.Gitlab(cfg.gitlab_api_url, cfg.gitlab_token)
+
+    version = gl.version()
+    user = gl.current_user()
+    print(
+        "gitlab %s (enterprise=%s) as %s -> terrateam %s"
+        % (
+            version.get("version"),
+            version.get("enterprise"),
+            user.get("username"),
+            cfg.terrateam_url,
+        ),
+        flush=True,
+    )
+
+    results = []
+    for id_ in ids:
+        results.append((id_,) + run_one(cfg, gl, id_))
+
+    print("\n=== summary ===", flush=True)
+    for id_, status, message, elapsed in results:
+        line = "%-6s %-10s %5.0fs" % (status, id_, elapsed)
+        if message:
+            line += "  %s" % message
+        print(line, flush=True)
+
+    failed = [r for r in results if r[1] == FAIL]
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docker/gitlab-e2e/harness/scenario.py
+++ b/docker/gitlab-e2e/harness/scenario.py
@@ -1,0 +1,253 @@
+"""Scenario registry, execution context and assertions.
+
+A scenario is a function registered with ``@scenario(id, description)`` that
+takes a :class:`Ctx` and raises :class:`AssertionFailed` (or any exception) to
+fail.  Everything a scenario needs to drive a real merge request and wait on
+the live webhook -> pipeline -> comment/commit-status loop hangs off ``Ctx``.
+
+Assertions prefer real API state -- GitLab notes, commit statuses, merge status
+-- over log grepping.  Log grepping is available for the cases where the
+observable outcome really is "nothing happened and nothing crashed".
+"""
+
+import subprocess
+import time
+
+REGISTRY = {}
+
+
+class AssertionFailed(Exception):
+    pass
+
+
+class Timeout(AssertionFailed):
+    pass
+
+
+class Skipped(Exception):
+    """Raised by a scenario that cannot run in the current environment."""
+
+
+def scenario(id_, description, phase=None):
+    def register(fn):
+        if id_ in REGISTRY:
+            raise RuntimeError("duplicate scenario id %s" % id_)
+        fn.id = id_
+        fn.description = description
+        fn.phase = phase
+        REGISTRY[id_] = fn
+        return fn
+
+    return register
+
+
+class Ctx:
+    def __init__(self, gl, cfg, fixture, log):
+        self.gl = gl
+        self.cfg = cfg
+        self.fixture = fixture
+        self.log = log
+        self._started = time.time()
+
+    # -- waiting -----------------------------------------------------------
+
+    def wait_for(self, what, fn, timeout=None):
+        """Poll ``fn`` until it returns something truthy, or time out.
+
+        ``fn`` returning None/False means "not yet"; anything else is the
+        result and is returned.
+        """
+        timeout = timeout or self.cfg.timeout
+        deadline = time.time() + timeout
+        last_report = 0.0
+        while time.time() < deadline:
+            result = fn()
+            if result:
+                self.log("ok: %s" % what)
+                return result
+            now = time.time()
+            if now - last_report > 30:
+                self.log("waiting for %s (%ds left)" % (what, int(deadline - now)))
+                last_report = now
+            time.sleep(self.cfg.poll_interval)
+        raise Timeout("timed out after %ds waiting for %s" % (timeout, what))
+
+    # -- merge request notes -----------------------------------------------
+
+    def notes(self, iid):
+        return self.gl.notes(self.fixture.id, iid)
+
+    def wait_for_note(self, iid, predicate, what, timeout=None):
+        def check():
+            for note in self.notes(iid):
+                if predicate(note["body"]):
+                    return note
+            return None
+
+        return self.wait_for("note matching %s" % what, check, timeout=timeout)
+
+    def wait_for_note_containing(self, iid, needle, timeout=None):
+        return self.wait_for_note(
+            iid, lambda body: needle in body, "%r" % needle, timeout=timeout
+        )
+
+    def assert_no_note_containing(self, iid, needle):
+        for note in self.notes(iid):
+            if needle in note["body"]:
+                raise AssertionFailed(
+                    "did not expect a note containing %r, found note %s" % (needle, note["id"])
+                )
+
+    def comment(self, iid, body):
+        self.log("commenting %r on !%d" % (body, iid))
+        return self.gl.create_note(self.fixture.id, iid, body)
+
+    def comment_as_approver(self, iid, body):
+        """Comment as the second account.
+
+        Needed wherever the acting user must not be the merge request author --
+        gate approvals in particular, which the server excludes when the
+        approver opened the merge request.
+        """
+        if not self.cfg.approver_token:
+            raise Skipped(
+                "GITLAB_APPROVER_TOKEN is not set, and this needs a user who is not the "
+                "merge request author"
+            )
+        from . import gitlab as gitlab_mod
+
+        other = gitlab_mod.Gitlab(self.cfg.gitlab_api_url, self.cfg.approver_token)
+        # Group membership does not reach a project created moments ago, so
+        # invite the account explicitly.  Harmless if it is already a member.
+        who = other.current_user()
+        try:
+            self.gl.add_project_member(self.fixture.id, who["id"])
+            self.log("invited %s to the fixture project" % who["username"])
+        except gitlab_mod.GitlabError as exc:
+            if exc.status not in (409, 400):
+                raise
+        self.log("commenting %r on !%d as %s" % (body, iid, who["username"]))
+        return gitlab_mod.retry(lambda: other.create_note(self.fixture.id, iid, body))
+
+    # -- commit statuses ---------------------------------------------------
+
+    def statuses(self, sha):
+        return self.gl.commit_statuses(self.fixture.id, sha)
+
+    def wait_for_status(self, sha, name, states=("success",), timeout=None):
+        def check():
+            for status in self.statuses(sha):
+                if status["name"] == name and status["status"] in states:
+                    return status
+            return None
+
+        return self.wait_for(
+            "commit status %r in %s" % (name, "/".join(states)), check, timeout=timeout
+        )
+
+    def status_names(self, sha):
+        return sorted({s["name"] for s in self.statuses(sha)})
+
+    # -- pipelines ---------------------------------------------------------
+
+    def wait_for_pipeline(self, ref, timeout=None):
+        def check():
+            pipelines = self.gl.pipelines(self.fixture.id, ref=ref, per_page=1)
+            return pipelines[0] if pipelines else None
+
+        return self.wait_for("a pipeline on %s" % ref, check, timeout=timeout)
+
+    # -- server side -------------------------------------------------------
+
+    def server_logs(self):
+        """Terrateam server logs produced since this scenario started.
+
+        The window matters.  Scenarios run in sequence against one long-lived
+        server, so a fixed window such as ``--since 15m`` makes one scenario
+        assert on lines an earlier scenario produced -- which reads as a
+        failure in the wrong scenario.  ``{since}`` in TERRATEAM_LOGS_CMD is
+        substituted with this scenario's own age.
+        """
+        if not self.cfg.logs_cmd:
+            raise Skipped("TERRATEAM_LOGS_CMD is not set, cannot inspect server logs")
+        cmd = self.cfg.logs_cmd
+        if "{since}" in cmd:
+            # A few seconds of slack for clock skew between here and the server.
+            cmd = cmd.replace("{since}", "%ds" % (int(time.time() - self._started) + 5))
+        else:
+            self.log(
+                "warning: TERRATEAM_LOGS_CMD has no {since} placeholder, so log "
+                "assertions can pick up lines from earlier scenarios"
+            )
+        proc = subprocess.run(cmd, shell=True, capture_output=True, text=True, timeout=120)
+        return proc.stdout + proc.stderr
+
+    def assert_not_in_logs(self, needle):
+        logs = self.server_logs()
+        hits = [line for line in logs.splitlines() if needle in line]
+        if hits:
+            raise AssertionFailed(
+                "found %d log line(s) containing %r, first: %s" % (len(hits), needle, hits[0])
+            )
+        self.log("ok: no %r in server logs" % needle)
+
+    def psql(self, sql):
+        """Run a read-only query against the Terrateam database."""
+        if not self.cfg.psql:
+            raise Skipped("TERRATEAM_PSQL is not set, cannot query the Terrateam database")
+        proc = subprocess.run(
+            self.cfg.psql + " -tAc " + _shell_quote(sql),
+            shell=True,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        if proc.returncode != 0:
+            raise AssertionFailed("psql failed: %s" % (proc.stderr.strip(),))
+        # A multi-statement query prints a command tag per statement (BEGIN,
+        # ROLLBACK, INSERT 0 1, ...) interleaved with the rows.  Drop the tags
+        # so callers only see result rows.
+        tags = ("BEGIN", "COMMIT", "ROLLBACK", "SET")
+        prefixes = ("INSERT ", "UPDATE ", "DELETE ", "SELECT ", "CREATE ", "DROP ")
+        return [
+            line
+            for line in (l.strip() for l in proc.stdout.strip().splitlines())
+            if line and line not in tags and not line.startswith(prefixes)
+        ]
+
+    # -- generic -----------------------------------------------------------
+
+    def assert_names_dirspace(self, body, dir_, present=True):
+        """Assert a comment does (or does not) report a run for ``dir_``.
+
+        The plan and apply templates render a dirspace two different ways: as a
+        row in the summary table (`` `dev` ``) when notifications.summary is
+        enabled, and as a per-dirspace section otherwise.  Accept either, so the
+        assertion is about the dirspace having run rather than about which
+        template branch produced the comment.
+        """
+        forms = ["`%s`" % dir_, "**Dir**: %s" % dir_, "## %s |" % dir_]
+        found = [f for f in forms if f in body]
+        if present and not found:
+            raise AssertionFailed(
+                "comment does not report a run for %r (looked for %s)" % (dir_, forms)
+            )
+        if not present and found:
+            raise AssertionFailed("comment unexpectedly reports a run for %r via %s" % (dir_, found))
+        self.log(
+            "ok: comment %s a run for %r" % ("reports" if present else "does not report", dir_)
+        )
+
+    def assert_true(self, cond, message):
+        if not cond:
+            raise AssertionFailed(message)
+        self.log("ok: %s" % message)
+
+    def assert_eq(self, actual, expected, message):
+        if actual != expected:
+            raise AssertionFailed("%s: expected %r, got %r" % (message, expected, actual))
+        self.log("ok: %s" % message)
+
+
+def _shell_quote(s):
+    return "'" + s.replace("'", "'\\''") + "'"

--- a/docker/gitlab-e2e/run-scenario
+++ b/docker/gitlab-e2e/run-scenario
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+#
+# Run one or more GitLab e2e scenarios against a live GitLab and a live
+# Terrateam server.  See README.md.
+#
+#   ./run-scenario --list
+#   ./run-scenario 1.1
+#   ./run-scenario 3.3 3.4
+#   ./run-scenario --all
+#
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Load .env if present.  Values already in the environment win, so CI can
+# override without editing the file.
+if [[ -f "$here/.env" ]]; then
+    set -o allexport
+    # shellcheck disable=SC1091
+    source "$here/.env"
+    set +o allexport
+fi
+
+export PYTHONPATH="$here${PYTHONPATH:+:$PYTHONPATH}"
+exec python3 -m harness.runner "$@"

--- a/docker/gitlab-e2e/scenarios/__init__.py
+++ b/docker/gitlab-e2e/scenarios/__init__.py
@@ -1,0 +1,27 @@
+"""Scenario registry.
+
+Importing this package registers every scenario.  Add new modules here so
+``run-scenario --all`` picks them up.
+"""
+
+from . import (  # noqa: F401
+    item02,
+    item03,
+    item04,
+    item05,
+    item06,
+    item07,
+    item13_14,
+    phase1,
+)
+
+__all__ = [
+    "phase1",
+    "item02",
+    "item03",
+    "item04",
+    "item05",
+    "item06",
+    "item07",
+    "item13_14",
+]

--- a/docker/gitlab-e2e/scenarios/item02.py
+++ b/docker/gitlab-e2e/scenarios/item02.py
@@ -1,0 +1,104 @@
+"""Audit item 02 / TEST-PLAN 3.1 -- gates on GitLab EE.
+
+GitLab EE re-exported the OSS Gate stub, so `add_approval` always returned
+`Premium_feature_err Gatekeeping` and `eval` always returned no gates:
+gatekeeping was silently inert on GitLab even on a commercial plan.
+
+Two config notes that cost time to work out, recorded here so the next person
+does not repeat them:
+
+- A `run` step declares a gate through `on_error`, not through a `gate:` key.
+  The strict schema rejects `gate:` on a `run` step; only `checkov`, `conftest`
+  and `opa` steps take one.  The published docs are wrong about this.
+- The gate is emitted when the step *fails*, which is why the fixture runs
+  `false`.  terrat_runner sets `ignore_errors` automatically when a step
+  carries gates, so the run still succeeds overall and the gate is what blocks
+  the apply.
+
+This scenario needs an **EE** server.  On OSS the apply is refused with the
+premium-feature message instead, which the scenario reports as a skip rather
+than a failure.  It also needs GITLAB_APPROVER_TOKEN, a second account, because
+self-approval is deliberately excluded.
+"""
+
+from harness.scenario import Skipped, scenario
+
+from . import markers
+
+GATE_TOKEN = "e2e-gate"
+
+GATE_CONFIG = """\
+notifications:
+  summary:
+    enabled: true
+when_modified:
+  file_patterns:
+    - '${DIR}/*.tf'
+workflows:
+  - tag_query: ''
+    plan:
+      - type: init
+      - type: plan
+      - type: run
+        cmd: ['false']
+        on_error:
+          - type: gate
+            token: %s
+            any_of: ['*']
+            any_of_count: 1
+""" % GATE_TOKEN
+
+
+@scenario("3.1", "Gates block an apply until the token is approved (EE)", phase=3)
+def gates_block_apply(ctx):
+    ctx.fixture.create(config_yml=GATE_CONFIG)
+    ctx.fixture.register_webhook()
+    branch = ctx.fixture.branch_with_change("e2e/gate")
+    mr = ctx.fixture.open_mr(branch)
+
+    ctx.wait_for_note_containing(mr["iid"], markers.PLAN_COMPLETE)
+
+    # The gate should have been stored from the plan result.
+    def gate_stored():
+        rows = ctx.psql(
+            "select token from gitlab_gates where repository = %d and pull_number = %d"
+            % (ctx.fixture.id, mr["iid"])
+        )
+        return rows or None
+
+    ctx.wait_for("the gate to be recorded in gitlab_gates", gate_stored)
+
+    # --- the apply must be blocked -------------------------------------
+    ctx.comment(mr["iid"], "terrateam apply")
+
+    def blocked_or_premium():
+        for note in ctx.notes(mr["iid"]):
+            if markers.GATE_PREMIUM in note["body"]:
+                raise Skipped("server is OSS, gatekeeping is a commercial feature")
+            if markers.GATE_BLOCKED in note["body"]:
+                return note
+        return None
+
+    note = ctx.wait_for("the apply to be blocked by the gate", blocked_or_premium)
+    ctx.assert_true(GATE_TOKEN in note["body"], "the blocking comment names the gate token")
+    ctx.assert_no_note_containing(mr["iid"], markers.APPLY_COMPLETE)
+
+    # --- approving the gate unblocks it --------------------------------
+    # The approval must come from someone other than the merge request author:
+    # select_gate_approvals ends in `approver <> gpr.username`, so a gate can
+    # never be satisfied by the person who opened the merge request.  Approving
+    # as the author leaves the gate blocked, which looks exactly like the
+    # feature being broken -- it is the feature working.
+    ctx.comment_as_approver(mr["iid"], "terrateam gate approve %s" % GATE_TOKEN)
+
+    def approval_recorded():
+        rows = ctx.psql(
+            "select approver from gitlab_gate_approvals where token = '%s' "
+            "and repository = %d and pull_number = %d" % (GATE_TOKEN, ctx.fixture.id, mr["iid"])
+        )
+        return rows or None
+
+    ctx.wait_for("the approval to be recorded in gitlab_gate_approvals", approval_recorded)
+
+    ctx.comment(mr["iid"], "terrateam apply")
+    ctx.wait_for_note_containing(mr["iid"], markers.APPLY_COMPLETE)

--- a/docker/gitlab-e2e/scenarios/item03.py
+++ b/docker/gitlab-e2e/scenarios/item03.py
@@ -1,0 +1,96 @@
+"""Audit item 03 / TEST-PLAN 3.3 and 3.4 -- webhook actions must not crash.
+
+Before the fix, every merge-request action other than open/reopen/update/merge/
+close hit ``| _ -> raise (Failure "nyi")``, so approving an MR returned a 500
+and logged a backtrace.  Approval events are emitted routinely, so this fired
+constantly in normal use.
+
+The observable outcome of the fix is that nothing happens, which is why these
+scenarios assert on webhook delivery status and on the absence of the exception
+in the server logs rather than on a comment.  Both assertions are on real
+state: GitLab records the response code it got for each hook delivery.
+"""
+
+from harness.scenario import scenario
+
+from . import markers
+
+APPROVAL_ACTIONS = ("approve", "unapprove")
+
+
+@scenario("3.3", "MR approve/unapprove and draft toggle are NOOPs, not 500s", phase=3)
+def approval_actions_are_noops(ctx):
+    ctx.fixture.create()
+    hook = ctx.fixture.register_webhook()
+    branch = ctx.fixture.branch_with_change("e2e/approve")
+    mr = ctx.fixture.open_mr(branch)
+    iid = mr["iid"]
+
+    ctx.log("approving MR !%d" % iid)
+    ctx.gl.approve_merge_request(ctx.fixture.id, iid)
+    ctx.log("unapproving MR !%d" % iid)
+    ctx.gl.unapprove_merge_request(ctx.fixture.id, iid)
+
+    ctx.log("toggling draft on MR !%d" % iid)
+    ctx.gl.update_merge_request(ctx.fixture.id, iid, title="Draft: " + mr["title"])
+    ctx.gl.update_merge_request(ctx.fixture.id, iid, title=mr["title"])
+
+    # GitLab keeps the response code of the most recent deliveries.  A 500 from
+    # the raise would show up here, and GitLab disables a hook that keeps
+    # failing.
+    def hook_healthy():
+        current = ctx.gl.get("/projects/%d/hooks/%d" % (ctx.fixture.id, hook["id"]))
+        if current.get("disabled_until") or current.get("alert_status") == "disabled":
+            raise AssertionError(
+                "GitLab disabled the webhook, which means Terrateam kept erroring: %s"
+                % current.get("alert_status")
+            )
+        return True
+
+    ctx.wait_for("the webhook to stay healthy", hook_healthy, timeout=60)
+
+    # The real assertion: the exception is gone from the logs.
+    ctx.assert_not_in_logs(markers.NYI)
+
+    # And the MR is still functional afterwards -- the handler did not wedge.
+    ctx.comment(iid, "terrateam plan")
+    ctx.wait_for_note_containing(iid, markers.PLAN_COMPLETE)
+
+
+@scenario("3.4", "A project in nested subgroups is handled, not a nyi", phase=3)
+def deep_subgroup_path(ctx):
+    """``parse_path_with_namespace`` used to raise on shapes it did not expect.
+
+    Splitting on the first ``/`` puts the top-level group in ``owner`` and the
+    rest in ``name``.  This scenario proves a nested path round-trips: the repo
+    must be recorded with the two halves joining back to the full path, and the
+    normal plan loop must still work from inside a subgroup.
+    """
+    # Two levels of nesting gives a path_with_namespace of
+    # <group>/<a>/<b>/<project> -- the a/b/c/repo shape the item calls out.
+    # The names carry the run's unique suffix because GitLab deletes groups
+    # asynchronously: reusing a fixed name collides with the previous run's
+    # group while it is still marked for deletion.
+    suffix = ctx.fixture.name.rsplit("-", 1)[-1]
+    ctx.fixture.create(subgroups=("e2e-a-%s" % suffix, "e2e-b-%s" % suffix))
+    ctx.log("fixture path is %s" % ctx.fixture.path)
+    ctx.assert_true(
+        ctx.fixture.path.count("/") >= 3, "the fixture really is deeply nested"
+    )
+    ctx.fixture.register_webhook()
+    branch = ctx.fixture.branch_with_change("e2e/subgroup")
+    mr = ctx.fixture.open_mr(branch)
+
+    ctx.wait_for_note_containing(mr["iid"], markers.PLAN_COMPLETE)
+    ctx.assert_not_in_logs(markers.NYI)
+
+    rows = ctx.psql(
+        "select owner || '/' || name from gitlab_installation_repositories where id = %d"
+        % ctx.fixture.id
+    )
+    ctx.assert_true(rows, "the repo was recorded in gitlab_installation_repositories")
+    ctx.assert_eq(
+        rows[0],
+        ctx.fixture.path,
+        "owner and name rejoin to the full path_with_namespace",
+    )

--- a/docker/gitlab-e2e/scenarios/item04.py
+++ b/docker/gitlab-e2e/scenarios/item04.py
@@ -1,0 +1,114 @@
+"""Audit item 04 / TEST-PLAN 3.8 -- work-manifest API access tokens.
+
+Before the fix the four post-initiate endpoints called
+``enforce_work_manifest_access (Some work_manifest_id) work_manifest_id``,
+comparing the URL path parameter to itself, so the check always passed and
+knowing the work manifest id was the entire credential.  After the fix they
+take the caller's access token from the session and require it to be the work
+manifest's token.
+
+**This scenario is expected to fail against main today, and that is the point.**
+
+Running it against a build with the server-side checks enabled proved the
+enforcement cannot ship yet: the GitLab runner authenticates by putting the raw
+work manifest id in the URL path and never sends an Authorization header at
+all, so turning the checks on returns 403 to the runner and no plan ever
+completes.  See items/04 for the evidence.
+
+It therefore stands as the acceptance test for the coordinated change that
+closes item 04: teach terrat-runner to send the token the initiate response
+already returns, roll that out, and only then enable the server checks.  When
+both halves below pass, the item is done.
+
+Both halves matter: the failure path first, then the happy path, because a
+scenario that only proves calls get rejected would also pass if the whole
+service were down.
+"""
+
+import json
+import urllib.error
+import urllib.request
+
+from harness.scenario import Skipped, scenario
+
+from . import markers
+
+
+def _call(url, method="GET", token=None, body=None):
+    """Call the work-manifest API directly and return the status code."""
+    data = json.dumps(body).encode() if body is not None else None
+    headers = {}
+    if data:
+        headers["Content-Type"] = "application/json"
+    if token:
+        headers["Authorization"] = "Bearer " + token
+    req = urllib.request.Request(url, data=data, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            return resp.status
+    except urllib.error.HTTPError as exc:
+        return exc.code
+    except urllib.error.URLError as exc:
+        raise Skipped("cannot reach the Terrateam work-manifest API: %s" % exc) from None
+
+
+@scenario("3.8", "Work-manifest API rejects calls without the access token", phase=3)
+def work_manifest_requires_token(ctx):
+    api = ctx.cfg.terrateam_url + "/api/gitlab/v1/work-manifests"
+
+    # Drive a real run so there is a work manifest in a queued/running state to
+    # aim at.  Without one the endpoints would reject on the state check rather
+    # than the token check, and the test would pass for the wrong reason.
+    ctx.fixture.create()
+    ctx.fixture.register_webhook()
+    branch = ctx.fixture.branch_with_change("e2e/wm-token")
+    mr = ctx.fixture.open_mr(branch)
+
+    def running_manifest():
+        rows = ctx.psql(
+            "select wm.id from work_manifests wm "
+            "join gitlab_work_manifests gwm on gwm.id = wm.id "
+            "where gwm.repository = %d and wm.state in ('queued','running') "
+            "order by wm.created_at desc limit 1" % ctx.fixture.id
+        )
+        return rows[0] if rows else None
+
+    work_manifest_id = ctx.wait_for("a queued or running work manifest", running_manifest)
+    ctx.log("aiming at work manifest %s" % work_manifest_id)
+
+    # --- failure path -----------------------------------------------------
+    # No Authorization header at all.  Before the fix these returned 200/404
+    # depending on the endpoint; after it they must be refused.
+    for method, path, body in (
+        ("GET", "/%s/workspaces" % work_manifest_id, None),
+        # The GET route's query parameters are path and workspace, not dir --
+        # getting them wrong routes to nothing and returns 404, which would
+        # look like a pass if the assertion accepted it.
+        ("GET", "/%s/plans?path=dev&workspace=default" % work_manifest_id, None),
+        (
+            "POST",
+            "/%s/plans" % work_manifest_id,
+            {"path": "dev", "workspace": "default", "plan_data": "", "has_changes": False},
+        ),
+    ):
+        status = _call(api + path, method=method, token=None)
+        # 404 is explicitly not accepted: it means the route did not match, so
+        # the call never reached the check being tested.
+        ctx.assert_true(
+            status in (401, 403),
+            "%s %s without a token is refused (got %s)" % (method, path.split("?")[0], status),
+        )
+
+    # A well-formed but wrong bearer token must also be refused, so the check is
+    # really on the token and not merely on the header being present.
+    status = _call(api + "/%s/workspaces" % work_manifest_id, token="not-a-real-token")
+    ctx.assert_true(
+        status in (401, 403),
+        "a bogus bearer token is refused (got %s)" % status,
+    )
+
+    # --- happy path -------------------------------------------------------
+    # The runner authenticates with the token it got from initiate, so if
+    # enforcement were wrong this run would never produce a plan comment.
+    ctx.wait_for_note_containing(mr["iid"], markers.PLAN_COMPLETE)
+    ctx.assert_not_in_logs(markers.NYI)

--- a/docker/gitlab-e2e/scenarios/item05.py
+++ b/docker/gitlab-e2e/scenarios/item05.py
@@ -1,0 +1,103 @@
+"""Audit item 05 / TEST-PLAN 3.2 -- comment strategies on GitLab.
+
+The GitLab comment layer hardcoded Append and raised nyi from the comment-id
+lookups, because it had no table mapping a dirspace back to the note it had
+posted.  Every run therefore added another comment.
+
+These scenarios run a plan twice on one merge request and assert what happened
+to the *first* note, which is the only way to tell the strategies apart:
+
+- minimize: the first note still exists but its body has been collapsed.  GitLab
+  has no native minimize, so Terrateam rewrites the note as a closed <details>
+  block wrapping the original body.
+- delete: the first note is gone.
+- append (the default): the first note is untouched and both remain.
+"""
+
+from harness.scenario import scenario
+
+from . import markers
+
+MINIMIZE_MARKER = "Outdated output (minimized)"
+
+
+def _config(strategy):
+    return """\
+notifications:
+  summary:
+    enabled: true
+  policies:
+    - tag_query: ''
+      comment_strategy: %s
+when_modified:
+  file_patterns:
+    - '${DIR}/*.tf'
+""" % strategy
+
+
+def _plan_notes(ctx, iid):
+    return [n for n in ctx.notes(iid) if markers.PLAN_COMPLETE in n["body"]]
+
+
+def _run_twice(ctx, strategy):
+    ctx.fixture.create(config_yml=_config(strategy))
+    ctx.fixture.register_webhook()
+    branch = ctx.fixture.branch_with_change("e2e/comment")
+    mr = ctx.fixture.open_mr(branch)
+
+    ctx.wait_for_note_containing(mr["iid"], markers.PLAN_COMPLETE)
+    first = _plan_notes(ctx, mr["iid"])[0]
+    ctx.log("first plan note is %d" % first["id"])
+
+    ctx.comment(mr["iid"], "terrateam plan")
+
+    def second_plan():
+        notes = _plan_notes(ctx, mr["iid"])
+        newer = [n for n in notes if n["id"] != first["id"]]
+        return newer[0] if newer else None
+
+    second = ctx.wait_for("a second plan comment", second_plan)
+    ctx.log("second plan note is %d" % second["id"])
+    return mr, first, second
+
+
+def _note_ids(ctx, iid):
+    return {n["id"] for n in ctx.notes(iid)}
+
+
+@scenario("3.2", "Comment strategy minimize collapses the previous comment", phase=3)
+def minimize_strategy(ctx):
+    mr, first, _second = _run_twice(ctx, "minimize")
+
+    def collapsed():
+        for note in ctx.notes(mr["iid"]):
+            if note["id"] == first["id"]:
+                return MINIMIZE_MARKER in note["body"] or None
+        # The note disappearing is a failure for minimize, not a pass.
+        raise AssertionError("the first note was deleted, but the strategy was minimize")
+
+    ctx.wait_for("the first comment to be collapsed", collapsed, timeout=120)
+
+
+@scenario("3.2d", "Comment strategy delete removes the previous comment", phase=3)
+def delete_strategy(ctx):
+    mr, first, _second = _run_twice(ctx, "delete")
+
+    def gone():
+        return first["id"] not in _note_ids(ctx, mr["iid"]) or None
+
+    ctx.wait_for("the first comment to be deleted", gone, timeout=120)
+
+
+@scenario("3.2a", "Comment strategy append leaves the previous comment alone", phase=3)
+def append_strategy(ctx):
+    mr, first, second = _run_twice(ctx, "append")
+
+    ids = _note_ids(ctx, mr["iid"])
+    ctx.assert_true(first["id"] in ids, "the first comment is still present")
+    ctx.assert_true(second["id"] in ids, "the second comment is present")
+    for note in ctx.notes(mr["iid"]):
+        if note["id"] == first["id"]:
+            ctx.assert_true(
+                MINIMIZE_MARKER not in note["body"], "the first comment was not collapsed"
+            )

--- a/docker/gitlab-e2e/scenarios/item06.py
+++ b/docker/gitlab-e2e/scenarios/item06.py
@@ -1,0 +1,71 @@
+"""Audit item 06 / TEST-PLAN 3.7 -- commit statuses on GitLab.
+
+Two halves, and only one of them inverts.
+
+`details_url` was hardcoded to the empty string and the API sent
+`target_url = None`, so the status on a merge request had no link back to the
+run.  That is fixed and is asserted here.
+
+Per-dirspace statuses are **not** expected, and the scenario asserts their
+absence rather than their presence.  A GitLab commit status is attached to a
+pipeline and the pipeline's status is the aggregate of its statuses, so a check
+per dirspace would fold into the merge request's pipeline: one queued or failed
+dirspace would drive the whole pipeline pending or failed, which feeds
+detailed_merge_status as ci_must_pass and would block merges on Terrateam's own
+bookkeeping.  So TEST-PLAN 3.7 does not invert as written, and this scenario
+pins the current behaviour plus the check that mergeability still evaluates.
+"""
+
+from harness.scenario import scenario
+
+from . import markers
+
+APPLY_STATUS = "terrateam apply"
+
+
+@scenario("3.7", "Commit status links to the run page and does not break mergeability", phase=3)
+def commit_status_details_url(ctx):
+    mr = None
+    ctx.fixture.create()
+    ctx.fixture.register_webhook()
+    branch = ctx.fixture.branch_with_change("e2e/status", dirs=("dev", "prod"))
+    mr = ctx.fixture.open_mr(branch)
+
+    ctx.wait_for_note_containing(mr["iid"], markers.PLAN_COMPLETE)
+    status = ctx.wait_for_status(
+        mr["sha"], APPLY_STATUS, states=("success", "pending", "running", "failed")
+    )
+
+    # --- the link ------------------------------------------------------
+    # The aggregate "terrateam apply" status is created without a work manifest
+    # -- it summarises the merge request rather than one run -- so it links to
+    # the Terrateam base URL rather than to /i/<id>/runs/<uuid>.  That matches
+    # the GitHub provider, whose make has the same None branch.  The regression
+    # this guards is target_url being absent entirely, which is what it was.
+    target = status.get("target_url")
+    ctx.assert_true(bool(target), "the commit status carries a target_url (got %r)" % target)
+    ctx.assert_true(
+        target.startswith(ctx.cfg.terrateam_url),
+        "the target_url points at this Terrateam: %s" % target,
+    )
+
+    # --- the deliberate absence of per-dirspace statuses ---------------
+    names = ctx.status_names(mr["sha"])
+    ctx.log("commit statuses present: %s" % names)
+    per_dirspace = [n for n in names if n.startswith("terrateam ") and (" dev " in n or " prod " in n)]
+    ctx.assert_true(
+        not per_dirspace,
+        "no per-dirspace statuses are published, which is deliberate (found %s)" % per_dirspace,
+    )
+
+    # --- mergeability still evaluates ----------------------------------
+    def mergeable():
+        current = ctx.gl.merge_request(ctx.fixture.id, mr["iid"])
+        dms = current.get("detailed_merge_status")
+        ctx.log("detailed_merge_status=%s" % dms)
+        # Anything other than a CI-blocked state means the statuses Terrateam
+        # posted have not wedged the pipeline.
+        return dms not in (None, "checking", "ci_still_running", "ci_must_pass") or None
+
+    dms = ctx.wait_for("detailed_merge_status to settle", mergeable, timeout=180)
+    ctx.log("settled on detailed_merge_status=%s" % dms)

--- a/docker/gitlab-e2e/scenarios/item07.py
+++ b/docker/gitlab-e2e/scenarios/item07.py
@@ -1,0 +1,40 @@
+"""Audit item 07 / TEST-PLAN 3.5 -- comments link to the Terrateam run page.
+
+`Ui.work_manifest_url` returned None on GitLab, and the plan and apply templates
+render the Console link only when `work_manifest_url` is defined, so no GitLab
+comment ever linked back to the run.
+
+Note the item's framing is slightly off: the `Ui` module that *raised*
+`Failure "nyi"` lives in terrat_vcs_gitlab_comment_templates and is referenced
+by nothing.  The one on the publishing path is in terrat_vcs_gitlab_comment and
+returned None, so the symptom was a missing link rather than a crash.
+"""
+
+from harness.scenario import scenario
+
+from . import markers
+
+
+@scenario("3.5", "Plan comments link to the Terrateam run page", phase=3)
+def comment_links_to_run_page(ctx):
+    ctx.fixture.create()
+    ctx.fixture.register_webhook()
+    branch = ctx.fixture.branch_with_change("e2e/ui-link")
+    mr = ctx.fixture.open_mr(branch)
+
+    note = ctx.wait_for_note_containing(mr["iid"], markers.PLAN_COMPLETE)
+    ctx.assert_true(
+        markers.WORK_MANIFEST_URL in note["body"],
+        "the plan comment renders the Terrateam Console link",
+    )
+    # The link must point at this installation's run page on the configured UI
+    # base, not at some placeholder.
+    expected = "%s/i/%s/runs/pr/%d" % (
+        ctx.cfg.terrateam_url,
+        ctx.cfg.installation_id,
+        mr["iid"],
+    )
+    ctx.assert_true(
+        expected in note["body"],
+        "the link is %s" % expected,
+    )

--- a/docker/gitlab-e2e/scenarios/item13_14.py
+++ b/docker/gitlab-e2e/scenarios/item13_14.py
@@ -1,0 +1,123 @@
+"""Audit items 13 and 14 -- cross-installation isolation.
+
+Both fixes are about one installation being unable to reach another's rows, and
+proving that properly needs two installations. Rather than fake it, these
+scenarios drive a real run to produce real rows and then exercise the guards
+directly against the database:
+
+- item 13 runs the actual upsert inside a transaction that is rolled back,
+  once with a foreign installation id and once with the real one, and asserts
+  the foreign one cannot rewrite the row while the real one still can. Nothing
+  is committed, so the database is left exactly as found.
+- item 14 runs the actual lookup as a read-only select, once scoped to the
+  owning installation and once to a foreign one.
+
+This is narrower than a forged webhook from a second tenant, and the gap is
+recorded in RESULTS.md rather than papered over. What it does cover is the part
+most likely to regress: that the predicate is present and correct, and that
+normal operation still works with it in place.
+"""
+
+from harness.scenario import scenario
+
+from . import markers
+
+FOREIGN_INSTALLATION = 999999999
+
+
+@scenario("13", "A foreign installation cannot rewrite a repository row", phase=3)
+def repo_installation_binding(ctx):
+    ctx.fixture.create()
+    ctx.fixture.register_webhook()
+    branch = ctx.fixture.branch_with_change("e2e/binding")
+    mr = ctx.fixture.open_mr(branch)
+    ctx.wait_for_note_containing(mr["iid"], markers.PLAN_COMPLETE)
+
+    repo_id = ctx.fixture.id
+    rows = ctx.psql(
+        "select installation_id, owner, name from gitlab_installation_repositories "
+        "where id = %d" % repo_id
+    )
+    ctx.assert_true(rows, "the repository was recorded")
+    installation_id, owner, name = rows[0].split("|")
+    ctx.log("repo %d owned by installation %s as %s/%s" % (repo_id, installation_id, owner, name))
+
+    upsert = (
+        "insert into gitlab_installation_repositories as r (id, installation_id, name, owner) "
+        "values (%d, %s, 'evil-name', 'evil-owner') "
+        "on conflict (id) do update set (owner, name) = (excluded.owner, excluded.name) "
+        "where r.installation_id = excluded.installation_id "
+        "and (r.owner, r.name) <> (excluded.owner, excluded.name);"
+    )
+
+    # --- a foreign installation must not be able to rewrite it ---------
+    out = ctx.psql(
+        "begin; "
+        + (upsert % (repo_id, FOREIGN_INSTALLATION))
+        + " select owner || '/' || name from gitlab_installation_repositories where id = %d; "
+        "rollback;" % repo_id
+    )
+    ctx.assert_eq(
+        out[-1],
+        "%s/%s" % (owner, name),
+        "a foreign installation leaves owner and name unchanged",
+    )
+
+    # --- the owning installation still can ------------------------------
+    out = ctx.psql(
+        "begin; "
+        + (upsert % (repo_id, installation_id))
+        + " select owner || '/' || name from gitlab_installation_repositories where id = %d; "
+        "rollback;" % repo_id
+    )
+    ctx.assert_eq(
+        out[-1],
+        "evil-owner/evil-name",
+        "the owning installation can still rename its own repository",
+    )
+
+    # Nothing was committed.
+    rows = ctx.psql(
+        "select owner || '/' || name from gitlab_installation_repositories where id = %d" % repo_id
+    )
+    ctx.assert_eq(rows[0], "%s/%s" % (owner, name), "the database was left unchanged")
+
+
+@scenario("14", "A work manifest is only reachable by its own installation", phase=3)
+def run_id_scoping(ctx):
+    ctx.fixture.create()
+    ctx.fixture.register_webhook()
+    branch = ctx.fixture.branch_with_change("e2e/runid")
+    mr = ctx.fixture.open_mr(branch)
+    ctx.wait_for_note_containing(mr["iid"], markers.PLAN_COMPLETE)
+
+    def manifest_with_run_id():
+        rows = ctx.psql(
+            "select run_id, installation_id from gitlab_work_manifests "
+            "where repository = %d and run_id is not null "
+            "order by created_at desc limit 1" % ctx.fixture.id
+        )
+        return rows[0] if rows else None
+
+    row = ctx.wait_for("a work manifest with a run_id", manifest_with_run_id)
+    run_id, installation_id = row.split("|")
+    ctx.log("work manifest run_id=%s installation=%s" % (run_id, installation_id))
+
+    # This is the query the Job_event path runs.
+    scoped = (
+        "select count(*) from gitlab_work_manifests where run_id = '%s' and installation_id = %s"
+    )
+
+    found = ctx.psql(scoped % (run_id, installation_id))
+    ctx.assert_eq(found[0], "1", "the owning installation resolves its own work manifest")
+
+    not_found = ctx.psql(scoped % (run_id, FOREIGN_INSTALLATION))
+    ctx.assert_eq(not_found[0], "0", "a foreign installation resolves nothing")
+
+    # And the unscoped form -- what the code used to run -- would have found it,
+    # which is what made the fix necessary.
+    unscoped = ctx.psql("select count(*) from work_manifests where run_id = '%s'" % run_id)
+    ctx.assert_true(
+        int(unscoped[0]) >= 1,
+        "the unscoped query the fix replaced would have matched (count=%s)" % unscoped[0],
+    )

--- a/docker/gitlab-e2e/scenarios/markers.py
+++ b/docker/gitlab-e2e/scenarios/markers.py
@@ -1,0 +1,29 @@
+"""Strings the scenarios assert on.
+
+These come from the comment templates in
+``code/src/terrat_vcs_gitlab_comment_templates/tmpl``.  Keeping them in one
+place means a template rename breaks in an obvious spot rather than in eight
+scenarios at once.
+"""
+
+# tmpl/plan_complete2.tmpl
+PLAN_COMPLETE = "## Plans"
+# tmpl/apply_complete2.tmpl
+APPLY_COMPLETE = "## Applies"
+# tmpl/unlock_success.tmpl
+UNLOCK_SUCCESS = "All directories and workspaces have been unlocked."
+# tmpl/plan_complete2.tmpl, only rendered once work_manifest_url is defined
+WORK_MANIFEST_URL = "Outputs can be viewed in the Terrateam Console"
+# tmpl/gate_check_failure.tmpl
+GATE_BLOCKED = "Gatekeeper Requirements Not Satisfied"
+# tmpl/premium_feature_err_gatekeeping.tmpl
+GATE_PREMIUM = "Gatekeeping is a Commercial Feature"
+# tmpl/plan_complete2.tmpl, the two overall_success branches
+PLAN_SUCCESS = "## Plans :thumbsup:"
+PLAN_FAILURE = "## Plans :heavy_multiplication_x:"
+# tmpl/comment_too_large.tmpl
+COMMENT_TOO_LARGE = "exceeds the GitLab comment size and cannot be displayed"
+
+# The exception text the GitLab service used to raise on unhandled webhook
+# input.  Its absence from the logs is the assertion for item 03.
+NYI = 'Failure("nyi")'

--- a/docker/gitlab-e2e/scenarios/phase1.py
+++ b/docker/gitlab-e2e/scenarios/phase1.py
@@ -1,0 +1,166 @@
+"""TEST-PLAN Phase 1 -- the core plan/apply loop.
+
+These are the baseline scenarios: they are expected to pass on any healthy
+install and are what a regression in the GitLab integration would break first.
+"""
+
+from harness.scenario import scenario
+
+from . import markers
+
+
+def _fixture_with_mr(ctx, dirs=("dev",), config_yml=None):
+    """Seed a fixture, wire the webhook, and open an MR touching ``dirs``."""
+    kwargs = {"config_yml": config_yml} if config_yml else {}
+    ctx.fixture.create(**kwargs)
+    ctx.fixture.register_webhook()
+    branch = ctx.fixture.branch_with_change("e2e/change", dirs=dirs)
+    return ctx.fixture.open_mr(branch)
+
+
+@scenario("1.1", "Autoplan on MR open produces a plan comment and a commit status", phase=1)
+def autoplan_on_open(ctx):
+    mr = _fixture_with_mr(ctx)
+    ctx.wait_for_note_containing(mr["iid"], markers.PLAN_COMPLETE)
+    # The plan should have found a change: the fixture bumps a trigger value.
+    note = ctx.wait_for_note_containing(mr["iid"], markers.PLAN_SUCCESS)
+    ctx.assert_names_dirspace(note["body"], "dev")
+    ctx.wait_for_status(mr["sha"], "terrateam apply", states=("success", "pending", "failed"))
+
+
+@scenario("1.2", "terrateam plan comment triggers a plan", phase=1)
+def plan_via_comment(ctx):
+    mr = _fixture_with_mr(ctx)
+    # Let the autoplan settle first so the assertion below cannot match it.
+    ctx.wait_for_note_containing(mr["iid"], markers.PLAN_COMPLETE)
+    before = len(ctx.notes(mr["iid"]))
+    ctx.comment(mr["iid"], "terrateam plan")
+
+    def another_plan():
+        notes = ctx.notes(mr["iid"])
+        if len(notes) <= before:
+            return None
+        return any(markers.PLAN_COMPLETE in n["body"] for n in notes[before:]) or None
+
+    ctx.wait_for("a second plan comment", another_plan)
+
+
+@scenario("1.3", "terrateam apply comment applies and the status goes green", phase=1)
+def apply_via_comment(ctx):
+    mr = _fixture_with_mr(ctx)
+    ctx.wait_for_note_containing(mr["iid"], markers.PLAN_COMPLETE)
+    ctx.comment(mr["iid"], "terrateam apply")
+    ctx.wait_for_note_containing(mr["iid"], markers.APPLY_COMPLETE)
+    ctx.wait_for_status(mr["sha"], "terrateam apply", states=("success",))
+
+
+@scenario("1.4", "Pushing to the MR branch re-plans (Sync)", phase=1)
+def replan_on_push(ctx):
+    mr = _fixture_with_mr(ctx)
+    ctx.wait_for_note_containing(mr["iid"], markers.PLAN_COMPLETE)
+    before = len(ctx.notes(mr["iid"]))
+
+    ctx.log("pushing a second commit to the MR branch")
+    ctx.fixture.branch_with_change("e2e/change", dirs=("dev",), revision="3")
+
+    def replanned():
+        notes = ctx.notes(mr["iid"])
+        if len(notes) <= before:
+            return None
+        return any(markers.PLAN_COMPLETE in n["body"] for n in notes[before:]) or None
+
+    ctx.wait_for("a plan comment for the new commit", replanned)
+
+
+@scenario("1.5", "Merging the MR is handled without error", phase=1)
+def merge_is_handled(ctx):
+    mr = _fixture_with_mr(ctx)
+    ctx.wait_for_note_containing(mr["iid"], markers.PLAN_COMPLETE)
+    ctx.comment(mr["iid"], "terrateam apply")
+    ctx.wait_for_note_containing(mr["iid"], markers.APPLY_COMPLETE)
+
+    def mergeable():
+        current = ctx.gl.merge_request(ctx.fixture.id, mr["iid"])
+        return current.get("detailed_merge_status") == "mergeable" or None
+
+    ctx.wait_for("the MR to become mergeable", mergeable)
+    current = ctx.gl.merge_request(ctx.fixture.id, mr["iid"])
+    ctx.gl.merge_merge_request(ctx.fixture.id, mr["iid"], sha=current["sha"])
+
+    def merged():
+        current = ctx.gl.merge_request(ctx.fixture.id, mr["iid"])
+        return current["state"] == "merged" or None
+
+    ctx.wait_for("the MR to report merged", merged)
+    # The close path must not crash the event handler.
+    ctx.assert_not_in_logs(markers.NYI)
+
+
+@scenario("1.6", "Two dirspaces plan; apply dir:dev applies only dev", phase=1)
+def dirspace_targeting(ctx):
+    mr = _fixture_with_mr(ctx, dirs=("dev", "prod"))
+    note = ctx.wait_for_note_containing(mr["iid"], markers.PLAN_COMPLETE)
+    ctx.assert_names_dirspace(note["body"], "dev")
+    ctx.assert_names_dirspace(note["body"], "prod")
+
+    ctx.comment(mr["iid"], "terrateam apply dir:dev")
+    applied = ctx.wait_for_note_containing(mr["iid"], markers.APPLY_COMPLETE)
+    ctx.assert_names_dirspace(applied["body"], "dev")
+    ctx.assert_names_dirspace(applied["body"], "prod", present=False)
+
+
+@scenario("1.7", "terrateam unlock releases a lock", phase=1)
+def unlock(ctx):
+    mr = _fixture_with_mr(ctx)
+    ctx.wait_for_note_containing(mr["iid"], markers.PLAN_COMPLETE)
+    ctx.comment(mr["iid"], "terrateam unlock")
+    ctx.wait_for_note_containing(mr["iid"], markers.UNLOCK_SUCCESS)
+
+
+@scenario("1.8", "A very large plan falls back to the compact comment", phase=1)
+def large_plan_output(ctx):
+    # 400 resources is comfortably past the GitLab comment size limit once
+    # rendered as a plan diff.
+    big = """\
+terraform {
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3.2"
+    }
+  }
+}
+
+resource "null_resource" "big" {
+  count = 400
+  triggers = {
+    revision = "2"
+    padding  = "%s"
+  }
+}
+""" % ("x" * 2000)
+
+    ctx.fixture.create()
+    ctx.fixture.register_webhook()
+    ctx.gl.commit(
+        ctx.fixture.id,
+        "e2e/big",
+        "CHG Produce a very large plan",
+        [{"action": "update", "file_path": "dev/main.tf", "content": big}],
+        start_branch=ctx.fixture.default_branch,
+    )
+    mr = ctx.fixture.open_mr("e2e/big")
+
+    def compact_or_plan():
+        for note in ctx.notes(mr["iid"]):
+            if markers.COMMENT_TOO_LARGE in note["body"]:
+                return note
+            if markers.PLAN_COMPLETE in note["body"]:
+                return note
+        return None
+
+    note = ctx.wait_for("a plan comment, compact or full", compact_or_plan)
+    ctx.assert_true(
+        len(note["body"]) < 1_000_000, "the comment Terrateam posted was accepted by GitLab"
+    )
+    ctx.assert_not_in_logs(markers.NYI)


### PR DESCRIPTION
Closes #1449. Part of the #1445 stack (11/12, bottom to top). Base: `1456-gitlab-unit-tests`. `1457-gitlab-min-version-docs` stacks on top.