### PR TITLE
#1586 FIX test.yml: keep build-test matrix running, skip at step level

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -89,9 +89,14 @@ jobs:
             exit 1
           fi
 
+  # NOTE: this job must always RUN, never be skipped with a job-level `if:`.
+  # A matrix job skipped by `if:` is not expanded — GitHub reports a single
+  # check named "build-test" instead of the eight "build-test (target, arch)"
+  # contexts the ruleset requires, which leaves the PR blocked just as the old
+  # `paths-ignore` did. So the job runs and each step opts out instead; the
+  # eight checks are reported and pass in seconds for docs-only changes.
   build-test:
     needs: changes
-    if: needs.changes.outputs.code == 'true'
     runs-on: ${{ matrix.runs-on }}
     permissions:
       contents: read
@@ -116,9 +121,11 @@ jobs:
 
     steps:
       - name: Checkout code
+        if: needs.changes.outputs.code == 'true'
         uses: actions/checkout@v4
 
       - name: Log in to Container Registry
+        if: needs.changes.outputs.code == 'true'
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -126,10 +133,12 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Generate date tag
+        if: needs.changes.outputs.code == 'true'
         id: date
         run: echo "date=$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
 
       - name: Extract branch name and commit
+        if: needs.changes.outputs.code == 'true'
         id: branch
         env:
           HEAD_REF: ${{ github.head_ref }}
@@ -143,12 +152,12 @@ jobs:
           echo "branch=${BRANCH_NAME}-${SHORT_SHA}" >> $GITHUB_OUTPUT
 
       - name: Set base image
-        if: ${{ ! inputs.build_base_image }}
+        if: ${{ needs.changes.outputs.code == 'true' && ! inputs.build_base_image }}
         run: |
           ./scripts/base_image >> $GITHUB_ENV
 
       - name: Build and push ${{ matrix.target }} with BASE_IMAGE
-        if: ${{ ! inputs.build_base_image }}
+        if: ${{ needs.changes.outputs.code == 'true' && ! inputs.build_base_image }}
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -162,7 +171,7 @@ jobs:
           platforms: ${{ matrix.platform }}
 
       - name: Build and push ${{ matrix.target }} without BASE_IMAGE
-        if: ${{ inputs.build_base_image }}
+        if: ${{ needs.changes.outputs.code == 'true' && inputs.build_base_image }}
         uses: docker/build-push-action@v6
         with:
           context: .


### PR DESCRIPTION
Closes #1586. Corrects #1584, which did not actually fix the deadlock.

**What #1584 got wrong:** it gated `build-test` with a job-level `if:`. When a matrix job is skipped that way, **GitHub does not expand the matrix** — it reports one check named `build-test`, not the eight `build-test (target, arch)` contexts the ruleset requires. So on a docs-only PR the required checks are still never reported and it stays `BLOCKED`. Export PR #1585 shows it exactly: `changes` ✓, `format-check` skipped, **one** `build-test` skipped, mergeState BLOCKED.

The mistake behind it: the 8 names were verified from what the matrix emits when it *runs*, and I assumed skipping preserved them. It doesn't. Owning that.

**This fix:** `build-test` **always runs** (no job-level `if:`), so the matrix expands and all eight contexts are reported. The `changes` guard moves onto **every step** inside the job. On a docs-only PR each of the eight jobs starts, skips all its steps, and completes with conclusion `success` in seconds — satisfying the ruleset. On a code PR nothing changes: every step's guard is true and the real build runs. `format-check` has no matrix, so its job-level gate from #1584 stays.

Steps that already had an `if:` (`! inputs.build_base_image` / `inputs.build_base_image`) get the guard AND-ed in, so the `workflow_dispatch` base-image path is unaffected.

**Verification plan — empirical this time, not reasoned:** after merge, dispatch a copybara export (`gh workflow run copybara.yml -R stategraph/mono -f command=export`) and confirm the resulting docs-only PR shows all eight `build-test (…)` contexts as passing and becomes mergeable. #1582 and #1585 are unrecoverable (their checks were already decided) and are being closed.