### PR TITLE
#1545 FIX Fail the release when the shipped binary was not built from the release commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,7 +100,18 @@ jobs:
           target: ${{ matrix.target }}
           build-args: |
             BASE_IMAGE=${{ env.BASE_IMAGE }}
+            GIT_SHA=${{ github.sha }}
           tags: ghcr.io/terrateamio/${{ matrix.target }}:${{ env.VERSION_TAG }}-${{ matrix.arch }}
+
+      - name: Verify the shipped binary was built from this commit
+        if: matrix.target == 'terrat-oss' || matrix.target == 'terrat-ee'
+        env:
+          IMAGE: ghcr.io/terrateamio/${{ matrix.target }}:${{ env.VERSION_TAG }}-${{ matrix.arch }}
+          BUILD_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          docker run --rm --entrypoint sh "$IMAGE" -c "grep -q \"$BUILD_SHA\" /usr/local/bin/terrat" \
+            || { echo "Binary does not contain the release SHA: stale or hybrid build"; exit 1; }
 
       - name: Extract ttm binary (${{ matrix.arch }})
         if: matrix.target == 'ttm'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,7 +110,7 @@ jobs:
           BUILD_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
-          docker run --rm --entrypoint sh "$IMAGE" -c "grep -q \"$BUILD_SHA\" /usr/local/bin/terrat" \
+          docker run --rm --entrypoint sh "$IMAGE" -c "strings /usr/local/bin/terrat | grep -qF \"$BUILD_SHA\"" \
             || { echo "Binary does not contain the release SHA: stale or hybrid build"; exit 1; }
 
       - name: Extract ttm binary (${{ matrix.arch }})


### PR DESCRIPTION
## Description

Fixes #1545

The build step now passes the release commit's SHA into the image build, where the Dockerfile stamps it into the binary, and a new step refuses to let the release proceed if the pushed `terrat-oss` or `terrat-ee` binary does not contain that SHA. A stale or hybrid binary — the failure mode described in the issue — can no longer ship silently: the release fails loudly at the exact image that is wrong, per target and per architecture.

`ttm` and `code-indexer` are not gated: those binaries do not link the build-info module. They can be added once they do.

**Merge ordering:** this must not merge until the monorepo export carrying the clean-tree Dockerfile and the `terrat_build_info` stamp has landed on `main` here. Merged before that, the gate fails every release, because the binary has no SHA to find. Merged after, the first gated release also serves as the fix's verification.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (explain):

## Public release note (optional)

Releases now verify that the shipped binary was compiled from the release commit before publishing.
