### PR TITLE
#1506 FIX Publish terrat-oss and terrat-ee to ghcr.io/terrateamio

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,6 +35,7 @@ jobs:
       TERRATEAM_ENVIRONMENT: ${{ inputs.environment }}
       FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
       MATRIX_PASSWORD: ${{ secrets.MATRIX_PASSWORD }}
+      GITHUB_REPOSITORY_OWNER: terrateamio
 
     permissions:
       contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,12 +80,20 @@ jobs:
         with:
           fetch-tags: true
 
+      - name: Generate terrateamio packages token
+        id: terrateamio-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.TERRATEAMIO_PACKAGES_APP_ID }}
+          private-key: ${{ secrets.TERRATEAMIO_PACKAGES_APP_PRIVATE_KEY }}
+          owner: terrateamio
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: x-access-token
+          password: ${{ steps.terrateamio-token.outputs.token }}
 
       - name: Set base image
         run: |
@@ -100,12 +108,12 @@ jobs:
           target: ${{ matrix.target }}
           build-args: |
             BASE_IMAGE=${{ env.BASE_IMAGE }}
-          tags: ghcr.io/${{ github.repository_owner }}/${{ matrix.target }}:${{ env.VERSION_TAG }}-${{ matrix.arch }}
+          tags: ghcr.io/terrateamio/${{ matrix.target }}:${{ env.VERSION_TAG }}-${{ matrix.arch }}
 
       - name: Extract ttm binary (${{ matrix.arch }})
         if: matrix.target == 'ttm'
         run: |
-          docker create --name ttm-extract ghcr.io/${{ github.repository_owner }}/ttm:${{ env.VERSION_TAG }}-${{ matrix.arch }}
+          docker create --name ttm-extract ghcr.io/terrateamio/ttm:${{ env.VERSION_TAG }}-${{ matrix.arch }}
           docker cp ttm-extract:/usr/local/bin/ttm ./ttm-linux-${{ matrix.arch }}
           docker rm ttm-extract
           chmod +x ./ttm-linux-${{ matrix.arch }}
@@ -136,13 +144,14 @@ jobs:
   create-multi-arch-manifest:
     needs: [set-version-tag, build]
     runs-on: ubuntu-22.04
+    environment: ${{ github.event.inputs.environment || 'production' }}
 
     outputs:
       is_latest_version_tag: ${{ steps.is-latest-version-tag.outputs.is_latest_version_tag }}
 
     env:
       VERSION_TAG: ${{ needs.set-version-tag.outputs.version_tag }}
-      GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
+      GITHUB_REPOSITORY_OWNER: terrateamio
       GITHUB_REF: ${{ github.ref }}
       TERRATEAM_ENVIRONMENT: ${{ github.event.inputs.environment || 'production' }}
 
@@ -150,12 +159,13 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+      - name: Generate terrateamio packages token
+        id: terrateamio-token
+        uses: actions/create-github-app-token@v3
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          app-id: ${{ secrets.TERRATEAMIO_PACKAGES_APP_ID }}
+          private-key: ${{ secrets.TERRATEAMIO_PACKAGES_APP_PRIVATE_KEY }}
+          owner: terrateamio
 
       - name: Set is latest version tag
         id: is-latest-version-tag
@@ -163,6 +173,13 @@ jobs:
           is_latest_version_tag="$(./scripts/is_latest_version_tag)"
           echo "IS_LATEST_VERSION_TAG=${is_latest_version_tag}" >> "${GITHUB_ENV}"
           echo "is_latest_version_tag=${is_latest_version_tag}" >> "${GITHUB_OUTPUT}"
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: x-access-token
+          password: ${{ steps.terrateamio-token.outputs.token }}
 
       - name: Create and push multi-arch manifest
         run: |


### PR DESCRIPTION
## Description

release.yml pushed all four images under github.repository_owner (stategraph). terrat-oss and terrat-ee need to publish under the terrateamio org instead, matching what docker-compose.yml already expects (ghcr.io/terrateamio/terrat-oss). Adds a scoped GitHub App (packages:write only, installed on terrateamio) and uses its token for those two targets' build/push and manifest steps; code-indexer/ttm are unaffected. deploy.yml is updated to pull terrat-ee from the same org. All registry-owner selection is now explicit per target/step rather than implicitly derived from github.repository_owner, since this project has already moved orgs once.

Fixes #1506.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (explain):

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/stategraph/stategraph/blob/main/CONTRIBUTING.md)
- [x] The pull request title follows this format:
      `ISSUE_NUMBER ACTION_TYPE Short description` (e.g., `123 ADD Feature description`)
- [ ] I have added tests and documentation (if applicable)
- [x] My changes generate no new warnings/errors and do not break existing functionality

## Additional context (optional)

Requires TERRATEAMIO_PACKAGES_APP_ID / TERRATEAMIO_PACKAGES_APP_PRIVATE_KEY, which are already set on the production environment. staging does not have these secrets, so a manual staging dispatch would fail on the terrat-oss/terrat-ee build steps -- out of scope here since the automatic push-to-main trigger always resolves to production.
