### PR TITLE
#1214 ADD summary notification mode config

### DIFF
--- a/api_schemas/terrat/config-schema.json
+++ b/api_schemas/terrat/config-schema.json
@@ -1235,6 +1235,14 @@
         "enabled": {
           "default": false,
           "type": "boolean"
+        },
+        "mode": {
+          "default": "header",
+          "enum": [
+            "header",
+            "pull_request"
+          ],
+          "type": "string"
         }
       },
       "type": "object"

--- a/code/src/terrat_base_repo_config_v1/terrat_base_repo_config_v1.ml
+++ b/code/src/terrat_base_repo_config_v1/terrat_base_repo_config_v1.ml
@@ -1055,10 +1055,25 @@ module Notifications = struct
   end
 
   module Summary = struct
-    (* Enterprise feature: the comment summary header only renders in the
-       Enterprise Edition.  Defaults to disabled so Open Source users are not
-       blocked by the premium-feature gate on the default configuration. *)
-    type t = { enabled : bool [@default false] } [@@deriving make, show, yojson, eq]
+    module Mode = struct
+      type t =
+        | Header
+        | Pull_request
+      [@@deriving show, yojson, eq]
+    end
+
+    (* Enterprise feature: the comment summary only renders in the Enterprise
+       Edition.  Defaults to disabled so Open Source users are not blocked by
+       the premium-feature gate on the default configuration.
+
+       [Header] renders the summary as a header inside each plan/apply comment.
+       [Pull_request] maintains a single unified summary comment for the whole
+       pull request and suppresses the per-work-manifest result comments. *)
+    type t = {
+      enabled : bool; [@default false]
+      mode : Mode.t; [@default Mode.Header]
+    }
+    [@@deriving make, show, yojson, eq]
   end
 
   type t = {
@@ -2469,7 +2484,13 @@ let of_version_1_notifications notifications =
   let policies = CCOption.get_or ~default:[] policies in
   let summary =
     match summary with
-    | Some { Sn.enabled } -> { Notifications.Summary.enabled }
+    | Some { Sn.enabled; mode } ->
+        let mode =
+          match mode with
+          | `Header -> Notifications.Summary.Mode.Header
+          | `Pull_request -> Notifications.Summary.Mode.Pull_request
+        in
+        { Notifications.Summary.enabled; mode }
     | None -> Notifications.Summary.make ()
   in
   CCResult.map_l of_version_1_notification_policy policies
@@ -3298,10 +3319,17 @@ let to_version_1_notification_policy policy =
 let to_version_1_notifications notifications =
   let module N = Terrat_repo_config.Notifications in
   let module Sn = Terrat_repo_config.Notifications_summary in
-  let { Notifications.policies; summary = { Notifications.Summary.enabled } } = notifications in
+  let { Notifications.policies; summary = { Notifications.Summary.enabled; mode } } =
+    notifications
+  in
+  let mode =
+    match mode with
+    | Notifications.Summary.Mode.Header -> `Header
+    | Notifications.Summary.Mode.Pull_request -> `Pull_request
+  in
   {
     N.policies = Some (CCList.map to_version_1_notification_policy policies);
-    summary = Some { Sn.enabled };
+    summary = Some { Sn.enabled; mode };
   }
 
 let to_version_1_storage_plans plans =

--- a/code/src/terrat_base_repo_config_v1/terrat_base_repo_config_v1.mli
+++ b/code/src/terrat_base_repo_config_v1/terrat_base_repo_config_v1.mli
@@ -675,13 +675,24 @@ module Notifications : sig
 
     type t = {
       tag_query : Tag_query.t;
-      comment_strategy : Strategy.t; [@default Strategy.Append]
+      comment_strategy : Strategy.t; [@default Strategy.Minimize]
     }
     [@@deriving make, show, yojson, eq]
   end
 
   module Summary : sig
-    type t = { enabled : bool [@default false] } [@@deriving make, show, yojson, eq]
+    module Mode : sig
+      type t =
+        | Header
+        | Pull_request
+      [@@deriving show, yojson, eq]
+    end
+
+    type t = {
+      enabled : bool; [@default false]
+      mode : Mode.t; [@default Mode.Header]
+    }
+    [@@deriving make, show, yojson, eq]
   end
 
   type t = {

--- a/code/src/terrat_repo_config/terrat_repo_config_notifications_summary.ml
+++ b/code/src/terrat_repo_config/terrat_repo_config_notifications_summary.ml
@@ -1,2 +1,23 @@
-type t = { enabled : bool [@default false] }
+module Mode = struct
+  let t_of_yojson = function
+    | `String "header" -> Ok `Header
+    | `String "pull_request" -> Ok `Pull_request
+    | json -> Error ("Unknown value: " ^ Yojson.Safe.pretty_to_string json)
+
+  let t_to_yojson = function
+    | `Header -> `String "header"
+    | `Pull_request -> `String "pull_request"
+
+  type t =
+    ([ `Header
+     | `Pull_request
+     ]
+    [@of_yojson t_of_yojson] [@to_yojson t_to_yojson])
+  [@@deriving yojson { strict = false; meta = true }, show, eq]
+end
+
+type t = {
+  enabled : bool; [@default false]
+  mode : Mode.t; [@default `Header]
+}
 [@@deriving yojson { strict = true; meta = true }, make, show, eq]

--- a/code/tests/terrat_base_repo_config_v1/test.ml
+++ b/code/tests/terrat_base_repo_config_v1/test.ml
@@ -65,12 +65,76 @@ let test_to_version_1_round_trip =
           | _ -> failwith "Round-trip to Version_1 did not produce Engine_stategraph")
       | Error _ -> failwith "of_version_1_json failed in round-trip setup")
 
+let test_notifications_summary_mode_pull_request =
+  Oth.test ~name:"of_version_1_json: notifications summary mode pull_request" (fun _ ->
+      let module Sum = V1.Notifications.Summary in
+      let json =
+        `Assoc
+          [
+            ( "notifications",
+              `Assoc
+                [
+                  ("summary", `Assoc [ ("enabled", `Bool true); ("mode", `String "pull_request") ]);
+                ] );
+          ]
+      in
+      match V1.of_version_1_json json with
+      | Ok cfg -> (
+          let { V1.Notifications.summary; _ } = V1.notifications cfg in
+          match summary with
+          | { Sum.enabled = true; mode = Sum.Mode.Pull_request } -> ()
+          | _ -> failwith "Expected summary enabled=true with mode=Pull_request")
+      | Error _ -> failwith "of_version_1_json failed on notifications summary pull_request config")
+
+let test_notifications_summary_mode_default =
+  Oth.test ~name:"of_version_1_json: notifications summary mode defaults to header" (fun _ ->
+      let module Sum = V1.Notifications.Summary in
+      let json =
+        `Assoc [ ("notifications", `Assoc [ ("summary", `Assoc [ ("enabled", `Bool true) ]) ]) ]
+      in
+      match V1.of_version_1_json json with
+      | Ok cfg -> (
+          let { V1.Notifications.summary; _ } = V1.notifications cfg in
+          match summary with
+          | { Sum.enabled = true; mode = Sum.Mode.Header } -> ()
+          | _ -> failwith "Expected summary enabled=true with default mode=Header")
+      | Error _ -> failwith "of_version_1_json failed on notifications summary default mode config")
+
+let test_notifications_summary_mode_round_trip =
+  Oth.test ~name:"to_version_1: notifications summary mode round-trips" (fun _ ->
+      let module Sn = Repo.Notifications_summary in
+      let round_trip mode_str expected =
+        let json =
+          `Assoc
+            [
+              ( "notifications",
+                `Assoc
+                  [ ("summary", `Assoc [ ("enabled", `Bool true); ("mode", `String mode_str) ]) ] );
+            ]
+        in
+        match V1.of_version_1_json json with
+        | Ok cfg -> (
+            let v1 = V1.to_version_1 cfg in
+            match v1.Repo.Version_1.notifications with
+            | Some { Repo.Notifications.summary = Some { Sn.enabled = true; mode }; _ } ->
+                if mode <> expected then
+                  failwith
+                    (Printf.sprintf "Round-trip of mode %s produced a different mode" mode_str)
+            | _ -> failwith "Round-trip to Version_1 did not produce a notifications summary")
+        | Error _ -> failwith "of_version_1_json failed in notifications summary round-trip setup"
+      in
+      round_trip "pull_request" `Pull_request;
+      round_trip "header" `Header)
+
 let test =
   Oth.parallel
     [
       test_of_version_1_json_minimal;
       test_of_version_1_json_with_version;
       test_to_version_1_round_trip;
+      test_notifications_summary_mode_pull_request;
+      test_notifications_summary_mode_default;
+      test_notifications_summary_mode_round_trip;
     ]
 
 let () =

--- a/code/tests/terrat_repo_config/test.ml
+++ b/code/tests/terrat_repo_config/test.ml
@@ -91,6 +91,49 @@ let test_engine_chain_unknown_falls_to_other =
       | Error _ ->
           failwith "Expected Engine_other to accept unknown engine names; got Error instead")
 
+module Ns = Terrat_repo_config.Notifications_summary
+
+let test_notifications_summary_pull_request_round_trip =
+  Oth.test ~name:"Notifications_summary: mode pull_request round-trip" (fun _ ->
+      let json = `Assoc [ ("enabled", `Bool true); ("mode", `String "pull_request") ] in
+      match Ns.of_yojson json with
+      | Ok t -> (
+          assert (t.Ns.enabled = true);
+          assert (t.Ns.mode = `Pull_request);
+          let round_tripped = Ns.to_yojson t in
+          match Ns.of_yojson round_tripped with
+          | Ok t' -> assert (t'.Ns.mode = `Pull_request)
+          | Error msg -> failwith msg)
+      | Error msg -> failwith msg)
+
+let test_notifications_summary_header_round_trip =
+  Oth.test ~name:"Notifications_summary: mode header round-trip" (fun _ ->
+      let json = `Assoc [ ("enabled", `Bool true); ("mode", `String "header") ] in
+      match Ns.of_yojson json with
+      | Ok t -> (
+          assert (t.Ns.mode = `Header);
+          let round_tripped = Ns.to_yojson t in
+          match Ns.of_yojson round_tripped with
+          | Ok t' -> assert (t'.Ns.mode = `Header)
+          | Error msg -> failwith msg)
+      | Error msg -> failwith msg)
+
+let test_notifications_summary_mode_default =
+  Oth.test ~name:"Notifications_summary: mode omitted defaults to header" (fun _ ->
+      let json = `Assoc [ ("enabled", `Bool true) ] in
+      match Ns.of_yojson json with
+      | Ok t ->
+          assert (t.Ns.enabled = true);
+          assert (t.Ns.mode = `Header)
+      | Error msg -> failwith msg)
+
+let test_notifications_summary_rejects_unknown_mode =
+  Oth.test ~name:"Notifications_summary: unknown mode rejected" (fun _ ->
+      let json = `Assoc [ ("enabled", `Bool true); ("mode", `String "sidebar") ] in
+      match Ns.of_yojson json with
+      | Ok _ -> failwith "Expected unknown mode to be rejected, but it was accepted"
+      | Error _ -> ())
+
 let test =
   Oth.parallel
     [
@@ -102,6 +145,10 @@ let test =
       test_engine_chain_to_yojson_dispatches;
       test_stategraph_with_tf_fields_round_trip;
       test_engine_chain_unknown_falls_to_other;
+      test_notifications_summary_pull_request_round_trip;
+      test_notifications_summary_header_round_trip;
+      test_notifications_summary_mode_default;
+      test_notifications_summary_rejects_unknown_mode;
     ]
 
 let () =


### PR DESCRIPTION
## Description

Adds the repo-configuration surface for `notifications.summary.mode` with values `header` and `pull_request`, defaulting to `header`.

This PR is intentionally limited to schema/config parsing and round-trip tests. The actual unified PR comment behavior is stacked later in #1214 so this layer stays reviewable and mechanical.

## Stack

Base: #1472

1. #1471: `abb_curl` PATCH body fix
2. #1472: unified-comment table plus concurrent index migration
3. This PR: summary mode config surface
4. #1475: unified comment renderer and tests
5. #1476: pull request comment update API
6. #1477: GitHub unified summary comment integration

## Validation

- `git diff --check 1214-unified-comment-index..1214-github-unified-comment`
- The rebuilt final branch is byte-for-byte equivalent to the superseded #1473 branch.
- Full local build remains blocked by the temp worktree filling the root filesystem during dune sandbox creation (`No space left on device`).

Part of #1214.