### PR TITLE
#1214 ADD pull request comment updates

### DIFF
--- a/code/src/terrat_github/terrat_github.ml
+++ b/code/src/terrat_github/terrat_github.ml
@@ -133,6 +133,13 @@ type minimize_comment_err =
   ]
 [@@deriving show]
 
+type update_comment_err =
+  [ Githubc2_abb.call_err
+  | `Not_found
+  | `Unprocessable_entity of Githubc2_components.Validation_error.t
+  ]
+[@@deriving show]
+
 type fetch_pull_request_review_decision_err =
   [ Githubc2_abb.call_err
   | `Graphql_err of string list
@@ -555,6 +562,30 @@ let minimize_comment ~owner ~repo ~comment_id client =
           | `OK -> Abb.Future.return (Ok ())
           | `Not_found -> Abb.Future.return (Error `Not_found)))
   | `Not_found _ -> Abb.Future.return (Error `Not_found)
+
+let update_comment ~owner ~repo ~comment_id ~body client =
+  Prmths.Counter.inc_one (Metrics.fn_call_total "update_comment");
+  let open Abb.Future.Infix_monad in
+  (* No retries: a deleted comment comes back as an error (404) and retrying
+     it just delays the caller's fallback of posting a fresh comment. *)
+  call
+    ~tries:1
+    client
+    Githubc2_issues.Update_comment.(
+      make
+        ~body:Request_body.(make Primary.{ body })
+        Parameters.(make ~comment_id:(CCInt64.of_int comment_id) ~owner ~repo))
+  >>= function
+  | Ok resp -> (
+      match Openapi.Response.value resp with
+      | `OK _ -> Abb.Future.return (Ok ())
+      | `Unprocessable_entity _ as err -> Abb.Future.return (Error err))
+  | Error (`Missing_response resp) when Openapi.Response.status resp = 404 ->
+      (* A comment that has been deleted by the user comes back as a 404, which
+         the generated client does not have a response for, so detect that case
+         here. *)
+      Abb.Future.return (Error `Not_found)
+  | Error (#Githubc2_abb.call_err as err) -> Abb.Future.return (Error err)
 
 (* [reviewDecision] is GitHub's own verdict on whether the pull request
    satisfies the target branch's required-review rule, including CODEOWNERS

--- a/code/src/terrat_github/terrat_github.mli
+++ b/code/src/terrat_github/terrat_github.mli
@@ -91,6 +91,13 @@ type minimize_comment_err =
   ]
 [@@deriving show]
 
+type update_comment_err =
+  [ Githubc2_abb.call_err
+  | `Not_found
+  | `Unprocessable_entity of Githubc2_components.Validation_error.t
+  ]
+[@@deriving show]
+
 type fetch_pull_request_review_decision_err =
   [ Githubc2_abb.call_err
   | `Graphql_err of string list
@@ -303,6 +310,14 @@ val minimize_comment :
   comment_id:int ->
   Githubc2_abb.t ->
   (unit, [> minimize_comment_err ]) result Abb.Future.t
+
+val update_comment :
+  owner:string ->
+  repo:string ->
+  comment_id:int ->
+  body:string ->
+  Githubc2_abb.t ->
+  (unit, [> update_comment_err ]) result Abb.Future.t
 
 (** GitHub's [PullRequest.reviewDecision], which is its own verdict on the target branch's
     required-review rule, CODEOWNERS included. [None] means GitHub returned [null], which happens

--- a/code/src/terrat_vcs_api/terrat_vcs_api.ml
+++ b/code/src/terrat_vcs_api/terrat_vcs_api.ml
@@ -158,6 +158,14 @@ module type S = sig
     Comment.Id.t ->
     (unit, [> `Error ]) result Abb.Future.t
 
+  val update_pull_request_comment :
+    request_id:string ->
+    Client.t ->
+    ('diff, 'checks) Pull_request.t ->
+    Comment.Id.t ->
+    string ->
+    (unit, [> `Not_found | `Error ]) result Abb.Future.t
+
   val fetch_pull_request :
     request_id:string ->
     Account.t ->

--- a/code/src/terrat_vcs_api_github/terrat_vcs_api_github.ml
+++ b/code/src/terrat_vcs_api_github/terrat_vcs_api_github.ml
@@ -476,6 +476,27 @@ let minimize_pull_request_comment ~request_id client pull_request comment_id =
          want to block the actual commenting *)
       Abb.Future.return (Ok ())
 
+let update_pull_request_comment ~request_id client pull_request comment_id body =
+  let open Abb.Future.Infix_monad in
+  Terrat_github.update_comment
+    ~owner:(Repo.owner (Terrat_pull_request.repo pull_request))
+    ~repo:(Repo.name (Terrat_pull_request.repo pull_request))
+    ~comment_id
+    ~body
+    client.Client.client
+  >>= function
+  | Ok () -> Abb.Future.return (Ok ())
+  | Error `Not_found -> Abb.Future.return (Error `Not_found)
+  | Error (#Terrat_github.update_comment_err as err) ->
+      Prmths.Counter.inc_one Metrics.github_errors_total;
+      Logs.err (fun m ->
+          m
+            "%s : UPDATE_COMMENT_ON_PULL_REQUEST : %a"
+            request_id
+            Terrat_github.pp_update_comment_err
+            err);
+      Abb.Future.return (Error `Error)
+
 let diff_of_github_diff =
   CCList.map
     Githubc2_components.Diff_entry.(

--- a/code/src/terrat_vcs_api_gitlab/terrat_vcs_api_gitlab.ml
+++ b/code/src/terrat_vcs_api_gitlab/terrat_vcs_api_gitlab.ml
@@ -472,6 +472,9 @@ let delete_pull_request_comment ~request_id:_ _client _pull_request _comment_id 
 let minimize_pull_request_comment ~request_id:_ _client _pull_request _comment_id =
   raise (Failure "nyi")
 
+let update_pull_request_comment ~request_id:_ _client _pull_request _comment_id _body =
+  raise (Failure "nyi")
+
 let fetch_diff ~request_id ~client ~repo merge_request_iid =
   let module Gl =
     Gitlabc_projects_merge_requests.GetApiV4ProjectsIdMergeRequestsMergeRequestIidDiffs

--- a/code/src/terrat_vcs_api_nyi/terrat_vcs_api_nyi.ml
+++ b/code/src/terrat_vcs_api_nyi/terrat_vcs_api_nyi.ml
@@ -119,6 +119,10 @@ let fetch_tree ~request_id client repo ref_ = raise (Failure "nyi")
 let comment_on_pull_request ~request_id client pull_request body = raise (Failure "nyi")
 let delete_pull_request_comment ~request_id client pull_request comment_id = raise (Failure "nyi")
 let minimize_pull_request_comment ~request_id client pull_request comment_id = raise (Failure "nyi")
+
+let update_pull_request_comment ~request_id client pull_request comment_id body =
+  raise (Failure "nyi")
+
 let fetch_diff ~client ~owner ~repo pull_number = raise (Failure "nyi")
 let fetch_pull_request ~request_id account client repo pull_request_id = raise (Failure "nyi")
 let fetch_diff_files ~request_id ~base_ref ~branch_ref repo client = raise (Failure "nyi")


### PR DESCRIPTION
## Description

Adds the VCS API plumbing needed to update an existing pull request comment in place.

For GitHub this wraps `Githubc2_issues.Update_comment`, treats a deleted comment as `Not_found`, and maps other failures through the existing logging/error path. GitLab and NYI providers get explicit stubs so the shared interface remains complete.

## Stack

Base: #1475

1. #1471: `abb_curl` PATCH body fix
2. #1472: unified-comment table plus concurrent index migration
3. #1474: summary mode config surface
4. #1475: unified comment renderer and tests
5. This PR: pull request comment update API
6. #1477: GitHub unified summary comment integration

## Validation

- `git diff --check 1214-unified-comment-index..1214-github-unified-comment`
- The rebuilt final branch is byte-for-byte equivalent to the superseded #1473 branch.
- Full local build remains blocked by the temp worktree filling the root filesystem during dune sandbox creation (`No space left on device`).

Part of #1214.