### PR TITLE
#1518 ADD Global lock_policy configuration key

### DIFF
--- a/api_schemas/terrat/config-schema.json
+++ b/api_schemas/terrat/config-schema.json
@@ -1628,6 +1628,16 @@
         "integrations": {
           "$ref": "#/definitions/integrations"
         },
+        "lock_policy": {
+          "default": "strict",
+          "enum": [
+            "apply",
+            "merge",
+            "none",
+            "strict"
+          ],
+          "type": "string"
+        },
         "notifications": {
           "$ref": "#/definitions/notifications"
         },
@@ -1763,7 +1773,6 @@
           "$ref": "#/definitions/integrations"
         },
         "lock_policy": {
-          "default": "strict",
           "enum": [
             "apply",
             "merge",

--- a/code/src/terrat_base_repo_config_v1/terrat_base_repo_config_v1.ml
+++ b/code/src/terrat_base_repo_config_v1/terrat_base_repo_config_v1.ml
@@ -1226,6 +1226,7 @@ module View = struct
     hooks : Hooks.t; [@default Hooks.make ()]
     indexer : Indexer.t; [@default Indexer.make ()]
     integrations : Integrations.t; [@default Integrations.make ()]
+    lock_policy : Workflows.Entry.Lock_policy.t; [@default Workflows.Entry.Lock_policy.Strict]
     notifications : Notifications.t; [@default Notifications.make ()]
     parallel_runs : int; [@default 3]
     stacks : Stacks.t; [@default Stacks.make ()]
@@ -2543,7 +2544,7 @@ let of_version_1_workflows_lock_policy = function
   | `None -> Workflows.Entry.Lock_policy.None
   | `Strict -> Workflows.Entry.Lock_policy.Strict
 
-let of_version_1_workflows default_engine default_integrations workflows =
+let of_version_1_workflows default_engine default_integrations default_lock_policy workflows =
   let open CCResult.Infix in
   let module E = Terrat_repo_config_workflow_entry in
   CCResult.map_l
@@ -2567,7 +2568,9 @@ let of_version_1_workflows default_engine default_integrations workflows =
       >>= fun engine ->
       of_version_1_workflow_integrations default_integrations integrations
       >>= fun integrations ->
-      let lock_policy = of_version_1_workflows_lock_policy lock_policy in
+      let lock_policy =
+        CCOption.map_or ~default:default_lock_policy of_version_1_workflows_lock_policy lock_policy
+      in
       map_opt of_version_1_workflow_op_list plan
       >>= fun plan ->
       CCResult.map_err
@@ -2609,6 +2612,7 @@ let of_version_1 v1 =
     hooks;
     indexer;
     integrations;
+    lock_policy;
     notifications;
     parallel_runs;
     stacks;
@@ -2621,6 +2625,7 @@ let of_version_1 v1 =
   } =
     v1
   in
+  let lock_policy = of_version_1_workflows_lock_policy lock_policy in
   let open CCResult.Infix in
   map_opt of_version_1_access_control access_control
   >>= fun access_control ->
@@ -2660,7 +2665,7 @@ let of_version_1 v1 =
   >>= fun tags ->
   map_opt of_version_1_tree_builder tree_builder
   >>= fun tree_builder ->
-  map_opt (of_version_1_workflows engine integrations) workflows
+  map_opt (of_version_1_workflows engine integrations lock_policy) workflows
   >>= fun workflows ->
   Ok
     (View.make
@@ -2680,6 +2685,7 @@ let of_version_1 v1 =
        ?hooks
        ?indexer
        ?integrations
+       ~lock_policy
        ?notifications
        ~parallel_runs
        ?stacks
@@ -3503,7 +3509,7 @@ let to_version_1_workflows =
             CCFun.(Integrations.equal (Integrations.make ()) %> not)
             to_version_1_integrations
             integrations;
-        lock_policy = to_version_1_lock_policy lock_policy;
+        lock_policy = Some (to_version_1_lock_policy lock_policy);
         plan = Some (to_version_1_workflows_op plan);
         runs_on;
         tag_query = Terrat_tag_query.to_string tag_query;
@@ -3529,6 +3535,7 @@ let to_version_1 t =
     hooks;
     indexer;
     integrations;
+    lock_policy;
     notifications;
     parallel_runs;
     stacks;
@@ -3594,6 +3601,7 @@ let to_version_1 t =
         CCFun.(Integrations.equal (Integrations.make ()) %> not)
         to_version_1_integrations
         integrations;
+    lock_policy = to_version_1_lock_policy lock_policy;
     notifications =
       map_opt_if_true
         CCFun.(Notifications.equal (Notifications.make ()) %> not)
@@ -3960,6 +3968,7 @@ let engine t = t.View.engine
 let hooks t = t.View.hooks
 let indexer t = t.View.indexer
 let integrations t = t.View.integrations
+let lock_policy t = t.View.lock_policy
 let notifications t = t.View.notifications
 let parallel_runs t = t.View.parallel_runs
 let stacks t = t.View.stacks

--- a/code/src/terrat_base_repo_config_v1/terrat_base_repo_config_v1.mli
+++ b/code/src/terrat_base_repo_config_v1/terrat_base_repo_config_v1.mli
@@ -849,6 +849,7 @@ module View : sig
     hooks : Hooks.t; [@default Hooks.make ()]
     indexer : Indexer.t; [@default Indexer.make ()]
     integrations : Integrations.t; [@default Integrations.make ()]
+    lock_policy : Workflows.Entry.Lock_policy.t; [@default Workflows.Entry.Lock_policy.Strict]
     notifications : Notifications.t; [@default Notifications.make ()]
     parallel_runs : int; [@default 3]
     stacks : Stacks.t; [@default Stacks.make ()]
@@ -956,6 +957,7 @@ val engine : 'a t -> Engine.t
 val hooks : 'a t -> Hooks.t
 val indexer : 'a t -> Indexer.t
 val integrations : 'a t -> Integrations.t
+val lock_policy : 'a t -> Workflows.Entry.Lock_policy.t
 val notifications : 'a t -> Notifications.t
 val parallel_runs : 'a t -> int
 val stacks : 'a t -> Stacks.t

--- a/code/src/terrat_repo_config/terrat_repo_config_version_1.ml
+++ b/code/src/terrat_repo_config/terrat_repo_config_version_1.ml
@@ -110,6 +110,30 @@ module Indexer = struct
   [@@deriving yojson { strict = true; meta = true }, make, show, eq]
 end
 
+module Lock_policy = struct
+  let t_of_yojson = function
+    | `String "apply" -> Ok `Apply
+    | `String "merge" -> Ok `Merge
+    | `String "none" -> Ok `None
+    | `String "strict" -> Ok `Strict
+    | json -> Error ("Unknown value: " ^ Yojson.Safe.pretty_to_string json)
+
+  let t_to_yojson = function
+    | `Apply -> `String "apply"
+    | `Merge -> `String "merge"
+    | `None -> `String "none"
+    | `Strict -> `String "strict"
+
+  type t =
+    ([ `Apply
+     | `Merge
+     | `None
+     | `Strict
+     ]
+    [@of_yojson t_of_yojson] [@to_yojson t_to_yojson])
+  [@@deriving yojson { strict = false; meta = true }, show, eq]
+end
+
 module Storage = struct
   module Plans = struct
     type t =
@@ -179,6 +203,7 @@ type t = {
   hooks : Hooks.t option; [@default None]
   indexer : Indexer.t option; [@default None]
   integrations : Terrat_repo_config_integrations.t option; [@default None]
+  lock_policy : Lock_policy.t; [@default `Strict]
   notifications : Terrat_repo_config_notifications.t option; [@default None]
   parallel_runs : int; [@default 3]
   stacks : Terrat_repo_config_stacks.t option; [@default None]

--- a/code/src/terrat_repo_config/terrat_repo_config_workflow_entry.ml
+++ b/code/src/terrat_repo_config/terrat_repo_config_workflow_entry.ml
@@ -28,7 +28,7 @@ type t = {
   engine : Terrat_repo_config_engine.t option; [@default None]
   environment : string option; [@default None]
   integrations : Terrat_repo_config_integrations.t option; [@default None]
-  lock_policy : Lock_policy.t; [@default `Strict]
+  lock_policy : Lock_policy.t option; [@default None]
   plan : Terrat_repo_config_workflow_op_list.t option; [@default None]
   runs_on : Terrat_repo_config_runs_on.t option; [@default None]
   tag_query : string;

--- a/code/src/terrat_vcs_event_evaluator/terrat_vcs_event_evaluator.ml
+++ b/code/src/terrat_vcs_event_evaluator/terrat_vcs_event_evaluator.ml
@@ -465,7 +465,7 @@ module Make (S : Terrat_vcs_provider2.S) = struct
           pull_request
           dirspaces)
 
-  let store_dirspaceflows ~base_ref ~branch_ref request_id db repo dirspaceflows =
+  let store_dirspaceflows ~base_ref ~branch_ref ~lock_policy request_id db repo dirspaceflows =
     Abbs_time_it.run
       (fun time ->
         Logs.info (fun m ->
@@ -476,7 +476,15 @@ module Make (S : Terrat_vcs_provider2.S) = struct
               (S.Api.Ref.to_string base_ref)
               (S.Api.Ref.to_string branch_ref)
               time))
-      (fun () -> S.Db.store_dirspaceflows ~request_id ~base_ref ~branch_ref db repo dirspaceflows)
+      (fun () ->
+        S.Db.store_dirspaceflows
+          ~request_id
+          ~base_ref
+          ~branch_ref
+          ~lock_policy
+          db
+          repo
+          dirspaceflows)
 
   let query_plan request_id db work_manifest_id dirspace =
     Abbs_time_it.run
@@ -3603,6 +3611,7 @@ module Make (S : Terrat_vcs_provider2.S) = struct
       store_dirspaceflows
         ~base_ref
         ~branch_ref
+        ~lock_policy:(Terrat_base_repo_config_v1.lock_policy repo_config)
         state.State.request_id
         (Ctx.storage ctx)
         (Event.repo state.State.event)
@@ -3705,6 +3714,7 @@ module Make (S : Terrat_vcs_provider2.S) = struct
       store_dirspaceflows
         ~base_ref
         ~branch_ref
+        ~lock_policy:(Terrat_base_repo_config_v1.lock_policy repo_config)
         state.State.request_id
         (Ctx.storage ctx)
         (Event.repo state.State.event)
@@ -3866,6 +3876,7 @@ module Make (S : Terrat_vcs_provider2.S) = struct
       store_dirspaceflows
         ~base_ref
         ~branch_ref
+        ~lock_policy:(Terrat_base_repo_config_v1.lock_policy repo_config)
         state.State.request_id
         (Ctx.storage ctx)
         (Event.repo state.State.event)
@@ -3989,6 +4000,7 @@ module Make (S : Terrat_vcs_provider2.S) = struct
       store_dirspaceflows
         ~base_ref
         ~branch_ref
+        ~lock_policy:(Terrat_base_repo_config_v1.lock_policy repo_config)
         state.State.request_id
         (Ctx.storage ctx)
         (Event.repo state.State.event)
@@ -5318,6 +5330,7 @@ module Make (S : Terrat_vcs_provider2.S) = struct
           store_dirspaceflows
             ~base_ref
             ~branch_ref
+            ~lock_policy:(Terrat_base_repo_config_v1.lock_policy repo_config)
             state.State.request_id
             (Ctx.storage ctx)
             (Event.repo state.State.event)

--- a/code/src/terrat_vcs_event_evaluator2/terrat_vcs_event_evaluator2_wm_sm_tf_op.ml
+++ b/code/src/terrat_vcs_event_evaluator2/terrat_vcs_event_evaluator2_wm_sm_tf_op.ml
@@ -365,6 +365,7 @@ struct
               ~request_id:(Builder.log_id s)
               ~base_ref:dest_branch_ref
               ~branch_ref
+              ~lock_policy:(Terrat_base_repo_config_v1.lock_policy repo_config)
               db
               repo
               all_dirspaceflows))

--- a/code/src/terrat_vcs_provider2/terrat_vcs_provider2.ml
+++ b/code/src/terrat_vcs_provider2/terrat_vcs_provider2.ml
@@ -260,6 +260,7 @@ module type S = sig
       request_id:string ->
       base_ref:Api.Ref.t ->
       branch_ref:Api.Ref.t ->
+      lock_policy:Terrat_base_repo_config_v1.Workflows.Entry.Lock_policy.t ->
       t ->
       Api.Repo.t ->
       (Terrat_base_repo_config_v1.Dirs.Dir.Branch_target.t

--- a/code/src/terrat_vcs_provider2_nyi/terrat_vcs_provider2_nyi.ml
+++ b/code/src/terrat_vcs_provider2_nyi/terrat_vcs_provider2_nyi.ml
@@ -29,7 +29,7 @@ module Db = struct
   let store_repo_tree ~request_id db account ref_ files = raise (Failure "nyi")
   let store_flow_state ~request_id db work_manifest_id state = raise (Failure "nyi")
 
-  let store_dirspaceflows ~request_id ~base_ref ~branch_ref db repo dirspaceflows =
+  let store_dirspaceflows ~request_id ~base_ref ~branch_ref ~lock_policy db repo dirspaceflows =
     raise (Failure "nyi")
 
   let store_tf_operation_result ~request_id db work_manifest_id result = raise (Failure "nyi")

--- a/code/src/terrat_vcs_service_github/terrat_vcs_service_github_provider.ml
+++ b/code/src/terrat_vcs_service_github/terrat_vcs_service_github_provider.ml
@@ -1315,7 +1315,7 @@ module Db = struct
         Logs.err (fun m -> m "%s: ERROR : %a" request_id Pgsql_io.pp_err err);
         Abb.Future.return (Error `Error)
 
-  let store_dirspaceflows ~request_id ~base_ref ~branch_ref db repo dirspaceflows =
+  let store_dirspaceflows ~request_id ~base_ref ~branch_ref ~lock_policy db repo dirspaceflows =
     let id = CCInt64.of_int (Api.Repo.id repo) in
     let run =
       Abbs_future_combinators.List_result.iter
@@ -1339,7 +1339,7 @@ module Db = struct
                      let module Dfwf = Terrat_change.Dirspaceflow.Workflow in
                      let module Wf = Terrat_base_repo_config_v1.Workflows.Entry in
                      CCOption.map_or
-                       ~default:Terrat_base_repo_config_v1.Workflows.Entry.Lock_policy.Strict
+                       ~default:lock_policy
                        (fun { Dfwf.workflow = { Wf.lock_policy; _ }; _ } -> lock_policy)
                        workflow)
                    dirspaceflows)

--- a/code/src/terrat_vcs_service_gitlab/terrat_vcs_service_gitlab_provider.ml
+++ b/code/src/terrat_vcs_service_gitlab/terrat_vcs_service_gitlab_provider.ml
@@ -1314,7 +1314,7 @@ module Db = struct
         Logs.err (fun m -> m "%s: ERROR : %a" request_id Pgsql_io.pp_err err);
         Abb.Future.return (Error `Error)
 
-  let store_dirspaceflows ~request_id ~base_ref ~branch_ref db repo dirspaceflows =
+  let store_dirspaceflows ~request_id ~base_ref ~branch_ref ~lock_policy db repo dirspaceflows =
     let id = CCInt64.of_int (Api.Repo.id repo) in
     let run =
       Abbs_future_combinators.List_result.iter
@@ -1338,7 +1338,7 @@ module Db = struct
                      let module Dfwf = Terrat_change.Dirspaceflow.Workflow in
                      let module Wf = Terrat_base_repo_config_v1.Workflows.Entry in
                      CCOption.map_or
-                       ~default:Terrat_base_repo_config_v1.Workflows.Entry.Lock_policy.Strict
+                       ~default:lock_policy
                        (fun { Dfwf.workflow = { Wf.lock_policy; _ }; _ } -> lock_policy)
                        workflow)
                    dirspaceflows)

--- a/code/tests/terrat_base_repo_config_v1/test.ml
+++ b/code/tests/terrat_base_repo_config_v1/test.ml
@@ -65,12 +65,89 @@ let test_to_version_1_round_trip =
           | _ -> failwith "Round-trip to Version_1 did not produce Engine_stategraph")
       | Error _ -> failwith "of_version_1_json failed in round-trip setup")
 
+(* Tests for the global [lock_policy] key.  A workflow entry that does not set
+   [lock_policy] inherits the global value, an entry that sets it overrides the
+   global value, and the global value round-trips through Version_1. *)
+
+let pp_lock_policy = function
+  | V1.Workflows.Entry.Lock_policy.Apply -> "apply"
+  | V1.Workflows.Entry.Lock_policy.Merge -> "merge"
+  | V1.Workflows.Entry.Lock_policy.None -> "none"
+  | V1.Workflows.Entry.Lock_policy.Strict -> "strict"
+
+let config_of_json json =
+  match V1.of_version_1_json json with
+  | Ok cfg -> cfg
+  | Error _ -> failwith "of_version_1_json failed"
+
+let assert_lock_policy expected actual =
+  if not (V1.Workflows.Entry.Lock_policy.equal expected actual) then
+    failwith
+      (Printf.sprintf
+         "Expected lock_policy %s, got %s"
+         (pp_lock_policy expected)
+         (pp_lock_policy actual))
+
+let test_lock_policy_default =
+  Oth.test ~name:"lock_policy: defaults to strict" (fun _ ->
+      assert_lock_policy
+        V1.Workflows.Entry.Lock_policy.Strict
+        (V1.lock_policy (config_of_json (`Assoc []))))
+
+let test_lock_policy_global =
+  Oth.test ~name:"lock_policy: global value is read" (fun _ ->
+      assert_lock_policy
+        V1.Workflows.Entry.Lock_policy.Merge
+        (V1.lock_policy (config_of_json (`Assoc [ ("lock_policy", `String "merge") ]))))
+
+let test_lock_policy_workflow_inherits =
+  Oth.test ~name:"lock_policy: workflow entry inherits the global value" (fun _ ->
+      let json =
+        `Assoc
+          [
+            ("lock_policy", `String "apply");
+            ("workflows", `List [ `Assoc [ ("tag_query", `String "") ] ]);
+          ]
+      in
+      match V1.workflows (config_of_json json) with
+      | [ { V1.Workflows.Entry.lock_policy; _ } ] ->
+          assert_lock_policy V1.Workflows.Entry.Lock_policy.Apply lock_policy
+      | _ -> failwith "Expected exactly one workflow entry")
+
+let test_lock_policy_workflow_overrides =
+  Oth.test ~name:"lock_policy: workflow entry overrides the global value" (fun _ ->
+      let json =
+        `Assoc
+          [
+            ("lock_policy", `String "apply");
+            ( "workflows",
+              `List [ `Assoc [ ("tag_query", `String ""); ("lock_policy", `String "none") ] ] );
+          ]
+      in
+      match V1.workflows (config_of_json json) with
+      | [ { V1.Workflows.Entry.lock_policy; _ } ] ->
+          assert_lock_policy V1.Workflows.Entry.Lock_policy.None lock_policy
+      | _ -> failwith "Expected exactly one workflow entry")
+
+let test_lock_policy_to_version_1_round_trip =
+  Oth.test ~name:"lock_policy: global value round-trips through Version_1" (fun _ ->
+      let cfg = config_of_json (`Assoc [ ("lock_policy", `String "none") ]) in
+      let v1 = V1.to_version_1 cfg in
+      match v1.Repo.Version_1.lock_policy with
+      | `None -> ()
+      | _ -> failwith "Round-trip to Version_1 did not preserve lock_policy")
+
 let test =
   Oth.parallel
     [
       test_of_version_1_json_minimal;
       test_of_version_1_json_with_version;
       test_to_version_1_round_trip;
+      test_lock_policy_default;
+      test_lock_policy_global;
+      test_lock_policy_workflow_inherits;
+      test_lock_policy_workflow_overrides;
+      test_lock_policy_to_version_1_round_trip;
     ]
 
 let () =

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -257,6 +257,7 @@ export default defineConfig({
                 { label: "hooks", link: "/reference/configuration/hooks" },
                 { label: "ignore-patterns", link: "/reference/configuration/ignore-patterns" },
                 { label: "indexer", link: "/reference/configuration/indexer" },
+                { label: "lock-policy", link: "/reference/configuration/lock-policy" },
                 { label: "notifications", link: "/reference/configuration/notifications" },
                 { label: "parallel-runs", link: "/reference/configuration/parallel-runs" },
                 { label: "stacks", link: "/reference/configuration/stacks" },

--- a/docs/src/content/docs/reference/configuration/lock-policy.mdx
+++ b/docs/src/content/docs/reference/configuration/lock-policy.mdx
@@ -1,0 +1,37 @@
+---
+title: lock_policy
+description: The lock_policy configuration reference
+---
+
+The `lock_policy` configuration specifies, for the whole repository, under what situations Terrateam acquires a lock on a directory and workspace. It is the default for every directory, including those that do not match any [workflow](/reference/configuration/workflows). A `lock_policy` set on a workflow entry overrides this value for the directories that match that workflow.
+
+## Default Configuration
+```yaml
+lock_policy: strict
+```
+
+## Keys
+| Key | Type | Description |
+|-----|------|-------------|
+| lock_policy | String | When a directory should have a lock acquired. Values are `strict` (acquire a lock if either it is merged or applied), `apply` (only acquire a lock when it is applied), `merge` (only acquire a lock when it is merged), and `none` (never acquire a lock). Default is `strict`. |
+
+## Examples
+### Setting the Policy for the Whole Repository
+```yaml
+lock_policy: apply
+```
+Every directory only acquires a lock when it is applied.
+
+### Overriding the Policy for Some Directories
+```yaml
+lock_policy: apply
+
+workflows:
+  - tag_query: dir:production
+    lock_policy: strict
+```
+Directories under `production` use `strict`, everything else inherits `apply` from the global key.
+
+## Considerations
+- Be careful when modifying `lock_policy`. Any value other than `strict` is considered less safe, but can be useful in the right situation.
+- See [Lock Management](/workflows/advanced/lock-management) for a description of each policy and when a lock is acquired and released.

--- a/docs/src/content/docs/reference/configuration/workflows.mdx
+++ b/docs/src/content/docs/reference/configuration/workflows.mdx
@@ -24,7 +24,7 @@ workflows:
 | --- | --- | --- |
 | environment | String | The GitHub Environment to associate the workflow with. Default is null. |
 | runs_on | Object | Object describing the runs-on configuration.  Default is `ubuntu-latest`. |
-| lock_policy | String | When the directory should have a lock acquired. Values are strict (acquire a lock if either it is merged or applied), apply (only acquire a lock when it is applied), merge (only acquire a lock when it is merged), and none (never acquire a lock). Default is strict. |
+| lock_policy | String | When the directory should have a lock acquired. Values are strict (acquire a lock if either it is merged or applied), apply (only acquire a lock when it is applied), merge (only acquire a lock when it is merged), and none (never acquire a lock). Defaults to the top-level [lock_policy](/reference/configuration/lock-policy), which itself defaults to strict. |
 
 ### Tag Query
 A [tag query](/advanced-workflows/tags) is a list of all tags that must be present in a tag set to match the workflow.
@@ -34,7 +34,7 @@ Each `tag_query` consists of a map with the following attributes:
 | plan | `plan` | `plan` steps. |
 | apply | `apply` | `apply` steps. |
 | terragrunt | Boolean | Override the `terraform` command with `terragrunt`. Default is `false`. |
-| lock_policy | String | When the directory should have a lock acquired. Values are `strict` (acquire a lock if either it is merged or applied), `apply` (only acquire a lock when it is applied), `merge` (only acquire a lock when it is merged), and `none` (never acquire a lock). Default is `strict`. |
+| lock_policy | String | When the directory should have a lock acquired. Values are `strict` (acquire a lock if either it is merged or applied), `apply` (only acquire a lock when it is applied), `merge` (only acquire a lock when it is merged), and `none` (never acquire a lock). Defaults to the top-level [`lock_policy`](/reference/configuration/lock-policy), which itself defaults to `strict`. |
 | engine | [Engine](/reference/configuration/engine) | Configuration to override which engine to use for operations. |
 | environment | String | GitHub environment to use for the operation. Default is `null`. |
 :::note

--- a/docs/src/content/docs/workflows/advanced/lock-management.mdx
+++ b/docs/src/content/docs/workflows/advanced/lock-management.mdx
@@ -112,7 +112,7 @@ The `terrateam unlock` command is very powerful.
 
 ## Locking Policies
 
-The `lock_policy` option under workflows in your Terrateam configuration file instructs Terrateam under what situations it should acquire a lock.
+The `lock_policy` option instructs Terrateam under what situations it should acquire a lock. It can be set as a top-level key in your Terrateam configuration file, which applies to every directory, and it can be set on an individual workflow entry, which overrides the top-level value for the directories that match that workflow.
 
 | Policy   | Description                                                                                                         | Recommended Use Case                |
 |----------|---------------------------------------------------------------------------------------------------------------------|-------------------------------------|
@@ -120,6 +120,16 @@ The `lock_policy` option under workflows in your Terrateam configuration file in
 | `apply`  | Acquire a lock only if the directory has been applied in Terrateam. Lock is released once the change is merged.     | Standard apply/merge workflows      |
 | `merge`  | Acquire a lock only if the directory has been merged. Lock is released when the change is applied.                  | Dev/playground branches             |
 | `none`   | Never acquire a lock.                                                                                               | Special cases, not recommended      |
+
+For example, to make `apply` the policy for the whole repository while keeping `strict` for production directories:
+
+```yaml
+lock_policy: apply
+
+workflows:
+  - tag_query: dir:production
+    lock_policy: strict
+```
 
 ## Best Practices
 


### PR DESCRIPTION
## Description

Fixes #1518

`lock_policy` is now a top-level key applying to every directory, with workflow entries still overriding it. Default stays `strict`, so existing configs are unaffected. Also fixes directories matching no workflow, which previously got a hard-coded `Strict` in the providers regardless of config.

Dropped the `default` from `workflow-entry.lock_policy` in the schema so "unset" is distinguishable from "explicitly strict".

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [X] Documentation update
- [ ] Other (explain):

## Checklist

- [X] I have read the [contributing guidelines](https://github.com/stategraph/stategraph/blob/main/CONTRIBUTING.md)
- [X] The pull request title follows this format:
      `ISSUE_NUMBER ACTION_TYPE Short description` (e.g., `123 ADD Feature description`)
- [X] I have added tests and documentation (if applicable)
- [X] My changes generate no new warnings/errors and do not break existing functionality
