### PR TITLE
Promote stategraph staging 2026-08-07-15_36_19

### DIFF
--- a/code/src/terrat_vcs_github_comment/terrat_vcs_github_comment.ml
+++ b/code/src/terrat_vcs_github_comment/terrat_vcs_github_comment.ml
@@ -284,9 +284,18 @@ module S = struct
     let by_dirspace = CCList.map (fun el -> (Scope.Dirspace el.dirspace, el.steps)) els in
     let by_scope = t.hooks @ by_dirspace in
     let compact = CCList.exists (fun { compact; _ } -> compact) els in
+    (* Only the elements that are themselves oversized lose their step output. Previously any single
+       oversized element forced the compact view on the whole comment, so a large plan diff on one
+       dirspace erased the error text on every other one (#1540). *)
+    let compacted_dirspaces =
+      CCList.filter_map
+        (fun { compact; dirspace; _ } -> if compact then Some dirspace else None)
+        els
+    in
     let body =
       Publisher_tools.create_run_output
         ~view:(if compact then `Compact else `Full)
+        ~compacted_dirspaces
         ~summary
         ~pull_number
         ~dirspace_run_urls
@@ -312,6 +321,7 @@ module S = struct
         let body =
           Publisher_tools.create_run_output
             ~view:`Compact
+            ~compacted_dirspaces:(CCList.map (fun { dirspace; _ } -> dirspace) els)
             ~summary
             ~pull_number
             ~dirspace_run_urls
@@ -337,6 +347,7 @@ module S = struct
             let body =
               Publisher_tools.create_run_output
                 ~view:`Compact
+                ~compacted_dirspaces:(CCList.map (fun { dirspace; _ } -> dirspace) els)
                 ~summary
                 ~pull_number
                 ~dirspace_run_urls
@@ -366,9 +377,18 @@ module S = struct
     let by_dirspace = CCList.map (fun el -> (Scope.Dirspace el.dirspace, el.steps)) els in
     let by_scope = t.hooks @ by_dirspace in
     let compact = CCList.exists (fun { compact; _ } -> compact) els in
+    (* Only the elements that are themselves oversized lose their step output. Previously any single
+       oversized element forced the compact view on the whole comment, so a large plan diff on one
+       dirspace erased the error text on every other one (#1540). *)
+    let compacted_dirspaces =
+      CCList.filter_map
+        (fun { compact; dirspace; _ } -> if compact then Some dirspace else None)
+        els
+    in
     let body =
       Publisher_tools.create_run_output
         ~view:(if compact then `Compact else `Full)
+        ~compacted_dirspaces
         ~summary
         ~pull_number
         ~dirspace_run_urls

--- a/code/src/terrat_vcs_github_comment/terrat_vcs_github_comment_publishers.ml
+++ b/code/src/terrat_vcs_github_comment/terrat_vcs_github_comment_publishers.ml
@@ -7,11 +7,31 @@ module Tmpl = Terrat_vcs_github_comment_templates.Tmpl
 module Ui = Terrat_vcs_github_comment_ui.Ui
 module Visible_on = Terrat_base_repo_config_v1.Workflow_step.Visible_on
 
+(* How much of a FAILING step's output to keep when a comment has to shrink. Terraform and its
+   providers emit the error at the END of the output, so the tail is the part worth keeping. *)
+let failing_output_budget = 4000
+
+let tail_of ~max_bytes s =
+  if CCString.length s <= max_bytes then s
+  else
+    let cut = CCString.length s - max_bytes in
+    (* Resume at a line boundary so the kept text does not start mid-line. *)
+    let start =
+      match CCString.find ~start:cut ~sub:"\n" s with
+      | -1 -> cut
+      | i -> i + 1
+    in
+    "[... earlier output trimmed to fit the comment ...]\n"
+    ^ CCString.sub s start (CCString.length s - start)
+
 module Output = struct
   type t = {
     cmd : string option;
     name : string;
     raw : bool;
+    (* False once compaction has taken this step's output away. The template renders a placeholder
+       instead of [text]. *)
+    show_output : bool;
     success : bool;
     text : string;
     text_decorator : string option;
@@ -21,21 +41,45 @@ module Output = struct
   let make ?cmd ?text_decorator ?(raw = false) ~name ~success ~text ~visible_on () =
     (* If name looks like <namespace>/<action> then remove the namespace *)
     let name = CCOption.map_or ~default:name snd (CCString.Split.right ~by:"/" name) in
-    { cmd; name; raw; success; text; text_decorator; visible_on }
+    { cmd; name; raw; show_output = true; success; text; text_decorator; visible_on }
 
-  let to_kv { cmd; name; raw; success; text; text_decorator; visible_on = _ } =
+  let to_kv { cmd; name; raw; show_output; success; text; text_decorator; visible_on = _ } =
     `Assoc
       (CCList.flatten
          [
            [
              ("name", `String name);
              ("text", `String text);
+             ("show_output", `Bool show_output);
              ("success", `Bool success);
              ("raw", `Bool raw);
              ("text_decorator", `String (CCOption.get_or ~default:"" text_decorator));
            ];
            CCOption.map_or ~default:[] (fun cmd -> [ ("cmd", `String cmd) ]) cmd;
          ])
+
+  (* Compaction in priority order. A comment that is too long has to lose something, and the last
+     thing it should lose is the output saying why the run failed -- dropping every step's output
+     wholesale is what made a 403 from a provider unreadable (#1540).
+
+     A succeeding step's output is confirmation, not information, so it goes first. A failing step
+     keeps its output, trimmed to the tail. *)
+  let compact outputs =
+    CCList.map
+      (fun ({
+              cmd = _;
+              name = _;
+              raw = _;
+              show_output = _;
+              success;
+              text;
+              text_decorator = _;
+              visible_on = _;
+            } as o)
+         ->
+        if success then { o with show_output = false; text = "" }
+        else { o with text = tail_of ~max_bytes:failing_output_budget text })
+      outputs
 
   let filter ~overall_success =
     CCList.filter (fun { visible_on; _ } ->
@@ -303,6 +347,7 @@ end
 module Publisher_tools = struct
   let create_run_output
       ~view
+      ~compacted_dirspaces
       ~summary
       ~pull_number
       ~dirspace_run_urls
@@ -318,6 +363,12 @@ module Publisher_tools = struct
       work_manifest =
     let module Wm = Terrat_work_manifest3 in
     let module O = Terrat_api_components.Workflow_step_output in
+    let compact_if cond outputs = if cond then Output.compact outputs else outputs in
+    (* Per-dirspace, so one oversized plan diff cannot blank the error text on every OTHER dirspace
+       in the same comment (#1540). *)
+    let is_compacted dirspace =
+      CCList.exists (fun d -> Terrat_dirspace.compare d dirspace = 0) compacted_dirspaces
+    in
     let hooks_pre =
       CCList.Assoc.get ~eq:Scope.equal (Scope.Run { flow = "hooks"; subflow = "pre" }) by_scope
     in
@@ -430,6 +481,7 @@ module Publisher_tools = struct
                    |> CCOption.get_or ~default:[]
                    |> output_of_steps
                    |> Output.filter ~overall_success
+                   |> compact_if (view = `Compact)
                    |> kv_of_outputs) );
                ( "post_hooks",
                  `List
@@ -437,7 +489,10 @@ module Publisher_tools = struct
                    |> CCOption.get_or ~default:[]
                    |> output_of_steps
                    |> Output.filter ~overall_success
+                   |> compact_if (view = `Compact)
                    |> kv_of_outputs) );
+               (* Still drives structural choices in the template (collapsed sections, emoji);
+                  per-step output visibility is now [show_output] on each step. *)
                ("compact_view", `Bool (view = `Compact));
                ("compact_dirspaces", `Bool (CCList.length dirspaces > 5));
                ("summary", `Bool summary);
@@ -473,8 +528,11 @@ module Publisher_tools = struct
                                  ("success", `Bool success);
                                  ( "steps",
                                    `List
-                                     (kv_of_outputs
-                                        (Output.filter ~overall_success (output_of_steps steps))) );
+                                     (steps
+                                     |> output_of_steps
+                                     |> Output.filter ~overall_success
+                                     |> compact_if (is_compacted dirspace)
+                                     |> kv_of_outputs) );
                                  ("has_changes", `Bool has_changes);
                                  ("run_url", run_url);
                                  ("applied", `Bool applied);

--- a/code/src/terrat_vcs_github_comment/terrat_vcs_github_comment_publishers.mli
+++ b/code/src/terrat_vcs_github_comment/terrat_vcs_github_comment_publishers.mli
@@ -2,6 +2,12 @@ module Api = Terrat_vcs_api_github
 module Scope = Terrat_scope.Scope
 module Visible_on = Terrat_base_repo_config_v1.Workflow_step.Visible_on
 
+(** [tail_of ~max_bytes s] keeps the last [max_bytes] of [s], resuming at a line boundary and
+    prefixing a marker when anything was dropped. Terraform and provider errors are emitted at the
+    END of a step's output, so the tail is the part worth keeping when a comment has to shrink.
+    Exposed for testing. *)
+val tail_of : max_bytes:int -> string -> string
+
 val dirspace_compare :
   Terrat_dirspace.t * Terrat_api_components.Workflow_step_output.t list ->
   Terrat_dirspace.t * Terrat_api_components.Workflow_step_output.t list ->
@@ -38,6 +44,7 @@ end
 module Publisher_tools : sig
   val create_run_output :
     view:[> `Compact ] ->
+    compacted_dirspaces:Terrat_dirspace.t list ->
     summary:bool ->
     pull_number:int option ->
     dirspace_run_urls:(Terrat_dirspace.t * string) list ->

--- a/code/src/terrat_vcs_github_comment_templates/tmpl/apply_complete2.tmpl
+++ b/code/src/terrat_vcs_github_comment_templates/tmpl/apply_complete2.tmpl
@@ -99,7 +99,7 @@ Running plans **FAILED**.  See **Terrateam Apply Output**.
 
 **Details**: {{ h.details }}
       {%- endif %}
-      {%- if not compact_view %}
+      {%- if h.show_output %}
 {% if h.raw %}
 {{ h.text }}
 {% else %}
@@ -133,7 +133,7 @@ No output shown due to comment size.
 
 **Details**: {{ h.details }}
       {%- endif %}
-      {%- if not compact_view %}
+      {%- if h.show_output %}
 {% if h.raw %}
 {{ h.text }}
 {% else %}
@@ -187,7 +187,7 @@ No output shown due to comment size.
 
 **Details**: {{ s.details }}
     {%- endif %}
-    {%- if not compact_view %}
+    {%- if s.show_output %}
 
 ```
 {{ s.text }}

--- a/code/src/terrat_vcs_github_comment_templates/tmpl/plan_complete2.tmpl
+++ b/code/src/terrat_vcs_github_comment_templates/tmpl/plan_complete2.tmpl
@@ -166,7 +166,7 @@ After resolving the issue, run `terrateam plan` to execute the plan operation ag
       {% if h.details is defined %}
 **Details**: {{ h.details }}
       {% endif %}
-      {% if not compact_view %}
+      {% if h.show_output %}
 {% if h.raw %}
 {{ h.text }}
 {% else %}
@@ -197,7 +197,7 @@ No output shown due to comment size.
       {%- if h.details is defined %}
 **Details**: {{ h.details }}
       {%- endif %}
-      {% if not compact_view %}
+      {% if h.show_output %}
 {% if h.raw %}
 {{ h.text }}
 {% else %}
@@ -247,7 +247,7 @@ No output shown due to comment size.
     {%- if s.details is defined %}
 **Details**: {{ s.details }}
     {%- endif %}
-    {%- if not compact_view %}
+    {%- if s.show_output %}
 
 ```{{ s.text_decorator }}
 {{ s.text }}

--- a/code/src/terrat_vcs_gitlab_comment/terrat_vcs_gitlab_comment.ml
+++ b/code/src/terrat_vcs_gitlab_comment/terrat_vcs_gitlab_comment.ml
@@ -76,9 +76,18 @@ module S = struct
     let by_dirspace = CCList.map (fun el -> (Scope.Dirspace el.dirspace, el.steps)) els in
     let by_scope = t.hooks @ by_dirspace in
     let compact = CCList.exists (fun { compact; _ } -> compact) els in
+    (* Only the elements that are themselves oversized lose their step output. Previously any single
+       oversized element forced the compact view on the whole comment, so a large plan diff on one
+       dirspace erased the error text on every other one (#1540). *)
+    let compacted_dirspaces =
+      CCList.filter_map
+        (fun { compact; dirspace; _ } -> if compact then Some dirspace else None)
+        els
+    in
     let body =
       Publisher_tools.create_run_output
         ~view:(if compact then `Compact else `Full)
+        ~compacted_dirspaces
         ~summary
         ~pull_number
         ~dirspace_run_urls
@@ -103,6 +112,7 @@ module S = struct
         let body =
           Publisher_tools.create_run_output
             ~view:`Compact
+            ~compacted_dirspaces:(CCList.map (fun { dirspace; _ } -> dirspace) els)
             ~summary
             ~pull_number
             ~dirspace_run_urls
@@ -127,6 +137,7 @@ module S = struct
             let body =
               Publisher_tools.create_run_output
                 ~view:`Compact
+                ~compacted_dirspaces:(CCList.map (fun { dirspace; _ } -> dirspace) els)
                 ~summary
                 ~pull_number
                 ~dirspace_run_urls
@@ -154,9 +165,18 @@ module S = struct
     let by_dirspace = CCList.map (fun el -> (Scope.Dirspace el.dirspace, el.steps)) els in
     let by_scope = t.hooks @ by_dirspace in
     let compact = CCList.exists (fun { compact; _ } -> compact) els in
+    (* Only the elements that are themselves oversized lose their step output. Previously any single
+       oversized element forced the compact view on the whole comment, so a large plan diff on one
+       dirspace erased the error text on every other one (#1540). *)
+    let compacted_dirspaces =
+      CCList.filter_map
+        (fun { compact; dirspace; _ } -> if compact then Some dirspace else None)
+        els
+    in
     let body =
       Publisher_tools.create_run_output
         ~view:(if compact then `Compact else `Full)
+        ~compacted_dirspaces
         ~summary
         ~pull_number
         ~dirspace_run_urls

--- a/code/src/terrat_vcs_gitlab_comment/terrat_vcs_gitlab_comment_publishers.ml
+++ b/code/src/terrat_vcs_gitlab_comment/terrat_vcs_gitlab_comment_publishers.ml
@@ -7,11 +7,31 @@ module Tmpl = Terrat_vcs_gitlab_comment_templates.Tmpl
 module Ui = Terrat_vcs_gitlab_comment_ui.Ui
 module Visible_on = Terrat_base_repo_config_v1.Workflow_step.Visible_on
 
+(* How much of a FAILING step's output to keep when a comment has to shrink. Terraform and its
+   providers emit the error at the END of the output, so the tail is the part worth keeping. *)
+let failing_output_budget = 4000
+
+let tail_of ~max_bytes s =
+  if CCString.length s <= max_bytes then s
+  else
+    let cut = CCString.length s - max_bytes in
+    (* Resume at a line boundary so the kept text does not start mid-line. *)
+    let start =
+      match CCString.find ~start:cut ~sub:"\n" s with
+      | -1 -> cut
+      | i -> i + 1
+    in
+    "[... earlier output trimmed to fit the comment ...]\n"
+    ^ CCString.sub s start (CCString.length s - start)
+
 module Output = struct
   type t = {
     cmd : string option;
     name : string;
     raw : bool;
+    (* False once compaction has taken this step's output away. The template renders a placeholder
+       instead of [text]. *)
+    show_output : bool;
     success : bool;
     text : string;
     text_decorator : string option;
@@ -21,21 +41,45 @@ module Output = struct
   let make ?cmd ?text_decorator ?(raw = false) ~name ~success ~text ~visible_on () =
     (* If name looks like <namespace>/<action> then remove the namespace *)
     let name = CCOption.map_or ~default:name snd (CCString.Split.right ~by:"/" name) in
-    { cmd; name; raw; success; text; text_decorator; visible_on }
+    { cmd; name; raw; show_output = true; success; text; text_decorator; visible_on }
 
-  let to_kv { cmd; name; raw; success; text; text_decorator; visible_on = _ } =
+  let to_kv { cmd; name; raw; show_output; success; text; text_decorator; visible_on = _ } =
     `Assoc
       (CCList.flatten
          [
            [
              ("name", `String name);
              ("text", `String text);
+             ("show_output", `Bool show_output);
              ("success", `Bool success);
              ("raw", `Bool raw);
              ("text_decorator", `String (CCOption.get_or ~default:"" text_decorator));
            ];
            CCOption.map_or ~default:[] (fun cmd -> [ ("cmd", `String cmd) ]) cmd;
          ])
+
+  (* Compaction in priority order. A comment that is too long has to lose something, and the last
+     thing it should lose is the output saying why the run failed -- dropping every step's output
+     wholesale is what made a 403 from a provider unreadable (#1540).
+
+     A succeeding step's output is confirmation, not information, so it goes first. A failing step
+     keeps its output, trimmed to the tail. *)
+  let compact outputs =
+    CCList.map
+      (fun ({
+              cmd = _;
+              name = _;
+              raw = _;
+              show_output = _;
+              success;
+              text;
+              text_decorator = _;
+              visible_on = _;
+            } as o)
+         ->
+        if success then { o with show_output = false; text = "" }
+        else { o with text = tail_of ~max_bytes:failing_output_budget text })
+      outputs
 
   let filter ~overall_success =
     CCList.filter (fun { visible_on; _ } ->
@@ -305,6 +349,7 @@ end
 module Publisher_tools = struct
   let create_run_output
       ~view
+      ~compacted_dirspaces
       ~summary
       ~pull_number
       ~dirspace_run_urls
@@ -319,6 +364,12 @@ module Publisher_tools = struct
       work_manifest =
     let module Wm = Terrat_work_manifest3 in
     let module O = Terrat_api_components.Workflow_step_output in
+    let compact_if cond outputs = if cond then Output.compact outputs else outputs in
+    (* Per-dirspace, so one oversized plan diff cannot blank the error text on every OTHER dirspace
+       in the same comment (#1540). *)
+    let is_compacted dirspace =
+      CCList.exists (fun d -> Terrat_dirspace.compare d dirspace = 0) compacted_dirspaces
+    in
     let hooks_pre =
       CCList.Assoc.get ~eq:Scope.equal (Scope.Run { flow = "hooks"; subflow = "pre" }) by_scope
     in
@@ -431,6 +482,7 @@ module Publisher_tools = struct
                    |> CCOption.get_or ~default:[]
                    |> output_of_steps
                    |> Output.filter ~overall_success
+                   |> compact_if (view = `Compact)
                    |> kv_of_outputs) );
                ( "post_hooks",
                  `List
@@ -438,6 +490,7 @@ module Publisher_tools = struct
                    |> CCOption.get_or ~default:[]
                    |> output_of_steps
                    |> Output.filter ~overall_success
+                   |> compact_if (view = `Compact)
                    |> kv_of_outputs) );
                ("compact_view", `Bool (view = `Compact));
                ("compact_dirspaces", `Bool (CCList.length dirspaces > 5));
@@ -467,8 +520,11 @@ module Publisher_tools = struct
                                  ("success", `Bool success);
                                  ( "steps",
                                    `List
-                                     (kv_of_outputs
-                                        (Output.filter ~overall_success (output_of_steps steps))) );
+                                     (steps
+                                     |> output_of_steps
+                                     |> Output.filter ~overall_success
+                                     |> compact_if (is_compacted dirspace)
+                                     |> kv_of_outputs) );
                                  ("has_changes", `Bool has_changes);
                                  ("run_url", run_url);
                                ];

--- a/code/src/terrat_vcs_gitlab_comment/terrat_vcs_gitlab_comment_publishers.mli
+++ b/code/src/terrat_vcs_gitlab_comment/terrat_vcs_gitlab_comment_publishers.mli
@@ -2,6 +2,12 @@ module Api = Terrat_vcs_api_gitlab
 module Scope = Terrat_scope.Scope
 module Visible_on = Terrat_base_repo_config_v1.Workflow_step.Visible_on
 
+(** [tail_of ~max_bytes s] keeps the last [max_bytes] of [s], resuming at a line boundary and
+    prefixing a marker when anything was dropped. Terraform and provider errors are emitted at the
+    END of a step's output, so the tail is the part worth keeping when a comment has to shrink.
+    Exposed for testing. *)
+val tail_of : max_bytes:int -> string -> string
+
 val dirspace_compare :
   Terrat_dirspace.t * Terrat_api_components.Workflow_step_output.t list ->
   Terrat_dirspace.t * Terrat_api_components.Workflow_step_output.t list ->
@@ -38,6 +44,7 @@ end
 module Publisher_tools : sig
   val create_run_output :
     view:[> `Compact ] ->
+    compacted_dirspaces:Terrat_dirspace.t list ->
     summary:bool ->
     pull_number:int option ->
     dirspace_run_urls:(Terrat_dirspace.t * string) list ->

--- a/code/src/terrat_vcs_gitlab_comment_templates/tmpl/apply_complete2.tmpl
+++ b/code/src/terrat_vcs_gitlab_comment_templates/tmpl/apply_complete2.tmpl
@@ -99,7 +99,7 @@ Running plans **FAILED**.  See **Terrateam Apply Output**.
 
 **Details**: {{ h.details }}
       {%- endif %}
-      {%- if not compact_view %}
+      {%- if h.show_output %}
 {% if h.raw %}
 {{ h.text }}
 {% else %}
@@ -133,7 +133,7 @@ No output shown due to comment size.
 
 **Details**: {{ h.details }}
       {%- endif %}
-      {%- if not compact_view %}
+      {%- if h.show_output %}
 {% if h.raw %}
 {{ h.text }}
 {% else %}
@@ -178,7 +178,7 @@ No output shown due to comment size.
 
 **Details**: {{ s.details }}
     {%- endif %}
-    {%- if not compact_view %}
+    {%- if s.show_output %}
 
 ```
 {{ s.text }}

--- a/code/src/terrat_vcs_gitlab_comment_templates/tmpl/plan_complete2.tmpl
+++ b/code/src/terrat_vcs_gitlab_comment_templates/tmpl/plan_complete2.tmpl
@@ -166,7 +166,7 @@ After resolving the issue, run `terrateam plan` to execute the plan operation ag
       {% if h.details is defined %}
 **Details**: {{ h.details }}
       {% endif %}
-      {% if not compact_view %}
+      {% if h.show_output %}
 {% if h.raw %}
 {{ h.text }}
 {% else %}
@@ -197,7 +197,7 @@ No output shown due to comment size.
       {%- if h.details is defined %}
 **Details**: {{ h.details }}
       {%- endif %}
-      {% if not compact_view %}
+      {% if h.show_output %}
 {% if h.raw %}
 {{ h.text }}
 {% else %}
@@ -238,7 +238,7 @@ No output shown due to comment size.
     {%- if s.details is defined %}
 **Details**: {{ s.details }}
     {%- endif %}
-    {%- if not compact_view %}
+    {%- if s.show_output %}
 
 ```{{ s.text_decorator }}
 {{ s.text }}

--- a/code/tests/terrat_vcs_github_comment/dune
+++ b/code/tests/terrat_vcs_github_comment/dune
@@ -1,0 +1,3 @@
+(test
+ (name test)
+ (libraries containers oth terrat_vcs_github_comment))

--- a/code/tests/terrat_vcs_github_comment/test.ml
+++ b/code/tests/terrat_vcs_github_comment/test.ml
@@ -1,0 +1,46 @@
+(* When a comment is too large, step output has to be trimmed. Terraform and its providers emit the
+   error at the END of a step's output, so trimming must keep the tail -- keeping the head throws
+   away the only part anyone needs (#1540). *)
+
+module P = Terrat_vcs_github_comment_publishers
+
+let marker = "[... earlier output trimmed to fit the comment ...]"
+
+let test =
+  Oth.parallel
+    [
+      Oth.test ~name:"short output is returned untouched" (fun _ ->
+          let s = "line one\nline two\n" in
+          Oth.Assert.Eq.string ~expected:s ~actual:(P.tail_of ~max_bytes:1000 s));
+      Oth.test ~name:"output exactly at the budget is untouched" (fun _ ->
+          let s = CCString.repeat "a" 100 in
+          Oth.Assert.Eq.string ~expected:s ~actual:(P.tail_of ~max_bytes:100 s));
+      Oth.test ~name:"the tail is kept, not the head" (fun _ ->
+          (* The error is last, which is the whole point. *)
+          let s = CCString.repeat "noise\n" 500 ^ "Error: 403 Forbidden: read-only dashboard\n" in
+          let out = P.tail_of ~max_bytes:200 s in
+          Oth.Assert.str_contains ~haystack:out ~needle:"Error: 403 Forbidden";
+          Oth.Assert.true_ "trimmed output is bounded" (CCString.length out < 400));
+      Oth.test ~name:"a trim is announced" (fun _ ->
+          let s = CCString.repeat "x\n" 500 in
+          Oth.Assert.str_contains ~haystack:(P.tail_of ~max_bytes:50 s) ~needle:marker);
+      Oth.test ~name:"kept text resumes at a line boundary" (fun _ ->
+          let s = CCString.repeat "abcdefghij\n" 100 in
+          let out = P.tail_of ~max_bytes:35 s in
+          (* Everything after the marker line must be whole lines. *)
+          let body =
+            match CCString.Split.left ~by:"\n" out with
+            | Some (_marker_line, rest) -> rest
+            | None -> out
+          in
+          CCString.split ~by:"\n" body
+          |> CCList.filter (fun l -> l <> "")
+          |> CCList.iter (fun l -> Oth.Assert.Eq.string ~expected:"abcdefghij" ~actual:l));
+      Oth.test ~name:"output with no newline at all still trims" (fun _ ->
+          let s = CCString.repeat "z" 1000 in
+          let out = P.tail_of ~max_bytes:100 s in
+          Oth.Assert.str_contains ~haystack:out ~needle:marker;
+          Oth.Assert.true_ "bounded" (CCString.length out < 300));
+    ]
+
+let () = Oth.run ~file:__FILE__ ~setup:(fun () -> Ok ()) ~teardown:(fun _ -> ()) (fun _ -> test)


### PR DESCRIPTION
Automated copybara promotion from the staging repo.

Origin baseline: stategraph/stategraph-staging@main = db87edae7520c7b0a9ddf6617e4268dbcad010c3
Pass this SHA as `--last-rev` to resume a future promotion from here if copybara's recorded GitOrigin-RevId is unresolvable.