### PR TITLE
#1583 FIX test.yml: run always, skip build jobs for docs-only PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,8 +4,6 @@ on:
   pull_request:
     branches:
       - "main"
-    paths-ignore:
-      - 'docs/**'
   workflow_dispatch:
     inputs:
       build_base_image:
@@ -18,7 +16,47 @@ env:
   REGISTRY: ghcr.io
 
 jobs:
+  # Required status checks and `paths-ignore` do not mix: when a workflow is
+  # skipped by a path filter its checks are never created, so a required check
+  # stays pending and the PR can never merge. That deadlocked every docs-only
+  # monorepo->OSS export PR (e.g. #1582, which touched only docs/package-lock.json).
+  #
+  # So this workflow now always runs, and the expensive jobs opt out via `if:`
+  # instead. A job skipped by `if:` still reports a check run, with conclusion
+  # "skipped", which satisfies a required status check.
+  changes:
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - name: Determine whether anything outside docs/ changed
+        id: filter
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          # Anything that is not a pull_request (e.g. workflow_dispatch) always builds.
+          if [ "${GITHUB_EVENT_NAME}" != "pull_request" ]; then
+            echo "code=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          files=$(gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/files" --jq '.[].filename')
+          if printf '%s\n' "$files" | grep -qv '^docs/'; then
+            echo "Non-docs changes present; running the full build."
+            echo "code=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Only docs/ changed; skipping format-check and build-test."
+            echo "code=false" >> "$GITHUB_OUTPUT"
+          fi
+
   format-check:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-22.04
     permissions:
       contents: read
@@ -52,6 +90,8 @@ jobs:
           fi
 
   build-test:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ${{ matrix.runs-on }}
     permissions:
       contents: read


### PR DESCRIPTION
Closes #1583.

**The bug:** `test.yml` filters its trigger with `paths-ignore: ['docs/**']`, while the branch ruleset requires the 8 `build-test (target, arch)` checks. When a workflow is skipped by a path filter GitHub **never creates its check runs**, so those required checks stay pending forever — a docs-only PR is `BLOCKED` with no way to make it pass.

Live example: the export PR **#1582** changes exactly one file (`docs/package-lock.json`) and has been stuck since 19:02 UTC with only `terrateam apply` reported. The previous export #1577 touched `code/src/iris` and merged normally. Since `docs/**` is copybara-exported from `stategraph/mono`, docs-only export PRs recur constantly, so this would keep happening.

**The fix:** always run the workflow; let the expensive jobs opt out with `if:`. A job skipped by `if:` **still reports a check run** (conclusion `skipped`), which satisfies a required status check. This is the same detect-then-skip pattern `stategraph/mono` already relies on for its own required `Test / Build and test`.

- new `changes` job asks the API which files the PR touches and sets `code=true` unless everything is under `docs/`
- `format-check` and `build-test` gain `needs: changes` + `if: needs.changes.outputs.code == 'true'`
- non-`pull_request` runs (e.g. `workflow_dispatch`) always build

**Verified:** YAML parses; the matrix still emits exactly the 8 required contexts, byte-for-byte matching the ruleset's required list (`build-test (code-indexer, amd64)` … `build-test (ttm, arm64)`).

**Rejected alternative:** a separate companion workflow reporting the same check names. A PR touching *both* `docs/` and code satisfies both the `paths` and `paths-ignore` filters, so both workflows would run and emit duplicate `build-test (...)` names — a stub reporting success beside a real failing build is worse than the deadlock.

Also rejected: dropping `docs/**` from `paths-ignore` (every docs-only export then runs the full 8-way build), and removing the checks from the required list (weakens a change-management control).

Note this PR itself touches only `.github/workflows/`, so it takes the normal path and the real build runs. `.github/workflows/test.yml` is `PUBLIC_OWNED` in copybara, so this repo is the correct place to fix it.