### PR TITLE
#1214 FIX Send PATCH request bodies

### DIFF
--- a/code/src/abb_curl/abb_curl.ml
+++ b/code/src/abb_curl/abb_curl.ml
@@ -614,6 +614,12 @@ module Make (Abb : Abb_intf.S with type Native.t = Unix.file_descr) = struct
             Curl.set_customrequest handle "DELETE";
             maybe_set_body_writer handle body
         | `PATCH body ->
+            (* curl only consumes the body read-callback in POST/upload mode; a
+               custom request verb on its own sends the Content-Length from
+               set_postfieldsize with no bytes behind it, which servers reject
+               as an empty body.  Enable POST send-mode when there is a body and
+               let CUSTOMREQUEST override the verb back to PATCH. *)
+            if body <> None then Curl.set_post handle true;
             Curl.set_customrequest handle "PATCH";
             maybe_set_body_writer handle body
         | `Custom (meth_, body) ->


### PR DESCRIPTION
## Description

Fixes PATCH requests with bodies in `abb_curl` by enabling curl send mode when a PATCH body is present. The custom request verb remains PATCH, but curl now consumes the configured read callback instead of sending a content length with no bytes.

This was found while validating the unified PR summary comment work in #1214. The in-place GitHub comment update path is the first PATCH-with-body caller in this tree.

## Stack

1. This PR: `abb_curl` PATCH body fix
2. #1472: unified-comment migration/index groundwork
3. #1474: summary mode config surface
4. #1475: unified comment renderer and tests
5. #1476: pull request comment update API
6. #1477: GitHub unified summary comment integration

## Validation

- `git diff --check origin/main..1214-unified-pr-comments-stack`
- Attempted `make -C code terrat`; local run could not complete because the temporary worktree filled the root filesystem while dune was creating sandbox directories (`No space left on device`).

Part of #1214.