### PR TITLE
#1589 ADD container image scanning for released images

### DIFF
--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -83,51 +83,9 @@ jobs:
           sarif_file: trivy.sarif
           category: trivy-${{ matrix.image }}
 
-  # A scan nobody reads is not a control. Scheduled-workflow failure emails go only
-  # to whoever last touched the cron line, which is not a dependable alerting path.
-  # So a failure opens (or updates) a tracking issue: no secrets needed, identical
-  # in every repo, and the issue is itself the record that a finding was detected
-  # and acted on. Alerting is wired off these issues separately.
-  notify-failure:
-    name: Open tracking issue
-    needs: scan
-    if: failure() && github.event_name == 'schedule'
-    runs-on: ubuntu-22.04
-    timeout-minutes: 5
-    permissions:
-      contents: read
-      issues: write
-    steps:
-      - name: Open or update the tracking issue
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: |
-          set -euo pipefail
-          TITLE='Container scan: fixable HIGH/CRITICAL vulnerabilities in shipped images'
-          # Best-effort label so a missing label can never fail the alert itself.
-          gh label create container-scan --repo "$REPO" --color d73a4a \
-            --description 'Automated container image vulnerability scan findings' >/dev/null 2>&1 || true
-          EXISTING=$(gh issue list --repo "$REPO" --state open \
-            --search "\"$TITLE\" in:title" --json number --jq '.[0].number // empty')
-          if [ -n "$EXISTING" ]; then
-            gh issue comment "$EXISTING" --repo "$REPO" \
-              --body "Still failing on the scheduled run of $(date -u '+%Y-%m-%d %H:%M UTC'). $RUN_URL"
-            echo "Updated existing issue #$EXISTING"
-            exit 0
-          fi
-          # printf, not a heredoc: heredoc lines inside a YAML block scalar must stay
-          # indented, and that indentation would turn the body into a code block.
-          printf '%s\n' \
-            'The weekly container image scan found HIGH or CRITICAL vulnerabilities **with a fix available** in at least one image we ship.' \
-            '' \
-            "Run: $RUN_URL" \
-            '' \
-            'Per the Vulnerability Management Policy, remediation timelines run from confirmation. Triage the findings in the run output, then either bump the affected package / base image or record an explicit risk acceptance with justification.' \
-            '' \
-            'This issue is reused by later runs rather than reopened weekly, so it stays one thread until the scan is green. Close it once the scan passes.' \
-            > /tmp/scan-issue-body.md
-          gh issue create --repo "$REPO" --title "$TITLE" --label container-scan \
-            --body-file /tmp/scan-issue-body.md >/dev/null
-          echo "Opened a new tracking issue"
+# NOTE: deliberately NO issue-creating notify job here, unlike stategraph/mono.
+# This repo is public: an issue titled "fixable HIGH/CRITICAL vulnerabilities in
+# shipped images" -- and the public workflow-run logs it links to -- would disclose
+# unfixed vulnerabilities in released customer images. Findings go to code scanning
+# via the SARIF upload above instead, which is visible only to users with write,
+# maintain or admin access (and org owners), not to the public.

--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -85,25 +85,49 @@ jobs:
 
   # A scan nobody reads is not a control. Scheduled-workflow failure emails go only
   # to whoever last touched the cron line, which is not a dependable alerting path.
-  # SARIF lands in the Security tab, but nothing pushes it at anyone.
+  # So a failure opens (or updates) a tracking issue: no secrets needed, identical
+  # in every repo, and the issue is itself the record that a finding was detected
+  # and acted on. Alerting is wired off these issues separately.
   notify-failure:
-    name: Notify on scan failure
+    name: Open tracking issue
     needs: scan
     if: failure() && github.event_name == 'schedule'
     runs-on: ubuntu-22.04
-    # This repo has no repo-level secrets: the only Slack webhook is
-    # SLACK_WEBHOOK_URL in the `production` environment, so the job has to declare
-    # that environment to read it. Verified `production` carries no protection
-    # rules, so this does not sit waiting for a reviewer. (mono uses a repo-level
-    # SLACK_ENGINEERING_WEBHOOK_URL instead -- the two repos differ here.)
-    environment: production
-    timeout-minutes: 3
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: write
     steps:
-      - uses: slackapi/slack-github-action@v4
-        with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
-          webhook-type: incoming-webhook
-          payload: |
-            {
-              "text": ":rotating_light: Container scan found fixable HIGH/CRITICAL vulnerabilities in a RELEASED customer image. ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-            }
+      - name: Open or update the tracking issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          TITLE='Container scan: fixable HIGH/CRITICAL vulnerabilities in shipped images'
+          # Best-effort label so a missing label can never fail the alert itself.
+          gh label create container-scan --repo "$REPO" --color d73a4a \
+            --description 'Automated container image vulnerability scan findings' >/dev/null 2>&1 || true
+          EXISTING=$(gh issue list --repo "$REPO" --state open \
+            --search "\"$TITLE\" in:title" --json number --jq '.[0].number // empty')
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --repo "$REPO" \
+              --body "Still failing on the scheduled run of $(date -u '+%Y-%m-%d %H:%M UTC'). $RUN_URL"
+            echo "Updated existing issue #$EXISTING"
+            exit 0
+          fi
+          # printf, not a heredoc: heredoc lines inside a YAML block scalar must stay
+          # indented, and that indentation would turn the body into a code block.
+          printf '%s\n' \
+            'The weekly container image scan found HIGH or CRITICAL vulnerabilities **with a fix available** in at least one image we ship.' \
+            '' \
+            "Run: $RUN_URL" \
+            '' \
+            'Per the Vulnerability Management Policy, remediation timelines run from confirmation. Triage the findings in the run output, then either bump the affected package / base image or record an explicit risk acceptance with justification.' \
+            '' \
+            'This issue is reused by later runs rather than reopened weekly, so it stays one thread until the scan is green. Close it once the scan passes.' \
+            > /tmp/scan-issue-body.md
+          gh issue create --repo "$REPO" --title "$TITLE" --label container-scan \
+            --body-file /tmp/scan-issue-body.md >/dev/null
+          echo "Opened a new tracking issue"

--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -82,3 +82,28 @@ jobs:
         with:
           sarif_file: trivy.sarif
           category: trivy-${{ matrix.image }}
+
+  # A scan nobody reads is not a control. Scheduled-workflow failure emails go only
+  # to whoever last touched the cron line, which is not a dependable alerting path.
+  # SARIF lands in the Security tab, but nothing pushes it at anyone.
+  notify-failure:
+    name: Notify on scan failure
+    needs: scan
+    if: failure() && github.event_name == 'schedule'
+    runs-on: ubuntu-22.04
+    # This repo has no repo-level secrets: the only Slack webhook is
+    # SLACK_WEBHOOK_URL in the `production` environment, so the job has to declare
+    # that environment to read it. Verified `production` carries no protection
+    # rules, so this does not sit waiting for a reviewer. (mono uses a repo-level
+    # SLACK_ENGINEERING_WEBHOOK_URL instead -- the two repos differ here.)
+    environment: production
+    timeout-minutes: 3
+    steps:
+      - uses: slackapi/slack-github-action@v4
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": ":rotating_light: Container scan found fixable HIGH/CRITICAL vulnerabilities in a RELEASED customer image. ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            }

--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -1,0 +1,84 @@
+# Scan the released Terrateam images for known OS/library vulnerabilities.
+#
+# These are the images customers actually run, published by release.yml to
+# ghcr.io/terrateamio/{code-indexer,terrat-ee,terrat-oss,ttm}. A vulnerable layer
+# here ships to every self-hosted deployment.
+#
+# Scans PUBLISHED tags on a schedule rather than at build time: the point of
+# container scanning is catching advisories disclosed *after* an image was built,
+# which a build-time-only scan never sees. The per-PR *-dev images under the
+# stategraph org are ephemeral branch builds and are deliberately not scanned.
+#
+# NOTE: this file is listed in copybara's PUBLIC_OWNED (scripts/monorepo/copy.bara.sky
+# in stategraph/mono). Without that entry the monorepo export would DELETE it,
+# because copybara owns the whole public tree. If you rename or move this file,
+# update PUBLIC_OWNED in the same change.
+name: container scan
+
+on:
+  schedule:
+    # Mondays 06:30 UTC — offset from the mono and action scans.
+    - cron: '30 6 * * 1'
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - "main"
+    paths:
+      - 'docker/terrat/Dockerfile'
+      - '.github/workflows/container-scan.yml'
+
+jobs:
+  scan:
+    name: ${{ matrix.image }}
+    runs-on: ubuntu-22.04
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      packages: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        # The four release targets from release.yml, at :latest.
+        image:
+          - ghcr.io/terrateamio/terrat-oss:latest
+          - ghcr.io/terrateamio/terrat-ee:latest
+          - ghcr.io/terrateamio/ttm:latest
+          - ghcr.io/terrateamio/code-indexer:latest
+
+    steps:
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # ignore-unfixed: a vulnerability with no upstream fix is not actionable by
+      # us, and failing on it would keep this check permanently red -- which trains
+      # everyone to ignore it. Unfixed findings still reach the Security tab below.
+      - name: Trivy scan (fail on fixable HIGH/CRITICAL)
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          image-ref: ${{ matrix.image }}
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          exit-code: '1'
+          format: table
+
+      - name: Trivy scan (full SARIF, all severities)
+        if: always()
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          image-ref: ${{ matrix.image }}
+          scanners: vuln
+          format: sarif
+          output: trivy.sarif
+          exit-code: '0'
+
+      - name: Upload to code scanning
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy.sarif
+          category: trivy-${{ matrix.image }}


### PR DESCRIPTION
Closes #1589.

⚠️ **Merge stategraph/mono#1908 first** — see the ordering note at the bottom.

Nothing scanned the released images for OS/library vulnerabilities. `release.yml` publishes `ghcr.io/terrateamio/{code-indexer,terrat-ee,terrat-oss,ttm}`, and those are the images **every self-hosted deployment runs** — a vulnerable layer here ships to customers.

Weekly Trivy scan (plus `workflow_dispatch`, and on PRs touching `docker/terrat/Dockerfile`) of the four `:latest` tags, with **SARIF upload to the Security tab** — code scanning is free on this public repo, unlike private `mono`.

**Why published tags, not build time:** the value of container scanning is catching advisories disclosed *after* an image was built. A build-time-only scan never notices that today's CVE affects the release customers are already running. The per-PR `*-dev` images under the `stategraph` org are ephemeral branch builds (tagged per branch+SHA) and are deliberately excluded.

**Why `ignore-unfixed: true` on the failing check:** a vulnerability with no upstream fix isn't actionable by us, and failing on it keeps the check permanently red — which trains everyone to ignore it. Fails on HIGH/CRITICAL *with a fix available*; the SARIF upload still carries everything, unfixed included.

Verified all four packages exist and carry a `latest` tag before referencing them.

### Ordering — this file would otherwise be deleted
Copybara owns the **entire** public tree on export, and `PUBLIC_OWNED` only covers `base/test/release/deploy/docs.yml` via `TT_WORKFLOWS`. A new workflow file here that isn't listed gets **removed on the next monorepo export**. stategraph/mono#1908 adds `.github/workflows/container-scan.yml` to `PUBLIC_OWNED`, so **that must merge before this**, or this file silently vanishes. The workflow's header comment records the coupling for whoever renames it next.

### No `dependabot.yml` here, on purpose
This repo's dependency manifests (`docker/terrat/Dockerfile`, `code/src/iris`, `docs/`) are all copybara-owned, so Dependabot PRs against them can never legitimately merge — that's the problem behind disabling security updates here and closing 15 stale PRs. mono's `dependabot.yml` covers `docker/terrat` instead.

**Expect the first run to find things** — these images have never been scanned. That's the control working, not a regression.