### PR TITLE
#1559 FIX pass github.head_ref via env in test.yml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,10 +91,12 @@ jobs:
 
       - name: Extract branch name and commit
         id: branch
+        env:
+          HEAD_REF: ${{ github.head_ref }}
         run: |
           SHORT_SHA=$(git rev-parse --short HEAD)
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            BRANCH_NAME=$(echo ${{ github.head_ref }} | sed 's/[^a-zA-Z0-9._-]/-/g')
+          if [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then
+            BRANCH_NAME=$(printf '%s' "$HEAD_REF" | sed 's/[^a-zA-Z0-9._-]/-/g')
           else
             BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/} | sed 's/[^a-zA-Z0-9._-]/-/g')
           fi


### PR DESCRIPTION
Closes #1559.

Moves `github.head_ref` into `env:` and references it as `"$HEAD_REF"`; uses `$GITHUB_EVENT_NAME` instead of the inline expression. Branch names are now shell data rather than script text (GitHub Actions hardening guidance). Output `branch=<name>-<sha>` is unchanged.

Note: `.github/workflows/test.yml` is `PUBLIC_OWNED` in mono's copybara config (not synced), so this is filed here by agreement with Josh.