### PR TITLE
#1506 FIX Use docker buildx imagetools instead of docker manifest

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -85,6 +85,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,6 +158,9 @@ jobs:
           echo "IS_LATEST_VERSION_TAG=${is_latest_version_tag}" >> "${GITHUB_ENV}"
           echo "is_latest_version_tag=${is_latest_version_tag}" >> "${GITHUB_OUTPUT}"
 
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:

--- a/scripts/create_manifest
+++ b/scripts/create_manifest
@@ -20,21 +20,18 @@ fi
 for IMAGE_NAME in "$@"; do
   echo "Creating and pushing multi-architecture manifest for ${IMAGE_NAME}..."
 
-  # Create the multi-architecture manifest for the version tag
-  docker manifest create "${CONTAINER_REGISTRY}/${GITHUB_REPOSITORY_OWNER}/${IMAGE_NAME}:${VERSION_TAG}" \
-    --amend "${CONTAINER_REGISTRY}/${GITHUB_REPOSITORY_OWNER}/${IMAGE_NAME}:${VERSION_TAG}-amd64" \
-    --amend "${CONTAINER_REGISTRY}/${GITHUB_REPOSITORY_OWNER}/${IMAGE_NAME}:${VERSION_TAG}-arm64"
-
-  # Push the multi-architecture manifest for the version tag
-  docker manifest push "${CONTAINER_REGISTRY}/${GITHUB_REPOSITORY_OWNER}/${IMAGE_NAME}:${VERSION_TAG}"
+  # Create and push the multi-architecture manifest for the version tag
+  docker buildx imagetools create \
+    --tag "${CONTAINER_REGISTRY}/${GITHUB_REPOSITORY_OWNER}/${IMAGE_NAME}:${VERSION_TAG}" \
+    "${CONTAINER_REGISTRY}/${GITHUB_REPOSITORY_OWNER}/${IMAGE_NAME}:${VERSION_TAG}-amd64" \
+    "${CONTAINER_REGISTRY}/${GITHUB_REPOSITORY_OWNER}/${IMAGE_NAME}:${VERSION_TAG}-arm64"
 
   # Optionally create and push the "latest" tag if conditions are met
   if [[ "${IS_LATEST_VERSION_TAG:-false}" == "true" && "${PUSH_LATEST}" == "true" && "${IMAGE_NAME}" != "terrat-base" ]]; then
     echo "Creating and pushing the 'latest' multi-architecture tag for ${IMAGE_NAME}..."
-    docker manifest create "${CONTAINER_REGISTRY}/${GITHUB_REPOSITORY_OWNER}/${IMAGE_NAME}:latest" \
-      --amend "${CONTAINER_REGISTRY}/${GITHUB_REPOSITORY_OWNER}/${IMAGE_NAME}:${VERSION_TAG}-amd64" \
-      --amend "${CONTAINER_REGISTRY}/${GITHUB_REPOSITORY_OWNER}/${IMAGE_NAME}:${VERSION_TAG}-arm64"
-
-    docker manifest push "${CONTAINER_REGISTRY}/${GITHUB_REPOSITORY_OWNER}/${IMAGE_NAME}:latest"
+    docker buildx imagetools create \
+      --tag "${CONTAINER_REGISTRY}/${GITHUB_REPOSITORY_OWNER}/${IMAGE_NAME}:latest" \
+      "${CONTAINER_REGISTRY}/${GITHUB_REPOSITORY_OWNER}/${IMAGE_NAME}:${VERSION_TAG}-amd64" \
+      "${CONTAINER_REGISTRY}/${GITHUB_REPOSITORY_OWNER}/${IMAGE_NAME}:${VERSION_TAG}-arm64"
   fi
 done


### PR DESCRIPTION
create-multi-arch-manifest failed with 'manifest unknown' on the first terrateamio push, even though both per-arch tags existed. Swaps the legacy `docker manifest create/push` for `docker buildx imagetools create`, the modern way to assemble multi-arch manifest lists directly on the registry side (no local pull needed) — removes a class of registry-read flakiness. Also applied to base.yml's terrat-base manifest job for consistency, since it shares the same script.

Fixes #1506.