### PR TITLE
#1521 ADD terrat_apply_total metric with force label

### DIFF
--- a/code/src/terrat_metrics/terrat_metrics.ml
+++ b/code/src/terrat_metrics/terrat_metrics.ml
@@ -6,3 +6,8 @@ let errors_total =
     Prmths.Counter.v_labels ~label_names:[ "module"; "type" ] ~help ~namespace "errors_total"
   in
   fun ~m ~t -> Prmths.Counter.labels family [ m; t ]
+
+let apply_total =
+  let help = "Number of apply operations initiated" in
+  let family = Prmths.Counter.v_labels ~label_names:[ "force" ] ~help ~namespace "apply_total" in
+  fun ~force -> Prmths.Counter.labels family [ force ]

--- a/code/src/terrat_metrics/terrat_metrics.mli
+++ b/code/src/terrat_metrics/terrat_metrics.mli
@@ -1,1 +1,2 @@
 val errors_total : m:string -> t:string -> Prmths.Counter.t
+val apply_total : force:string -> Prmths.Counter.t

--- a/code/src/terrat_vcs_event_evaluator/dune
+++ b/code/src/terrat_vcs_event_evaluator/dune
@@ -11,6 +11,7 @@
   str_template
   terrat_base_repo_config_v1
   terrat_comment
+  terrat_metrics
   terrat_storage
   terrat_user
   terrat_vcs_provider2)

--- a/code/src/terrat_vcs_event_evaluator/terrat_vcs_event_evaluator.ml
+++ b/code/src/terrat_vcs_event_evaluator/terrat_vcs_event_evaluator.ml
@@ -3838,6 +3838,11 @@ module Make (S : Terrat_vcs_provider2.S) = struct
 
     let run_op_work_manifest_iter_create op ctx state =
       let module Wm = Terrat_work_manifest3 in
+      (match op with
+      | `Apply_force -> Prmths.Counter.inc_one (Terrat_metrics.apply_total ~force:"true")
+      | `Apply | `Apply_autoapprove | `Stack_auto_apply ->
+          Prmths.Counter.inc_one (Terrat_metrics.apply_total ~force:"false")
+      | `Plan -> ());
       let open Abbs_future_combinators.Infix_result_monad in
       Abbs_future_combinators.Infix_result_app.(
         (fun repo_config base_ref branch_ref working_branch_ref matches access_control_results ->

--- a/code/src/terrat_vcs_event_evaluator2/dune
+++ b/code/src/terrat_vcs_event_evaluator2/dune
@@ -14,6 +14,7 @@
   terrat_base_repo_config_v1
   terrat_comment
   terrat_kv_store
+  terrat_metrics
   terrat_storage
   terrat_vcs_event_evaluator
   terrat_vcs_event_evaluator2_targets

--- a/code/src/terrat_vcs_event_evaluator2/terrat_vcs_event_evaluator2_tasks.ml
+++ b/code/src/terrat_vcs_event_evaluator2/terrat_vcs_event_evaluator2_tasks.ml
@@ -2244,6 +2244,14 @@ struct
     let run_apply =
       run ~name:"run_apply" (fun s ({ Bs.Fetcher.fetch } as fetcher) ->
           let open Irm in
+          fetch Keys.job
+          >>= fun job ->
+          let force =
+            match job.Tjc.Job.type_ with
+            | Tjc.Job.Type_.Apply { force = true; _ } -> "true"
+            | _ -> "false"
+          in
+          Prmths.Counter.inc_one (Terrat_metrics.apply_total ~force);
           fetch Keys.dest_branch_ref
           >>= fun dest_branch_ref ->
           fetch Keys.working_branch_ref

--- a/docs/src/content/docs/self-hosted/observability-metrics.mdx
+++ b/docs/src/content/docs/self-hosted/observability-metrics.mdx
@@ -206,6 +206,28 @@ This is the primary error counter used throughout the application. Different mod
 - **Labels:** `success`
 - **Description:** Count of Terraform workflow run results initiated from GitLab
 
+## Apply Operations
+
+### `terrat_apply_total`
+
+- **Type:** Counter
+- **Labels:** `force`
+- **Description:** Total number of apply operations initiated
+- **Label values:** `force="true"` for `terrateam apply-force` operations, `force="false"` for regular applies (including autoapply and stack auto-apply)
+
+**Example queries:**
+
+```promql
+# Rate of all apply operations
+rate(terrat_apply_total[5m])
+
+# Rate of force-apply operations only
+rate(terrat_apply_total{force="true"}[5m])
+
+# Ratio of force applies to total applies
+rate(terrat_apply_total{force="true"}[1h]) / rate(terrat_apply_total[1h])
+```
+
 ## Event Evaluator
 
 ### `terrat_evaluator_op_on_account_disabled_total`


### PR DESCRIPTION
## Description

Fixes #1521. Supersedes #1505.

Adds a `terrat_apply_total{force="true|false"}` counter so force applies can be observed and alerted on separately from regular applies. It is emitted in both evaluators — at work manifest creation in the old one, and at `run_apply` in the new one — and documented with example queries in the metrics reference.

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [X] Documentation update
- [ ] Other (explain):

## Checklist

- [X] I have read the [contributing guidelines](https://github.com/stategraph/stategraph/blob/main/CONTRIBUTING.md)
- [X] The pull request title follows this format:
      `ISSUE_NUMBER ACTION_TYPE Short description` (e.g., `123 ADD Feature description`)
- [X] I have added tests and documentation (if applicable)
- [X] My changes generate no new warnings/errors and do not break existing functionality
