### PR TITLE
#1503 FIX Grant contents:write to set-version-tag and release-notify jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,8 @@ jobs:
   set-version-tag:
     runs-on: ubuntu-22.04
     environment: ${{ github.event.inputs.environment || 'production' }}
+    permissions:
+      contents: write
 
     outputs:
       version_tag: ${{ steps.set-version-tag.outputs.version_tag }}
@@ -170,6 +172,8 @@ jobs:
     needs: [set-version-tag, create-multi-arch-manifest]
     runs-on: ubuntu-22.04
     environment: ${{ github.event.inputs.environment || 'production' }}
+    permissions:
+      contents: write
 
     env:
       VERSION_TAG: ${{ needs.set-version-tag.outputs.version_tag }}


### PR DESCRIPTION
## Description

set-version-tag pushes a git tag and release-notify creates/uploads a GitHub release, both via GITHUB_TOKEN, but neither job grants contents: write, so both fail with 403 under the org's restrictive default token permissions. Adds permissions: contents: write to both (build already has this).

Fixes #1503.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (explain):

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/stategraph/stategraph/blob/main/CONTRIBUTING.md)
- [x] The pull request title follows this format:
      `ISSUE_NUMBER ACTION_TYPE Short description` (e.g., `123 ADD Feature description`)
- [ ] I have added tests and documentation (if applicable)
- [x] My changes generate no new warnings/errors and do not break existing functionality

## Additional context (optional)

No tests: workflow permissions fix, verified by the next release run succeeding.
