### PR TITLE
#1653 ADD Don't release on push to main if all PRs making it to the release have the label "no-release"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,38 @@ on:
           - staging
 
 jobs:
+  # Gate for the whole pipeline. Every push to main cuts a release, and a release that carries
+  # nothing user-facing is just noise in the feed people subscribe to. When every PR since the
+  # last release is labelled `no-release`, this job stops here.
+  release-gate:
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      pull-requests: read
+
+    outputs:
+      release: ${{ steps.release-gate.outputs.release }}
+
+    env:
+      GITHUB_REPOSITORY: ${{ github.repository }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          # Full history + tags: the gate walks main back to the previous release tag.
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Decide whether to release
+        id: release-gate
+        run: |
+          ./scripts/release_gate
+
   set-version-tag:
+    needs: release-gate
+    if: needs.release-gate.outputs.release == 'true'
     runs-on: ubuntu-22.04
     environment: ${{ github.event.inputs.environment || 'production' }}
     permissions:

--- a/scripts/release_gate
+++ b/scripts/release_gate
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+#
+#
+# Decide whether this push to main should be released at all.
+#
+# Every push to main cuts a release, and most of them are a copybara export from the
+# monorepo. Some exports carry nothing a user would want a release for. When EVERY PR in
+# this release carries the tag "no-release", the pipeline stops here and the change rides along with the next
+# real release instead.
+#
+# Fails open: anything unresolvable (no previous tag, no PR for a commit, an API error) means
+# release. A missed skip is noise; a missed release is a change that never ships.
+#
+# Writes `release=true|false` to GITHUB_OUTPUT.
+#
+# Environment variables:
+#   GITHUB_TOKEN      - GitHub token for authentication
+#   GITHUB_REPOSITORY - Repository in owner/repo format
+#   GITHUB_OUTPUT     - GitHub Actions step output file
+#   NO_RELEASE_LABEL  - (Optional) Label that marks a PR as not worth a release
+
+set -euf -o pipefail
+
+: "${GITHUB_TOKEN:?GITHUB_TOKEN is required}"
+: "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+: "${GITHUB_OUTPUT:?GITHUB_OUTPUT is required}"
+
+NO_RELEASE_LABEL="no-release"
+
+release() { # $1 = reason
+  echo "Releasing: $1"
+  echo "release=true" >> "${GITHUB_OUTPUT}"
+  exit 0
+}
+
+# The tag of the last release. Unlike scripts/create_release, this runs BEFORE the tag for
+# this release is created, so the newest tag is the previous one.
+PREVIOUS_TAG="$(git ls-remote --tags origin | grep -oE '20[0-9]{6}-[0-9]{4}-[a-f0-9]{6,8}$' | sort | tail -n1)"
+if [[ -z "${PREVIOUS_TAG}" ]]; then
+  release "no previous release tag to compare against"
+fi
+if ! git cat-file -e "${PREVIOUS_TAG}^{commit}" 2>/dev/null; then
+  release "previous tag ${PREVIOUS_TAG} is not in this checkout"
+fi
+
+echo "Previous tag: ${PREVIOUS_TAG}"
+
+# The PRs merged since that tag -- normally one export PR, more when a release was skipped or
+# a push landed while another was building.
+PR_NUMBERS="$(git log --first-parent --format=%H "${PREVIOUS_TAG}..HEAD" \
+  | while read -r sha; do
+      gh api "repos/${GITHUB_REPOSITORY}/commits/${sha}/pulls" --jq '.[].number' 2>/dev/null || true
+    done | sort -un)"
+
+if [[ -z "${PR_NUMBERS}" ]]; then
+  release "no PR resolved for the commits since ${PREVIOUS_TAG}"
+fi
+
+for pr in ${PR_NUMBERS}; do
+  if ! LABELS="$(gh pr view "${pr}" --repo "${GITHUB_REPOSITORY}" --json labels --jq '.labels[].name')"; then
+    release "could not read the labels of PR #${pr}"
+  fi
+  if ! grep -qxF "${NO_RELEASE_LABEL}" <<< "${LABELS}"; then
+    release "PR #${pr} is not labelled ${NO_RELEASE_LABEL}"
+  fi
+  echo "PR #${pr} is labelled ${NO_RELEASE_LABEL}"
+done
+
+echo "Every PR since ${PREVIOUS_TAG} is labelled ${NO_RELEASE_LABEL}; skipping this release."
+echo "::notice title=Release skipped::Every PR since ${PREVIOUS_TAG} is labelled ${NO_RELEASE_LABEL}"
+echo "release=false" >> "${GITHUB_OUTPUT}"


### PR DESCRIPTION
## Description

Together with https://github.com/stategraph/stategraph/pull/1654, fixes #1653

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [X] Other (explain):

## Checklist

- [X] I have read the [contributing guidelines](https://github.com/stategraph/stategraph/blob/main/CONTRIBUTING.md)
- [X] The pull request title follows this format:
      `ISSUE_NUMBER ACTION_TYPE Short description` (e.g., `123 ADD Feature description`)
- [X] I have added tests and documentation (if applicable)
- [X] My changes generate no new warnings/errors and do not break existing functionality

## Additional context (optional)

Don't release on push to main, if all PRs making to the release have been tagged "no-release".
Useful to avoid creating a release only carrying non-user facing changes (e.g. additions to libraries only
used in the monorepo), to reduce noise to people consuming releases changelogs.
