### PR TITLE
#1424 FIX Do not render carried forward plans from an earlier commit

### DIFF
--- a/code/src/terrat_vcs_github_comment/sql/select_comment_elements.sql
+++ b/code/src/terrat_vcs_github_comment/sql/select_comment_elements.sql
@@ -1,7 +1,18 @@
--- This CTE selects only the dirspaces which 
+-- The commit the current work manifest ran against.  Carried forward output
+-- produced against a different commit describes code that is no longer in the
+-- pull request, and any plan in it cannot be applied (an apply against it fails
+-- the valid-plan check with "missing plans"), so it is not rendered.
+with current_commit as (
+  select
+    wm.sha,
+    wm.base_sha
+  from work_manifests wm
+  where wm.id = $work_manifest
+),
+-- This CTE selects only the dirspaces which
 -- changed in the current work manifest
 -- provided by Terrateam's server.
-with currently_changed_dirspaces as (
+currently_changed_dirspaces as (
   select
     cd.path as dir,
     cd.workspace
@@ -82,6 +93,14 @@ left join applied_dirspaces ad on (
         gwmc.dir = ad.dir
     and gwmc.workspace = ad.workspace
 )
+cross join current_commit cc
 where
     gwmc.comment_id = $comment_id
+    -- Output from the current commit is always shown.  Output from an earlier
+    -- commit is only kept when it records an apply that already happened, which
+    -- renders with the "Already applied" marker rather than as pending work.
+    and (
+        (wm.sha = cc.sha and wm.base_sha = cc.base_sha)
+        or coalesce(ad.applied_at > wm.created_at, false)
+    )
 order by wso.idx


### PR DESCRIPTION
## Description

Fixes #1424

Rather than marking carried-forward output, don't show it when it is stale. A plan produced against an earlier commit cannot be applied — an apply against it fails the valid-plan check with "missing plans" — so rendering it as though it were current is misleading.

Output from the current commit still renders, and so does output for a dirspace that was already applied, which keeps the "Already applied" marker from #1395 working.

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (explain):

## Checklist

- [X] I have read the [contributing guidelines](https://github.com/stategraph/stategraph/blob/main/CONTRIBUTING.md)
- [X] The pull request title follows this format:
      `ISSUE_NUMBER ACTION_TYPE Short description` (e.g., `123 ADD Feature description`)
- [X] I have added tests and documentation (if applicable)
- [X] My changes generate no new warnings/errors and do not break existing functionality
