### PR TITLE
#1214 ADD GitHub unified summary comments

### DIFF
--- a/code/src/terrat_vcs_event_evaluator2/terrat_vcs_event_evaluator2.ml
+++ b/code/src/terrat_vcs_event_evaluator2/terrat_vcs_event_evaluator2.ml
@@ -466,26 +466,44 @@ module Make (S : Terrat_vcs_provider2.S) = struct
               S.Db.query_flow_state ~request_id db work_manifest.Terrat_work_manifest3.id
               >>= function
               | Some _ -> Abb.Future.return (Ok (`Legacy work_manifest))
-              | None -> Abb.Future.return (Ok `New_age))
-          | None -> Abb.Future.return (Ok `New_age))
+              | None -> Abb.Future.return (Ok (`New_age (Some work_manifest))))
+          | None -> Abb.Future.return (Ok (`New_age None)))
       >>= function
-      | `New_age ->
+      | `New_age work_manifest ->
           with_conn storage ~f:(fun db ->
               Pgsql_io.tx db ~f:(fun () ->
                   let open Abb.Future.Infix_monad in
                   Builder.State.make ~log_id:request_id ~config ~store ~db ~exec ~tasks ()
                   >>= fun s ->
                   Logs.info (fun m -> m "%s : target=%s" (Builder.log_id s) (Hmap.Key.info target));
-                  tx_safe ~request_id @@ Builder.eval s target))
+                  tx_safe ~request_id @@ Builder.eval s target
+                  >>= fun r ->
+                  (* Best effort so the unified comment reflects the failure. *)
+                  match work_manifest with
+                  | Some { Terrat_work_manifest3.id; _ } ->
+                      S.Comment.mark_unified_comment_dirty ~request_id db id
+                      >>= fun _ -> Abb.Future.return r
+                  | None -> Abb.Future.return r))
+          >>= fun _ ->
+          Abb.Future.return
+            (Ok (CCOption.map (fun { Terrat_work_manifest3.id; _ } -> id) work_manifest))
       | `Legacy work_manifest ->
           let ctx = Legacy.Ctx.make ~config ~storage ~request_id () in
           Legacy.run_work_manifest_failure ~ctx work_manifest.Terrat_work_manifest3.id
-          >>= fun _ -> Abb.Future.return (Ok (`Ok ()))
+          >>= fun _ -> Abb.Future.return (Ok (Some work_manifest.Terrat_work_manifest3.id))
     in
     let open Abb.Future.Infix_monad in
     log_err ~request_id run
     >>= function
-    | Ok _ -> Abb.Future.return (Ok ())
+    | Ok work_manifest_id ->
+        CCOption.map_or
+          ~default:(Abb.Future.return ())
+          (fun work_manifest_id ->
+            Fc.ignore
+              (Abb.Future.fork
+                 (S.Comment.drain_unified_comment ~request_id config storage work_manifest_id)))
+          work_manifest_id
+        >>= fun () -> Abb.Future.return (Ok ())
     | Error _ -> Abb.Future.return (Error `Error)
 
   let compute_node_poll ~request_id ~config ~storage ~exec ~compute_node_id offering =
@@ -826,6 +844,10 @@ module Make (S : Terrat_vcs_provider2.S) = struct
                     work_manifest_id
                     Terrat_work_manifest3.State.Aborted
                   >>= fun () ->
+                  let open Abb.Future.Infix_monad in
+                  (* Best effort so the unified comment reflects the abort. *)
+                  S.Comment.mark_unified_comment_dirty ~request_id db work_manifest_id
+                  >>= fun _ ->
                   run_work_manifest_event
                     ~request_id
                     ~config
@@ -847,6 +869,19 @@ module Make (S : Terrat_vcs_provider2.S) = struct
         | Ok _ -> Abb.Future.return (Ok ())
         | Error _ -> Abb.Future.return (Error `Error))
       ~finally:(fun () ->
+        Fc.ignore
+          (Abb.Future.fork
+             (S.Comment.drain_unified_comment ~request_id config storage work_manifest_id))
+        >>= fun () ->
+        (* The legacy evaluator resolves its result future while its
+           transaction is still open, so the dirty mark may not be visible to
+           the drain above yet.  A delayed second drain picks it up. *)
+        Fc.ignore
+          (Abb.Future.fork
+             (Abb.Sys.sleep 10.0
+             >>= fun () ->
+             S.Comment.drain_unified_comment ~request_id config storage work_manifest_id))
+        >>= fun () ->
         Fc.ignore
         @@ Abb.Future.fork
         @@ run_missing_drift_schedules ~request_id ~config ~storage ~exec ())

--- a/code/src/terrat_vcs_github_comment/sql/clear_unified_comment_dirty.sql
+++ b/code/src/terrat_vcs_github_comment/sql/clear_unified_comment_dirty.sql
@@ -1,0 +1,4 @@
+update github_unified_comments
+set dirty = 0
+where repository = $repository and pull_number = $pull_number and dirty = $dirty
+returning repository

--- a/code/src/terrat_vcs_github_comment/sql/mark_unified_comment_dirty.sql
+++ b/code/src/terrat_vcs_github_comment/sql/mark_unified_comment_dirty.sql
@@ -1,0 +1,9 @@
+-- Bump the dirty counter of an existing unified comment row.  Unlike the
+-- upsert, this never creates a row: only pull requests that already publish a
+-- unified comment are refreshed.
+update github_unified_comments as guc
+set dirty = guc.dirty + 1
+from github_work_manifests as gwm
+where gwm.id = $work_manifest
+  and guc.repository = gwm.repository
+  and guc.pull_number = gwm.pull_number

--- a/code/src/terrat_vcs_github_comment/sql/select_unified_comment_elements.sql
+++ b/code/src/terrat_vcs_github_comment/sql/select_unified_comment_elements.sql
@@ -1,0 +1,156 @@
+-- Recompute the state of every dirspace of the pull request that the given
+-- work manifest belongs to, at the pull request's current sha.  The counts are
+-- extracted from the plan output summary line when present.
+with pr as (
+    select
+        gpr.repository,
+        gpr.pull_number,
+        gpr.base_sha,
+        gpr.sha,
+        gpr.merged_sha,
+        gpr.state,
+        grm.core_id as repo_core_id
+    from github_work_manifests as gwm
+    inner join github_pull_requests as gpr
+        on gpr.repository = gwm.repository and gpr.pull_number = gwm.pull_number
+    inner join github_repositories_map as grm
+        on grm.repository_id = gpr.repository
+    where gwm.id = $work_manifest
+),
+-- In the case that the pull request being evaluated here is merged, work
+-- manifests run against the sha of the most recently merged pull request, so
+-- accept that sha as well.
+latest_merged_pull_request as (
+    select gpr.repository, gpr.merged_sha
+    from github_pull_requests as gpr
+    inner join pr on pr.repository = gpr.repository
+    where gpr.state = 'merged'
+    order by gpr.merged_at desc
+    limit 1
+),
+current_dirspaces as (
+    select distinct cd.path, cd.workspace
+    from change_dirspaces as cd
+    inner join pr
+        on pr.repo_core_id = cd.repo and pr.base_sha = cd.base_sha
+    left join latest_merged_pull_request as lmpr
+        on lmpr.repository = pr.repository
+    where pr.sha = cd.sha
+          or pr.merged_sha = cd.sha
+          or (pr.state = 'merged' and cd.sha = lmpr.merged_sha)
+),
+pr_work_manifests as (
+    select gwm.id, gwm.run_type, gwm.state, gwm.created_at
+    from github_work_manifests as gwm
+    inner join pr
+        on pr.repository = gwm.repository
+           and pr.pull_number = gwm.pull_number
+           and pr.base_sha = gwm.base_sha
+    left join latest_merged_pull_request as lmpr
+        on lmpr.repository = pr.repository
+    left join github_pull_request_latest_unlocks as lu
+        on lu.repository = gwm.repository and lu.pull_number = gwm.pull_number
+    where (pr.sha = gwm.sha
+           or pr.merged_sha = gwm.sha
+           or (pr.state = 'merged' and gwm.sha = lmpr.merged_sha))
+          and gwm.run_type in ('plan', 'autoplan', 'apply', 'autoapply', 'unsafe-apply')
+          and (lu.unlocked_at is null or lu.unlocked_at < gwm.created_at)
+),
+latest_plans as (
+    select path, workspace, success, work_manifest
+    from (
+        select
+            wmr.path,
+            wmr.workspace,
+            wmr.success,
+            wm.id as work_manifest,
+            row_number() over (partition by wmr.path, wmr.workspace
+                               order by wm.created_at desc) as rn
+        from pr_work_manifests as wm
+        inner join work_manifest_results as wmr
+            on wmr.work_manifest = wm.id
+        where wm.run_type in ('plan', 'autoplan')
+    ) as t
+    where rn = 1
+),
+latest_applies as (
+    select path, workspace, success, work_manifest
+    from (
+        select
+            wmr.path,
+            wmr.workspace,
+            wmr.success,
+            wm.id as work_manifest,
+            row_number() over (partition by wmr.path, wmr.workspace
+                               order by wm.created_at desc) as rn
+        from pr_work_manifests as wm
+        inner join work_manifest_results as wmr
+            on wmr.work_manifest = wm.id
+        where wm.run_type in ('apply', 'autoapply', 'unsafe-apply')
+    ) as t
+    where rn = 1
+),
+active_dirspaces as (
+    select distinct wmd.path, wmd.workspace
+    from pr_work_manifests as wm
+    inner join work_manifest_dirspaceflows as wmd
+        on wmd.work_manifest = wm.id
+    where wm.state in ('queued', 'running')
+),
+aborted_dirspaces as (
+    select distinct wmd.path, wmd.workspace
+    from pr_work_manifests as wm
+    inner join work_manifest_dirspaceflows as wmd
+        on wmd.work_manifest = wm.id
+    where wm.state = 'aborted'
+      and not exists (select 1
+                      from work_manifest_results as wmr
+                      where wmr.work_manifest = wm.id)
+)
+select
+    cd.path,
+    cd.workspace,
+    lp.success as plan_success,
+    -- The plans row is deleted once an apply fetches the plan, so fall back to
+    -- the plan step output which is retained forever.
+    coalesce(p.has_changes, (po.payload->>'has_changes')::boolean) as plan_has_changes,
+    lp.work_manifest as plan_work_manifest,
+    -- Exact resource-change counts, computed by the runner from
+    -- `terraform show -json`.  No text parsing: when a runner or engine does
+    -- not emit them the columns are null (rendered as "-") rather than guessed.
+    (po.payload->'resource_summary'->>'created')::bigint as created,
+    (po.payload->'resource_summary'->>'updated')::bigint as updated,
+    (po.payload->'resource_summary'->>'deleted')::bigint as deleted,
+    (po.payload->'resource_summary'->>'replaced')::bigint as replaced,
+    -- Inline output details are only rendered for small pull requests; at
+    -- scale the unified comment is a table with console links.
+    case when (select count(*) from current_dirspaces) <= 20 then
+        coalesce(po.payload->>'plan', po.payload->>'text')
+    end as plan_output,
+    la.success as apply_success,
+    la.work_manifest as apply_work_manifest,
+    (ad.path is not null) as active,
+    (ab.path is not null) as aborted
+from current_dirspaces as cd
+left join latest_plans as lp
+    on lp.path = cd.path and lp.workspace = cd.workspace
+left join plans as p
+    on p.work_manifest = lp.work_manifest and p.path = lp.path and p.workspace = lp.workspace
+left join lateral (
+    select wso.payload
+    from workflow_step_outputs as wso
+    where wso.work_manifest = lp.work_manifest
+      and wso.scope->>'type' = 'dirspace'
+      and wso.scope->>'dir' = lp.path
+      and wso.scope->>'workspace' = lp.workspace
+      and wso.step in ('tf/plan', 'pulumi/plan', 'custom/plan', 'fly/plan', 'stategraph/plan')
+    order by wso.idx desc
+    limit 1
+) as po on true
+left join latest_applies as la
+    on la.path = cd.path and la.workspace = cd.workspace
+left join active_dirspaces as ad
+    on ad.path = cd.path and ad.workspace = cd.workspace
+left join aborted_dirspaces as ab
+    on ab.path = cd.path and ab.workspace = cd.workspace
+order by cd.path, cd.workspace

--- a/code/src/terrat_vcs_github_comment/sql/select_unified_comment_state.sql
+++ b/code/src/terrat_vcs_github_comment/sql/select_unified_comment_state.sql
@@ -1,0 +1,12 @@
+select
+    gwm.repository,
+    gwm.pull_number,
+    gwm.installation_id,
+    gwm.repo_owner,
+    gwm.repo_name,
+    guc.comment_id,
+    guc.dirty
+from github_work_manifests as gwm
+inner join github_unified_comments as guc
+    on guc.repository = gwm.repository and guc.pull_number = gwm.pull_number
+where gwm.id = $work_manifest

--- a/code/src/terrat_vcs_github_comment/sql/update_unified_comment_id.sql
+++ b/code/src/terrat_vcs_github_comment/sql/update_unified_comment_id.sql
@@ -1,0 +1,3 @@
+update github_unified_comments
+set comment_id = $comment_id
+where repository = $repository and pull_number = $pull_number

--- a/code/src/terrat_vcs_github_comment/sql/upsert_unified_comment_dirty.sql
+++ b/code/src/terrat_vcs_github_comment/sql/upsert_unified_comment_dirty.sql
@@ -1,0 +1,9 @@
+insert into github_unified_comments (repository, pull_number, dirty)
+select
+    gwm.repository,
+    gwm.pull_number,
+    1
+from github_work_manifests as gwm
+where gwm.id = $work_manifest and gwm.pull_number is not null
+on conflict (repository, pull_number)
+do update set dirty = github_unified_comments.dirty + 1

--- a/code/src/terrat_vcs_github_comment/terrat_vcs_github_comment_ui.mli
+++ b/code/src/terrat_vcs_github_comment/terrat_vcs_github_comment_ui.mli
@@ -1,4 +1,6 @@
 module Ui : sig
+  val base_url : Terrat_vcs_api_github.Config.t -> Terrat_vcs_api_github.Account.t -> string
+
   val work_manifest_url :
     Terrat_vcs_api_github.Config.t ->
     Terrat_vcs_api_github.Account.t ->

--- a/code/src/terrat_vcs_github_comment/terrat_vcs_github_comment_unified.ml
+++ b/code/src/terrat_vcs_github_comment/terrat_vcs_github_comment_unified.ml
@@ -1,0 +1,529 @@
+module Api = Terrat_vcs_api_github
+module Tmpl = Terrat_vcs_github_comment_templates.Tmpl
+module Ui = Terrat_vcs_github_comment_ui.Ui
+module Unified = Terrat_vcs_comment_unified
+
+let src = Logs.Src.create "vcs_github_comment_unified"
+
+module Logs = (val Logs.src_log src : Logs.LOG)
+
+module Sql = struct
+  let read s = Pgsql_io.clean_string s
+
+  let upsert_unified_comment_dirty =
+    Pgsql_io.Typed_sql.(
+      sql /^ read [%blob "sql/upsert_unified_comment_dirty.sql"] /% Var.uuid "work_manifest")
+
+  let mark_unified_comment_dirty =
+    Pgsql_io.Typed_sql.(
+      sql /^ read [%blob "sql/mark_unified_comment_dirty.sql"] /% Var.uuid "work_manifest")
+
+  let select_unified_comment_state =
+    Pgsql_io.Typed_sql.(
+      sql
+      //
+      (* repository *)
+      Ret.bigint
+      //
+      (* pull_number *)
+      Ret.bigint
+      //
+      (* installation_id *)
+      Ret.bigint
+      //
+      (* repo_owner *)
+      Ret.text
+      //
+      (* repo_name *)
+      Ret.text
+      //
+      (* comment_id *)
+      Ret.(option bigint)
+      //
+      (* dirty *)
+      Ret.bigint
+      /^ read [%blob "sql/select_unified_comment_state.sql"]
+      /% Var.uuid "work_manifest")
+
+  let select_unified_comment_elements () =
+    Pgsql_io.Typed_sql.(
+      sql
+      //
+      (* path *)
+      Ret.text
+      //
+      (* workspace *)
+      Ret.text
+      //
+      (* plan_success *)
+      Ret.(option boolean)
+      //
+      (* plan_has_changes *)
+      Ret.(option boolean)
+      //
+      (* plan_work_manifest *)
+      Ret.(option uuid)
+      //
+      (* created *)
+      Ret.(option bigint)
+      //
+      (* updated *)
+      Ret.(option bigint)
+      //
+      (* deleted *)
+      Ret.(option bigint)
+      //
+      (* replaced *)
+      Ret.(option bigint)
+      //
+      (* plan_output *)
+      Ret.(option text)
+      //
+      (* apply_success *)
+      Ret.(option boolean)
+      //
+      (* apply_work_manifest *)
+      Ret.(option uuid)
+      //
+      (* active *)
+      Ret.boolean
+      //
+      (* aborted *)
+      Ret.boolean
+      /^ read [%blob "sql/select_unified_comment_elements.sql"]
+      /% Var.uuid "work_manifest")
+
+  let update_unified_comment_id =
+    Pgsql_io.Typed_sql.(
+      sql
+      /^ read [%blob "sql/update_unified_comment_id.sql"]
+      /% Var.bigint "comment_id"
+      /% Var.bigint "repository"
+      /% Var.bigint "pull_number")
+
+  let clear_unified_comment_dirty =
+    Pgsql_io.Typed_sql.(
+      sql
+      //
+      (* repository *)
+      Ret.bigint
+      /^ read [%blob "sql/clear_unified_comment_dirty.sql"]
+      /% Var.bigint "repository"
+      /% Var.bigint "pull_number"
+      /% Var.bigint "dirty")
+
+  let try_advisory_lock =
+    Pgsql_io.Typed_sql.(
+      sql
+      //
+      (* locked *)
+      Ret.boolean
+      /^ "select pg_try_advisory_xact_lock(hashtext('github_unified_comments'), hashtext($key))"
+      /% Var.text "key")
+end
+
+module S = struct
+  type t = {
+    account : Api.Account.t;
+    client : Githubc2_abb.t;
+    comment_id : Api.Comment.Id.t option;
+    config : Api.Config.t;
+    db : Pgsql_io.t;
+    pull_number : int64;
+    repo_name : string;
+    repo_owner : string;
+    repository : int64;
+    request_id : string;
+    work_manifest_id : Uuidm.t;
+  }
+
+  type el = {
+    created : int64 option;
+    deleted : int64 option;
+    dirspace : Terrat_dirspace.t;
+    has_changes : bool;
+    output : string option;
+    replaced : int64 option;
+    status : Unified.Status.t;
+    updated : int64 option;
+    work_manifest_id : Uuidm.t option;
+  }
+  [@@deriving ord, show]
+
+  type comment_id = Api.Comment.Id.t [@@deriving ord, show]
+
+  let status_of_row ~plan_success ~apply_success ~active ~aborted =
+    let module St = Unified.Status in
+    match (apply_success, active, plan_success) with
+    | Some true, _, _ -> St.Applied
+    | Some false, _, _ -> St.Failed
+    | None, true, _ -> St.Pending
+    | None, false, Some false -> St.Failed
+    | None, false, Some true -> St.Planned
+    | None, false, None -> if aborted then St.Failed else St.Pending
+
+  let query_comment_id t = Abb.Future.return (Ok t.comment_id)
+
+  let query_els t =
+    let open Abb.Future.Infix_monad in
+    Pgsql_io.Prepared_stmt.fetch
+      t.db
+      (Sql.select_unified_comment_elements ())
+      ~f:(fun
+          path
+          workspace
+          plan_success
+          plan_has_changes
+          plan_work_manifest
+          created
+          updated
+          deleted
+          replaced
+          plan_output
+          apply_success
+          apply_work_manifest
+          active
+          aborted
+        ->
+        {
+          created;
+          deleted;
+          dirspace = { Terrat_dirspace.dir = path; workspace };
+          has_changes = CCOption.get_or ~default:false plan_has_changes;
+          output = plan_output;
+          replaced;
+          status = status_of_row ~plan_success ~apply_success ~active ~aborted;
+          updated;
+          work_manifest_id = CCOption.or_ ~else_:plan_work_manifest apply_work_manifest;
+        })
+      t.work_manifest_id
+    >>= function
+    | Ok _ as r -> Abb.Future.return r
+    | Error (#Pgsql_io.err as err) ->
+        Logs.err (fun m -> m "%s : ERROR : %a" t.request_id Pgsql_io.pp_err err);
+        Abb.Future.return (Error `Error)
+
+  let status_kv status =
+    let module St = Unified.Status in
+    match status with
+    | St.Failed -> ":x: **Failed**"
+    | St.Planned -> ":pencil2: Planned"
+    | St.Pending -> ":hourglass_flowing_sand: Pending"
+    | St.Applied -> ":white_check_mark: Applied"
+
+  let status_machine status =
+    let module St = Unified.Status in
+    match status with
+    | St.Failed -> "failed"
+    | St.Planned -> "planned"
+    | St.Pending -> "pending"
+    | St.Applied -> "applied"
+
+  let count_kv el count =
+    match (el.status, el.has_changes, count) with
+    | Unified.Status.Pending, _, _ | _, false, _ | _, _, None -> "-"
+    | _, true, Some n -> Int64.to_string n
+
+  let run_url t el =
+    CCOption.map
+      (fun work_manifest_id ->
+        Uri.to_string
+        @@ CCOption.get_exn_or "run_url"
+        @@ Ui.run_url t.config t.account work_manifest_id)
+      el.work_manifest_id
+
+  let console_url t = Printf.sprintf "%s/runs/pr/%Ld" (Ui.base_url t.config t.account) t.pull_number
+
+  let sum f els =
+    CCList.fold_left (fun acc el -> Int64.add acc (CCOption.get_or ~default:0L (f el))) 0L els
+
+  let machine_kv t els =
+    let json =
+      `Assoc
+        [
+          ( "dirspaces",
+            `List
+              (CCList.map
+                 (fun el ->
+                   let { Terrat_dirspace.dir; workspace } = el.dirspace in
+                   `Assoc
+                     [
+                       ("dir", `String dir);
+                       ("workspace", `String workspace);
+                       ("status", `String (status_machine el.status));
+                       ("has_changes", `Bool el.has_changes);
+                       ( "created",
+                         CCOption.map_or ~default:`Null (fun n -> `Intlit (Int64.to_string n))
+                         @@ el.created );
+                       ( "updated",
+                         CCOption.map_or ~default:`Null (fun n -> `Intlit (Int64.to_string n))
+                         @@ el.updated );
+                       ( "deleted",
+                         CCOption.map_or ~default:`Null (fun n -> `Intlit (Int64.to_string n))
+                         @@ el.deleted );
+                       ( "replaced",
+                         CCOption.map_or ~default:`Null (fun n -> `Intlit (Int64.to_string n))
+                         @@ el.replaced );
+                       ( "run_url",
+                         CCOption.map_or ~default:`Null (fun url -> `String url) @@ run_url t el );
+                     ])
+                 els) );
+        ]
+    in
+    (* "--" may not appear inside an HTML comment; encode it away using JSON
+       unicode escapes so the payload stays valid JSON. *)
+    CCString.replace ~sub:"--" ~by:"\\u002d\\u002d" (Yojson.Safe.to_string json)
+
+  let render t tier els =
+    let module T = Unified.Tier in
+    let num_els = CCList.length els in
+    let shown =
+      match tier with
+      | T.Details _ | T.Table -> els
+      | T.Truncated n -> CCList.take n els
+    in
+    let details =
+      match tier with
+      | T.Details n ->
+          CCList.filter (fun el -> not (CCOption.is_none el.output)) (CCList.take n els)
+      | T.Table | T.Truncated _ -> []
+    in
+    let count_status status =
+      CCList.length (CCList.filter (fun el -> Unified.Status.compare el.status status = 0) els)
+    in
+    let kv =
+      `Assoc
+        [
+          ("num_dirspaces", `Int num_els);
+          ("num_failed", `Int (count_status Unified.Status.Failed));
+          ("num_planned", `Int (count_status Unified.Status.Planned));
+          ("num_pending", `Int (count_status Unified.Status.Pending));
+          ("num_applied", `Int (count_status Unified.Status.Applied));
+          ( "dirspaces",
+            `List
+              (CCList.map
+                 (fun el ->
+                   let { Terrat_dirspace.dir; workspace } = el.dirspace in
+                   `Assoc
+                     [
+                       ("dir", `String dir);
+                       ("workspace", `String workspace);
+                       ("status", `String (status_kv el.status));
+                       ("created", `String (count_kv el el.created));
+                       ("updated", `String (count_kv el el.updated));
+                       ("replaced", `String (count_kv el el.replaced));
+                       ("deleted", `String (count_kv el el.deleted));
+                       ( "run_url",
+                         CCOption.map_or ~default:`Null (fun url -> `String url) @@ run_url t el );
+                     ])
+                 shown) );
+          ( "totals",
+            `Assoc
+              [
+                ("created", `String (Int64.to_string (sum (fun el -> el.created) els)));
+                ("updated", `String (Int64.to_string (sum (fun el -> el.updated) els)));
+                ("replaced", `String (Int64.to_string (sum (fun el -> el.replaced) els)));
+                ("deleted", `String (Int64.to_string (sum (fun el -> el.deleted) els)));
+              ] );
+          ("truncated", `Int (num_els - CCList.length shown));
+          ("console_url", `String (console_url t));
+          ( "details",
+            `List
+              (CCList.map
+                 (fun el ->
+                   let { Terrat_dirspace.dir; workspace } = el.dirspace in
+                   `Assoc
+                     [
+                       ("dir", `String dir);
+                       ("workspace", `String workspace);
+                       ("output", `String (CCOption.get_or ~default:"" el.output));
+                     ])
+                 details) );
+          ( "show_apply_hint",
+            `Bool
+              (CCList.exists
+                 (fun el ->
+                   Unified.Status.compare el.status Unified.Status.Planned = 0 && el.has_changes)
+                 els) );
+          ( "machine",
+            match tier with
+            | T.Details _ | T.Table -> `String (machine_kv t els)
+            | T.Truncated _ -> `Null );
+        ]
+    in
+    match Minijinja.render_template Tmpl.unified_comment kv with
+    | Ok body -> body
+    | Error err ->
+        Logs.err (fun m -> m "%s : ERROR : %s" t.request_id err);
+        assert false
+
+  let update_comment t comment_id body =
+    let open Abb.Future.Infix_monad in
+    Terrat_github.update_comment
+      ~owner:t.repo_owner
+      ~repo:t.repo_name
+      ~comment_id:
+        (Api.Comment.Id.to_string comment_id |> CCInt.of_string |> CCOption.get_exn_or "comment_id")
+      ~body
+      t.client
+    >>= function
+    | Ok () -> Abb.Future.return (Ok ())
+    | Error `Not_found -> Abb.Future.return (Error `Not_found)
+    | Error (#Terrat_github.update_comment_err as err) ->
+        Logs.err (fun m -> m "%s : ERROR : %a" t.request_id Terrat_github.pp_update_comment_err err);
+        Abb.Future.return (Error `Error)
+
+  let post_comment t body =
+    let open Abb.Future.Infix_monad in
+    Terrat_github.publish_comment
+      ~owner:t.repo_owner
+      ~repo:t.repo_name
+      ~pull_number:(CCInt64.to_int t.pull_number)
+      ~body
+      t.client
+    >>= function
+    | Ok comment_id -> (
+        match Api.Comment.Id.of_string (CCInt.to_string comment_id) with
+        | Some comment_id -> Abb.Future.return (Ok comment_id)
+        | None -> Abb.Future.return (Error `Error))
+    | Error (#Terrat_github.publish_comment_err as err) ->
+        Logs.err (fun m ->
+            m "%s : ERROR : %a" t.request_id Terrat_github.pp_publish_comment_err err);
+        Abb.Future.return (Error `Error)
+
+  let upsert_comment_id t comment_id =
+    let open Abb.Future.Infix_monad in
+    Pgsql_io.Prepared_stmt.execute
+      t.db
+      Sql.update_unified_comment_id
+      (Int64.of_int
+         (Api.Comment.Id.to_string comment_id |> CCInt.of_string |> CCOption.get_exn_or "comment_id"))
+      t.repository
+      t.pull_number
+    >>= function
+    | Ok () -> Abb.Future.return (Ok ())
+    | Error (#Pgsql_io.err as err) ->
+        Logs.err (fun m -> m "%s : ERROR : %a" t.request_id Pgsql_io.pp_err err);
+        Abb.Future.return (Error `Error)
+
+  let dirspace el = el.dirspace
+  let status el = el.status
+  let has_changes el = el.has_changes
+
+  (* GitHub limits comments to 65536 characters.  Leave some margin for
+     good measure. *)
+  let max_comment_length = 65536 - 512
+end
+
+module Publisher = Unified.Make (S)
+
+let mark_dirty ~request_id db work_manifest_id =
+  let open Abb.Future.Infix_monad in
+  Pgsql_io.Prepared_stmt.execute db Sql.upsert_unified_comment_dirty work_manifest_id
+  >>= function
+  | Ok () -> Abb.Future.return (Ok ())
+  | Error (#Pgsql_io.err as err) ->
+      Logs.err (fun m -> m "%s : ERROR : %a" request_id Pgsql_io.pp_err err);
+      Abb.Future.return (Error `Error)
+
+let mark_dirty_if_tracked ~request_id db work_manifest_id =
+  let open Abb.Future.Infix_monad in
+  Pgsql_io.Prepared_stmt.execute db Sql.mark_unified_comment_dirty work_manifest_id
+  >>= function
+  | Ok () -> Abb.Future.return (Ok ())
+  | Error (#Pgsql_io.err as err) ->
+      Logs.err (fun m -> m "%s : ERROR : %a" request_id Pgsql_io.pp_err err);
+      Abb.Future.return (Error `Error)
+
+(* One refresh attempt.  Runs in its own transaction on its own connection so
+   the advisory lock and the GitHub API calls never extend a result
+   transaction.  Returns [`Race] when new results marked the comment dirty
+   while we were publishing, in which case the caller retries. *)
+let refresh ~request_id config storage work_manifest_id =
+  let open Abbs_future_combinators.Infix_result_monad in
+  Pgsql_pool.with_conn storage ~f:(fun db ->
+      Pgsql_io.tx db ~f:(fun () ->
+          Pgsql_io.Prepared_stmt.fetch
+            db
+            Sql.select_unified_comment_state
+            ~f:(fun repository pull_number installation_id repo_owner repo_name comment_id dirty ->
+              (repository, pull_number, installation_id, repo_owner, repo_name, comment_id, dirty))
+            work_manifest_id
+          >>= function
+          | [] | (_, _, _, _, _, _, 0L) :: _ -> Abb.Future.return (Ok `Done)
+          | (repository, pull_number, installation_id, repo_owner, repo_name, comment_id, dirty)
+            :: _ -> (
+              let key = Printf.sprintf "%Ld:%Ld" repository pull_number in
+              Pgsql_io.Prepared_stmt.fetch db Sql.try_advisory_lock ~f:CCFun.id key
+              >>= function
+              | [ false ] ->
+                  (* Another drain is publishing; it will pick up our dirty
+                     mark or the next result will. *)
+                  Abb.Future.return (Ok `Done)
+              | _ -> (
+                  let account = Api.Account.make (CCInt64.to_int installation_id) in
+                  Api.create_client ~request_id config account db
+                  >>= fun client ->
+                  let t =
+                    {
+                      S.account;
+                      client = Api.Client.to_native client;
+                      comment_id =
+                        CCOption.flat_map
+                          CCFun.(Int64.to_string %> Api.Comment.Id.of_string)
+                          comment_id;
+                      config;
+                      db;
+                      pull_number;
+                      repo_name;
+                      repo_owner;
+                      repository;
+                      request_id;
+                      work_manifest_id;
+                    }
+                  in
+                  Publisher.run t
+                  >>= fun () ->
+                  Pgsql_io.Prepared_stmt.fetch
+                    db
+                    Sql.clear_unified_comment_dirty
+                    ~f:CCFun.id
+                    repository
+                    pull_number
+                    dirty
+                  >>= function
+                  | [] -> Abb.Future.return (Ok `Race)
+                  | _ :: _ -> Abb.Future.return (Ok `Done)))))
+
+let drain ~request_id config storage work_manifest_id =
+  let open Abb.Future.Infix_monad in
+  let rec attempt n =
+    if n <= 0 then (
+      (* The dirty counter is still set; the next drain of this pull request
+         picks it up. *)
+      Logs.warn (fun m ->
+          m
+            "%s : DRAIN_UNIFIED_COMMENT : RETRIES_EXHAUSTED : %a"
+            request_id
+            Uuidm.pp
+            work_manifest_id);
+      Abb.Future.return (Ok `Done))
+    else
+      refresh ~request_id config storage work_manifest_id
+      >>= function
+      | Ok `Done -> Abb.Future.return (Ok `Done)
+      | Ok `Race -> attempt (n - 1)
+      | Error _ as err -> Abb.Future.return err
+  in
+  attempt 3
+  >>= function
+  | Ok `Done -> Abb.Future.return ()
+  | Error `Error ->
+      Logs.err (fun m -> m "%s : DRAIN_UNIFIED_COMMENT : ERROR" request_id);
+      Abb.Future.return ()
+  | Error (#Pgsql_pool.err as err) ->
+      Logs.err (fun m -> m "%s : DRAIN_UNIFIED_COMMENT : %a" request_id Pgsql_pool.pp_err err);
+      Abb.Future.return ()
+  | Error (#Pgsql_io.err as err) ->
+      Logs.err (fun m -> m "%s : DRAIN_UNIFIED_COMMENT : %a" request_id Pgsql_io.pp_err err);
+      Abb.Future.return ()

--- a/code/src/terrat_vcs_github_comment/terrat_vcs_github_comment_unified.mli
+++ b/code/src/terrat_vcs_github_comment/terrat_vcs_github_comment_unified.mli
@@ -1,0 +1,25 @@
+(** GitHub implementation of the unified pull request summary comment.
+
+    The flow has two halves. While a work manifest result is being processed (inside its
+    transaction), {!mark_dirty} bumps the dirty counter of the pull request's tracking row so the
+    refresh is committed atomically with the results. After the transaction commits, {!drain} runs
+    on a fresh connection: it takes an advisory lock so only one publisher runs per pull request,
+    recomputes the state of every dirspace, renders it, updates the tracked comment in place
+    (posting a new one if it disappeared), and clears the dirty counter it observed. If new results
+    arrived while publishing, the counter no longer matches and it retries. *)
+
+val mark_dirty :
+  request_id:string -> Pgsql_io.t -> Uuidm.t -> (unit, [> `Error ]) result Abb.Future.t
+
+(** Like {!mark_dirty} but never creates the tracking row, so pull requests that do not publish a
+    unified comment are unaffected. Used by failure paths, which cannot cheaply consult the repo
+    config. *)
+val mark_dirty_if_tracked :
+  request_id:string -> Pgsql_io.t -> Uuidm.t -> (unit, [> `Error ]) result Abb.Future.t
+
+val drain :
+  request_id:string ->
+  Terrat_vcs_api_github.Config.t ->
+  Pgsql_pool.t ->
+  Uuidm.t ->
+  unit Abb.Future.t

--- a/code/src/terrat_vcs_github_comment_templates/terrat_vcs_github_comment_templates.ml
+++ b/code/src/terrat_vcs_github_comment_templates/terrat_vcs_github_comment_templates.ml
@@ -182,6 +182,7 @@ module Tmpl = struct
 
   let plan_complete2 = jinja [%blob "tmpl/plan_complete2.tmpl"]
   let apply_complete2 = jinja [%blob "tmpl/apply_complete2.tmpl"]
+  let unified_comment = jinja [%blob "tmpl/unified_comment.tmpl"]
   let automerge_failure = read [%blob "tmpl/automerge_error.tmpl"]
 
   let premium_feature_err_access_control =

--- a/code/src/terrat_vcs_github_comment_templates/tmpl/unified_comment.tmpl
+++ b/code/src/terrat_vcs_github_comment_templates/tmpl/unified_comment.tmpl
@@ -1,0 +1,43 @@
+# Terrateam Summary
+
+**{{ num_dirspaces }} dirspace{{ 's' if num_dirspaces != 1 else '' }}** · {{ num_failed }} failed · {{ num_planned }} planned · {{ num_pending }} pending · {{ num_applied }} applied
+
+| Directory | Workspace | Status | Created | Updated | Replaced | Deleted |
+| --- | --- | :---: | :---: | :---: | :---: | :---: |
+{%- for d in dirspaces %}
+| {% if d.run_url %}[`{{ d.dir }}`]({{ d.run_url }}){% else %}`{{ d.dir }}`{% endif %} | `{{ d.workspace }}` | {{ d.status }} | {{ d.created }} | {{ d.updated }} | {{ d.replaced }} | {{ d.deleted }} |
+{%- endfor %}
+| **Total** | | | **{{ totals.created }}** | **{{ totals.updated }}** | **{{ totals.replaced }}** | **{{ totals.deleted }}** |
+{%- if truncated > 0 %}
+
+… {{ truncated }} more dirspace{{ 's' if truncated != 1 else '' }} not shown{% if console_url %} — see the [Terrateam Console]({{ console_url }}){% endif %}.
+{%- endif %}
+{%- if details %}
+
+## Output details
+{%- for d in details %}
+
+<details>
+  <summary>{{ d.dir }} | {{ d.workspace }}</summary>
+
+```diff
+{{ d.output }}
+```
+
+</details>
+{%- endfor %}
+{%- endif %}
+{%- if show_apply_hint %}
+
+---
+
+To apply all these changes, comment:
+
+```
+terrateam apply
+```
+{%- endif %}
+{%- if machine %}
+
+<!-- terrateam:unified:v1 {{ machine }} -->
+{%- endif %}

--- a/code/src/terrat_vcs_provider2/dune
+++ b/code/src/terrat_vcs_provider2/dune
@@ -4,6 +4,8 @@
   abb
   jsonu
   pgsql_io
+  pgsql_pool
+  uuidm
   str_template
   terrat_access_control2
   terrat_api

--- a/code/src/terrat_vcs_provider2/terrat_vcs_provider2.ml
+++ b/code/src/terrat_vcs_provider2/terrat_vcs_provider2.ml
@@ -513,6 +513,18 @@ module type S = sig
         Api.Config.t )
       Msg.t ->
       (unit, [> `Error ]) result Abb.Future.t
+
+    (** Refresh the unified summary comment of the pull request the given work manifest belongs to,
+        if it has been marked dirty. Runs on its own connections after the result transaction
+        commits and is best effort: it must log and swallow its errors. *)
+    val drain_unified_comment :
+      request_id:string -> Api.Config.t -> Pgsql_pool.t -> Uuidm.t -> unit Abb.Future.t
+
+    (** Mark the unified summary comment of the work manifest's pull request as needing a refresh,
+        but only if the pull request already tracks one. Used by failure paths so aborted runs show
+        up in the comment. *)
+    val mark_unified_comment_dirty :
+      request_id:string -> Db.t -> Uuidm.t -> (unit, [> `Error ]) result Abb.Future.t
   end
 
   module Repo_config : sig

--- a/code/src/terrat_vcs_provider2_nyi/terrat_vcs_provider2_nyi.ml
+++ b/code/src/terrat_vcs_provider2_nyi/terrat_vcs_provider2_nyi.ml
@@ -99,6 +99,8 @@ end
 
 module Comment = struct
   let publish_comment ~request_id client user pull_request msg = raise (Failure "nyi")
+  let drain_unified_comment ~request_id config storage work_manifest_id = raise (Failure "nyi")
+  let mark_unified_comment_dirty ~request_id db work_manifest_id = raise (Failure "nyi")
 end
 
 module Repo_config = struct

--- a/code/src/terrat_vcs_service_github/sql/delete_repo.sql
+++ b/code/src/terrat_vcs_service_github/sql/delete_repo.sql
@@ -22,6 +22,13 @@ delete_work_manifest_comments as (
         and gir.id = $repo_id
         and gir.installation_id = $installation_id
 ),
+delete_unified_comments as (
+    delete from github_unified_comments
+    using github_installation_repositories as gir
+    where github_unified_comments.repository = gir.id
+        and gir.id = $repo_id
+        and gir.installation_id = $installation_id
+),
 delete_plans as (
     delete from plans
     using work_manifests as wm, repo as r

--- a/code/src/terrat_vcs_service_github/terrat_vcs_service_github_provider.ml
+++ b/code/src/terrat_vcs_service_github/terrat_vcs_service_github_provider.ml
@@ -4149,22 +4149,51 @@ module Comment = struct
           work_manifest;
         } -> (
         let open Abb.Future.Infix_monad in
-        Result.Publisher3.post_comment
-          request_id
-          account_status
-          config
-          client
-          db
-          is_layered_run
-          remaining_layers
-          repo_config
-          result
-          pull_request
-          synthesized_config
-          work_manifest
-        >>= function
-        | Ok cid -> Abb.Future.return (Ok cid)
-        | Error _ -> Abb.Future.return (Error `Error))
+        let module V1 = Terrat_base_repo_config_v1 in
+        let module N = V1.Notifications in
+        let module R2 = Terrat_api_components.Work_manifest_tf_operation_result2 in
+        let module Wm = Terrat_work_manifest3 in
+        let post_classic () =
+          Result.Publisher3.post_comment
+            request_id
+            account_status
+            config
+            client
+            db
+            is_layered_run
+            remaining_layers
+            repo_config
+            result
+            pull_request
+            synthesized_config
+            work_manifest
+          >>= function
+          | Ok cid -> Abb.Future.return (Ok cid)
+          | Error _ -> Abb.Future.return (Error `Error)
+        in
+        let { N.summary = { N.Summary.enabled; mode }; _ } = V1.notifications repo_config in
+        let unified =
+          enabled
+          &&
+          match mode with
+          | N.Summary.Mode.Pull_request -> true
+          | N.Summary.Mode.Header -> false
+        in
+        if not unified then post_classic ()
+        else
+          (* The unified summary comment replaces the per work manifest result
+             comment.  Gates and access control denials have no other surface,
+             so results carrying them still post the classic comment. *)
+          Terrat_vcs_github_comment_unified.mark_dirty ~request_id db work_manifest.Wm.id
+          >>= function
+          | Ok () -> (
+              match (result.R2.gates, work_manifest.Wm.denied_dirspaces) with
+              | (None | Some []), [] -> Abb.Future.return (Ok ())
+              | _, _ -> post_classic ())
+          | Error `Error ->
+              (* If the refresh cannot be tracked, fall back to the classic
+                 comment rather than losing the output entirely. *)
+              post_classic ())
     | Msg.Tier_check checks ->
         let module C = Terrat_tier.Check in
         let { C.tier_name; users_per_month; runs_per_month } = checks in
@@ -4238,6 +4267,12 @@ module Comment = struct
              "WORK_MANIFEST_RUN_FAILED"
              Tmpl.work_manifest_run_failed
              kv
+
+  let drain_unified_comment ~request_id config storage work_manifest_id =
+    Terrat_vcs_github_comment_unified.drain ~request_id config storage work_manifest_id
+
+  let mark_unified_comment_dirty ~request_id db work_manifest_id =
+    Terrat_vcs_github_comment_unified.mark_dirty_if_tracked ~request_id db work_manifest_id
 end
 
 module Repo_config = struct
@@ -4386,7 +4421,7 @@ module Repo_config = struct
              checks -> Abb.Future.return (Error (`Premium_feature_err `Require_completed_reviews))
     | {
      V1.View.notifications =
-       { V1.Notifications.summary = { V1.Notifications.Summary.enabled = true }; _ };
+       { V1.Notifications.summary = { V1.Notifications.Summary.enabled = true; _ }; _ };
      _;
     } -> Abb.Future.return (Error (`Premium_feature_err `Notifications_summary))
     | _ -> Abb.Future.return (Ok (provenance, final_repo_config))

--- a/code/src/terrat_vcs_service_gitlab/terrat_vcs_service_gitlab_provider.ml
+++ b/code/src/terrat_vcs_service_gitlab/terrat_vcs_service_gitlab_provider.ml
@@ -4087,6 +4087,10 @@ module Comment = struct
              "WORK_MANIFEST_RUN_FAILED"
              Tmpl.work_manifest_run_failed
              kv
+
+  (* The unified summary comment is not implemented for GitLab yet. *)
+  let drain_unified_comment ~request_id:_ _config _storage _work_manifest_id = Abb.Future.return ()
+  let mark_unified_comment_dirty ~request_id:_ _db _work_manifest_id = Abb.Future.return (Ok ())
 end
 
 module Repo_config = struct
@@ -4235,7 +4239,7 @@ module Repo_config = struct
              checks -> Abb.Future.return (Error (`Premium_feature_err `Require_completed_reviews))
     | {
      V1.View.notifications =
-       { V1.Notifications.summary = { V1.Notifications.Summary.enabled = true }; _ };
+       { V1.Notifications.summary = { V1.Notifications.Summary.enabled = true; _ }; _ };
      _;
     } -> Abb.Future.return (Error (`Premium_feature_err `Notifications_summary))
     | _ -> Abb.Future.return (Ok (provenance, final_repo_config))

--- a/docs/src/content/docs/editions.mdx
+++ b/docs/src/content/docs/editions.mdx
@@ -31,7 +31,7 @@ Terrateam ships in two editions: the **Open Source Edition** (MPL-2.0, free) and
 | [Gatekeeper](/governance/gatekeeper) (manual approval gates with tokens) | ❌ | ✅ |
 | [Centralized Configuration](/governance/centralized-config) (defaults/overrides across repos) | ❌ | ✅ |
 | [API Access Tokens](/reference/api/access-tokens) (`/api/v1/{vcs}/access-token`) | ❌ | ✅ |
-| [Comment summary header](/reference/configuration/notifications) (`notifications.summary`) | ❌ | ✅ |
+| [Comment summary header and unified PR summary comment](/reference/configuration/notifications) (`notifications.summary`) | ❌ | ✅ |
 | Self-hostable | ✅ | ✅ (Enterprise license) |
 | License | MPL-2.0 | Commercial |
 

--- a/docs/src/content/docs/reference/configuration/notifications.mdx
+++ b/docs/src/content/docs/reference/configuration/notifications.mdx
@@ -36,6 +36,7 @@ The summary header is an [Enterprise](/editions) feature. Enabling it on the Ope
 | Key | Type | Description |
 | --- | --- | --- |
 | `enabled` | boolean | When `true`, each plan and apply comment starts with a summary header: a one-line rollup and a table of the dirspaces (directory and workspace combinations) executed in that comment, with their result and, for plans, whether there are changes. This lets reviewers see what a comment covers without expanding the full output. Default is `false`. |
+| `mode` | string | How the summary is presented. Values are `header` (the per-comment summary header described above) or `pull_request` (a single unified summary comment maintained for the whole pull request). Default is `header`. |
 
 The summary header is rendered above the collapsed plan/apply output. Enable it (Enterprise only):
 
@@ -44,6 +45,33 @@ notifications:
   summary:
     enabled: true
 ```
+
+#### Pull Request Mode
+
+With `mode: pull_request`, Terrateam maintains one summary comment per pull request instead of a header on every plan and apply comment. The comment is created when the first result arrives and updated in place as each subsequent run finishes, so reviewers always have a single up-to-date view of the pull request.
+
+The unified comment contains a table with one row per dirspace (directory and workspace combination):
+
+- **Status**: `Pending`, `Planned`, `Applied`, or `Failed`.
+- **Change counts**: `Created`, `Updated`, `Replaced`, and `Deleted`, parsed from the plan/apply output. `Replaced` is not yet populated and shows `-`.
+- **Link**: a per-dirspace link to the Terrateam console.
+
+A totals row sums the change counts across all dirspaces. Rows are sorted with failures first, then dirspaces with changes.
+
+In this mode the regular per-run plan and apply output comments are not posted; the full output is available in the Terrateam console via the links in the table. The exception is results carrying gate approvals or access control denials, which still post their own comment.
+
+If the table is too large to fit in a single comment, it is truncated to the top rows with a link to the console for the full list.
+
+Enable it (Enterprise only):
+
+```yaml
+notifications:
+  summary:
+    enabled: true
+    mode: pull_request
+```
+
+Both `mode` values require `enabled: true`, which is an [Enterprise](/editions) feature.
 
 ## Examples
 ### Multiple Comment Strategies for Diferent Dirspaces


### PR DESCRIPTION
## Description

Adds the GitHub implementation for `notifications.summary.mode: pull_request`.

This final integration layer wires together the earlier stack pieces:

- marks and drains unified comment dirty state from evaluator paths;
- recomputes PR dirspace state from storage;
- renders the GitHub summary table/template;
- updates the tracked PR comment in place, reposting if it was deleted;
- suppresses per-work-manifest result comments in pull-request summary mode except for gates/access-control denials;
- documents the final user-facing configuration.

This PR replaces the review shape of the larger draft #1473. The net final branch is byte-for-byte equivalent to #1473, but split into smaller review units.

## Stack

Base: #1476

1. #1471: `abb_curl` PATCH body fix
2. #1472: unified-comment table plus concurrent index migration
3. #1474: summary mode config surface
4. #1475: unified comment renderer and tests
5. #1476: pull request comment update API
6. This PR: GitHub unified summary comment integration
7. terrateamio/action#618: runner `resource_summary` counts

## Validation

Live validation from the original #1396 proof-of-work still applies: multi-dirspace consolidation, sorting, in-place update on push, apply state retention, delete-comment repost, `mode: header` parity, `> 20` dirspace table-only behavior, concurrency convergence to one comment, and structured counts from terraform/tofu/terragrunt/stategraph.

Local validation in this rebuilt stack:

- `git diff --check 1214-unified-comment-index..1214-github-unified-comment`
- `git diff --exit-code 1214-unified-pr-comments-stack 1214-github-unified-comment`
- Attempted `make -C code terrat`; local run could not complete because the temporary worktree filled the root filesystem while dune was creating sandbox directories (`No space left on device`).

Part of #1214. Supersedes #1473.