### PR TITLE
#1214 FIX Add unified comment index concurrently

### DIFF
--- a/code/src/terrat/migrations/2026-07-21-add-unified-comment-tracking.sql
+++ b/code/src/terrat/migrations/2026-07-21-add-unified-comment-tracking.sql
@@ -1,0 +1,10 @@
+create table if not exists github_unified_comments(
+    -- the id github gave us, null until the first unified comment is posted
+    comment_id bigint,
+    repository bigint not null,
+    pull_number bigint not null,
+    dirty bigint not null default 0,
+    created_at timestamptz not null default current_timestamp,
+    foreign key (repository, pull_number) references github_pull_requests (repository, pull_number),
+    primary key (repository, pull_number)
+);

--- a/code/src/terrat/migrations/2026-07-22-add-unified-comment-workflow-step-output-index.sql
+++ b/code/src/terrat/migrations/2026-07-22-add-unified-comment-workflow-step-output-index.sql
@@ -1,0 +1,5 @@
+-- Supports looking up a dirspace's step outputs without scanning every row of
+-- a work manifest.
+create index concurrently if not exists workflow_step_outputs_dirspace_idx
+    on workflow_step_outputs (work_manifest, (scope->>'dir'), (scope->>'workspace'))
+    where scope->>'type' = 'dirspace';

--- a/code/src/terrat/terrat_migrations.ml
+++ b/code/src/terrat/terrat_migrations.ml
@@ -281,6 +281,12 @@ let migrations =
       run_sql [%blob "migrations/2026-07-05-extend-repo-configs-with-history.sql"] );
     ("add-tasks-user-id", run_sql [%blob "migrations/2026-07-23-add-tasks-user-id.sql"]);
     ("add-repo-tree-builds", run_sql [%blob "migrations/2026-07-21-add-repo-tree-builds.sql"]);
+    ( "add-unified-comment-tracking",
+      run_sql [%blob "migrations/2026-07-21-add-unified-comment-tracking.sql"] );
+    ( "add-unified-comment-workflow-step-output-index",
+      run_sql
+        ~mode:`Async
+        [%blob "migrations/2026-07-22-add-unified-comment-workflow-step-output-index.sql"] );
   ]
 
 let run config storage = Mig.run { Migrate.config; storage; tx = () } migrations


### PR DESCRIPTION
## Description

Adds the database groundwork for the unified PR summary comment:

- `github_unified_comments` tracks the single PR-level comment and dirty counter.
- `workflow_step_outputs_dirspace_idx` supports dirspace-scoped step-output lookup.

The index is intentionally split into its own async migration with `CREATE INDEX CONCURRENTLY` so production writes to `workflow_step_outputs` are not blocked by a plain index build. This addresses #1399.

## Stack

Base: #1471

1. #1471: `abb_curl` PATCH body fix
2. This PR: unified-comment table plus concurrent index migration
3. #1474: summary mode config surface
4. #1475: unified comment renderer and tests
5. #1476: pull request comment update API
6. #1477: GitHub unified summary comment integration

## Validation

- `git diff --check origin/main..1214-unified-pr-comments-stack`
- Attempted `make -C code terrat`; local run could not complete because the temporary worktree filled the root filesystem while dune was creating sandbox directories (`No space left on device`).

Part of #1214. Addresses #1399.