### PR TITLE
#1506 FIX Stop relying on env overrides of reserved GITHUB_* vars for image org

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -77,7 +77,6 @@ jobs:
 
     env:
       VERSION_TAG: ${{ needs.set-version-tag.outputs.version_tag }}
-      IMAGE_REGISTRY_OWNER: ${{ github.repository_owner }}
       GITHUB_REF: ${{ github.ref }}
       TERRATEAM_ENVIRONMENT: ${{ github.event.inputs.environment || 'production' }}
 

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -77,7 +77,7 @@ jobs:
 
     env:
       VERSION_TAG: ${{ needs.set-version-tag.outputs.version_tag }}
-      GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
+      IMAGE_REGISTRY_OWNER: ${{ github.repository_owner }}
       GITHUB_REF: ${{ github.ref }}
       TERRATEAM_ENVIRONMENT: ${{ github.event.inputs.environment || 'production' }}
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,7 +35,7 @@ jobs:
       TERRATEAM_ENVIRONMENT: ${{ inputs.environment }}
       FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
       MATRIX_PASSWORD: ${{ secrets.MATRIX_PASSWORD }}
-      GITHUB_REPOSITORY_OWNER: terrateamio
+      IMAGE_REGISTRY_OWNER: terrateamio
 
     permissions:
       contents: read

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,7 +35,6 @@ jobs:
       TERRATEAM_ENVIRONMENT: ${{ inputs.environment }}
       FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
       MATRIX_PASSWORD: ${{ secrets.MATRIX_PASSWORD }}
-      IMAGE_REGISTRY_OWNER: terrateamio
 
     permissions:
       contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,7 +143,6 @@ jobs:
 
     env:
       VERSION_TAG: ${{ needs.set-version-tag.outputs.version_tag }}
-      IMAGE_REGISTRY_OWNER: terrateamio
       GITHUB_REF: ${{ github.ref }}
       TERRATEAM_ENVIRONMENT: ${{ github.event.inputs.environment || 'production' }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,7 +143,7 @@ jobs:
 
     env:
       VERSION_TAG: ${{ needs.set-version-tag.outputs.version_tag }}
-      GITHUB_REPOSITORY_OWNER: terrateamio
+      IMAGE_REGISTRY_OWNER: terrateamio
       GITHUB_REF: ${{ github.ref }}
       TERRATEAM_ENVIRONMENT: ${{ github.event.inputs.environment || 'production' }}
 

--- a/scripts/create_manifest
+++ b/scripts/create_manifest
@@ -22,16 +22,16 @@ for IMAGE_NAME in "$@"; do
 
   # Create and push the multi-architecture manifest for the version tag
   docker buildx imagetools create \
-    --tag "${CONTAINER_REGISTRY}/${GITHUB_REPOSITORY_OWNER}/${IMAGE_NAME}:${VERSION_TAG}" \
-    "${CONTAINER_REGISTRY}/${GITHUB_REPOSITORY_OWNER}/${IMAGE_NAME}:${VERSION_TAG}-amd64" \
-    "${CONTAINER_REGISTRY}/${GITHUB_REPOSITORY_OWNER}/${IMAGE_NAME}:${VERSION_TAG}-arm64"
+    --tag "${CONTAINER_REGISTRY}/${IMAGE_REGISTRY_OWNER}/${IMAGE_NAME}:${VERSION_TAG}" \
+    "${CONTAINER_REGISTRY}/${IMAGE_REGISTRY_OWNER}/${IMAGE_NAME}:${VERSION_TAG}-amd64" \
+    "${CONTAINER_REGISTRY}/${IMAGE_REGISTRY_OWNER}/${IMAGE_NAME}:${VERSION_TAG}-arm64"
 
   # Optionally create and push the "latest" tag if conditions are met
   if [[ "${IS_LATEST_VERSION_TAG:-false}" == "true" && "${PUSH_LATEST}" == "true" && "${IMAGE_NAME}" != "terrat-base" ]]; then
     echo "Creating and pushing the 'latest' multi-architecture tag for ${IMAGE_NAME}..."
     docker buildx imagetools create \
-      --tag "${CONTAINER_REGISTRY}/${GITHUB_REPOSITORY_OWNER}/${IMAGE_NAME}:latest" \
-      "${CONTAINER_REGISTRY}/${GITHUB_REPOSITORY_OWNER}/${IMAGE_NAME}:${VERSION_TAG}-amd64" \
-      "${CONTAINER_REGISTRY}/${GITHUB_REPOSITORY_OWNER}/${IMAGE_NAME}:${VERSION_TAG}-arm64"
+      --tag "${CONTAINER_REGISTRY}/${IMAGE_REGISTRY_OWNER}/${IMAGE_NAME}:latest" \
+      "${CONTAINER_REGISTRY}/${IMAGE_REGISTRY_OWNER}/${IMAGE_NAME}:${VERSION_TAG}-amd64" \
+      "${CONTAINER_REGISTRY}/${IMAGE_REGISTRY_OWNER}/${IMAGE_NAME}:${VERSION_TAG}-arm64"
   fi
 done

--- a/scripts/create_manifest
+++ b/scripts/create_manifest
@@ -22,16 +22,16 @@ for IMAGE_NAME in "$@"; do
 
   # Create and push the multi-architecture manifest for the version tag
   docker buildx imagetools create \
-    --tag "${CONTAINER_REGISTRY}/${IMAGE_REGISTRY_OWNER}/${IMAGE_NAME}:${VERSION_TAG}" \
-    "${CONTAINER_REGISTRY}/${IMAGE_REGISTRY_OWNER}/${IMAGE_NAME}:${VERSION_TAG}-amd64" \
-    "${CONTAINER_REGISTRY}/${IMAGE_REGISTRY_OWNER}/${IMAGE_NAME}:${VERSION_TAG}-arm64"
+    --tag "${CONTAINER_REGISTRY}/terrateamio/${IMAGE_NAME}:${VERSION_TAG}" \
+    "${CONTAINER_REGISTRY}/terrateamio/${IMAGE_NAME}:${VERSION_TAG}-amd64" \
+    "${CONTAINER_REGISTRY}/terrateamio/${IMAGE_NAME}:${VERSION_TAG}-arm64"
 
   # Optionally create and push the "latest" tag if conditions are met
   if [[ "${IS_LATEST_VERSION_TAG:-false}" == "true" && "${PUSH_LATEST}" == "true" && "${IMAGE_NAME}" != "terrat-base" ]]; then
     echo "Creating and pushing the 'latest' multi-architecture tag for ${IMAGE_NAME}..."
     docker buildx imagetools create \
-      --tag "${CONTAINER_REGISTRY}/${IMAGE_REGISTRY_OWNER}/${IMAGE_NAME}:latest" \
-      "${CONTAINER_REGISTRY}/${IMAGE_REGISTRY_OWNER}/${IMAGE_NAME}:${VERSION_TAG}-amd64" \
-      "${CONTAINER_REGISTRY}/${IMAGE_REGISTRY_OWNER}/${IMAGE_NAME}:${VERSION_TAG}-arm64"
+      --tag "${CONTAINER_REGISTRY}/terrateamio/${IMAGE_NAME}:latest" \
+      "${CONTAINER_REGISTRY}/terrateamio/${IMAGE_NAME}:${VERSION_TAG}-amd64" \
+      "${CONTAINER_REGISTRY}/terrateamio/${IMAGE_NAME}:${VERSION_TAG}-arm64"
   fi
 done

--- a/scripts/deploy_ecs
+++ b/scripts/deploy_ecs
@@ -6,7 +6,7 @@ export AWS_PAGER=""
 CLUSTER_NAME="terrateam-app"
 SERVICE_NAME="terrateam-app-service"
 IMAGE_NAME="terrat-ee"
-GHCR_IMAGE="ghcr.io/${GITHUB_REPOSITORY_OWNER}/${IMAGE_NAME}:${VERSION_TAG}"
+GHCR_IMAGE="ghcr.io/${IMAGE_REGISTRY_OWNER}/${IMAGE_NAME}:${VERSION_TAG}"
 
 # Fetch the current service information
 aws ecs describe-services --cluster "$CLUSTER_NAME" --services "$SERVICE_NAME" > service.json

--- a/scripts/deploy_ecs
+++ b/scripts/deploy_ecs
@@ -6,7 +6,7 @@ export AWS_PAGER=""
 CLUSTER_NAME="terrateam-app"
 SERVICE_NAME="terrateam-app-service"
 IMAGE_NAME="terrat-ee"
-GHCR_IMAGE="ghcr.io/${IMAGE_REGISTRY_OWNER}/${IMAGE_NAME}:${VERSION_TAG}"
+GHCR_IMAGE="ghcr.io/terrateamio/${IMAGE_NAME}:${VERSION_TAG}"
 
 # Fetch the current service information
 aws ecs describe-services --cluster "$CLUSTER_NAME" --services "$SERVICE_NAME" > service.json

--- a/scripts/deploy_flyio
+++ b/scripts/deploy_flyio
@@ -2,7 +2,7 @@
 set -euf -o pipefail
 
 IMAGE_NAME="terrat-ee"
-GHCR_IMAGE="ghcr.io/${GITHUB_REPOSITORY_OWNER}/${IMAGE_NAME}:${VERSION_TAG}"
+GHCR_IMAGE="ghcr.io/${IMAGE_REGISTRY_OWNER}/${IMAGE_NAME}:${VERSION_TAG}"
 FLY_APP_PREFIX="${FLY_APP_PREFIX:-terrateam-app}"
 
 flyctl deploy --strategy canary --access-token "${FLY_API_TOKEN}" --image "${GHCR_IMAGE}" -a "${FLY_APP_PREFIX}-${TERRATEAM_ENVIRONMENT}"

--- a/scripts/deploy_flyio
+++ b/scripts/deploy_flyio
@@ -2,7 +2,7 @@
 set -euf -o pipefail
 
 IMAGE_NAME="terrat-ee"
-GHCR_IMAGE="ghcr.io/${IMAGE_REGISTRY_OWNER}/${IMAGE_NAME}:${VERSION_TAG}"
+GHCR_IMAGE="ghcr.io/terrateamio/${IMAGE_NAME}:${VERSION_TAG}"
 FLY_APP_PREFIX="${FLY_APP_PREFIX:-terrateam-app}"
 
 flyctl deploy --strategy canary --access-token "${FLY_API_TOKEN}" --image "${GHCR_IMAGE}" -a "${FLY_APP_PREFIX}-${TERRATEAM_ENVIRONMENT}"


### PR DESCRIPTION
GitHub Actions silently ignores env: overrides of reserved GITHUB_* vars, so GITHUB_REPOSITORY_OWNER: terrateamio was dropped and scripts saw the real value (stategraph) instead -- that's why create-multi-arch-manifest failed. create_manifest and deploy_flyio now hardcode terrateamio directly (both exclusively used for terrateamio-owned images); deploy_ecs/deploy.yml keep IMAGE_REGISTRY_OWNER, a non-reserved name that actually works as an env override. Fixes #1506.