### PR TITLE
#1501 FIX Grant id-token permission to deploy job in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -213,6 +213,9 @@ jobs:
     needs: [set-version-tag, release-notify, create-multi-arch-manifest]
     if: ${{ needs.create-multi-arch-manifest.outputs.is_latest_version_tag == 'true' }}
     uses: ./.github/workflows/deploy.yml
+    permissions:
+      contents: read
+      id-token: write
     with:
       environment: ${{ github.event.inputs.environment || 'production' }}
       VERSION_TAG: ${{ needs.set-version-tag.outputs.version_tag }}


### PR DESCRIPTION
## Description

deploy job in release.yml calls deploy.yml (needs id-token: write) but grants no permissions, so release runs fail to parse. Adds contents: read, id-token: write.

Fixes #1501.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (explain):

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/stategraph/stategraph/blob/main/CONTRIBUTING.md)
- [x] The pull request title follows this format:
      `ISSUE_NUMBER ACTION_TYPE Short description` (e.g., `123 ADD Feature description`)
- [ ] I have added tests and documentation (if applicable)
- [x] My changes generate no new warnings/errors and do not break existing functionality

## Additional context (optional)

No tests: one-line workflow permissions fix, verified by the next release run succeeding.
